### PR TITLE
Change "Author" to "Authors" in CIP 2.

### DIFF
--- a/CIP2/CIP2.md
+++ b/CIP2/CIP2.md
@@ -1,7 +1,7 @@
 ---
 CIP: 2
 Title: Coin Selection Algorithms for Cardano
-Author: Jonathan Knowles <jonathan.knowles@iohk.io>
+Authors: Jonathan Knowles <jonathan.knowles@iohk.io>
 Comments-URI: https://github.com/cardano-foundation/CIPs/wiki/Comments:CIP-0002
 Status: Draft
 Type: Informational


### PR DESCRIPTION
This brings CIP 2 into compliance with the header format specified in CIP 1.