### PR TITLE
[CIP-2] Fix links to reference implementations of coin selection algorithms.

### DIFF
--- a/CIP2/CIP2.md
+++ b/CIP2/CIP2.md
@@ -998,7 +998,7 @@ available in the following languages:
 
 | _Language_ | _Documentation_ | _Source_ |
 | -- | -- | -- |
-| **Haskell** | [Documentation](https://input-output-hk.github.io/cardano-coin-selection/haddock/cardano-coin-selection-1.0.0/Cardano-CoinSelection-Algorithm-LargestFirst.html) | [Source](https://input-output-hk.github.io/cardano-coin-selection/haddock/cardano-coin-selection-1.0.0/src/Cardano.CoinSelection.Algorithm.LargestFirst.html) |
+| **Haskell** | [Documentation](https://hackage.haskell.org/package/cardano-coin-selection/docs/Cardano-CoinSelection-Algorithm-LargestFirst.html) | [Source](https://hackage.haskell.org/package/cardano-coin-selection/docs/src/Cardano.CoinSelection.Algorithm.LargestFirst.html) |
 
 ## Random-Improve
 
@@ -1007,7 +1007,7 @@ are available in the following languages:
 
 | _Language_ | _Documentation_ | _Source_ |
 | -- | -- | -- |
-| **Haskell** | [Documentation](https://input-output-hk.github.io/cardano-coin-selection/haddock/cardano-coin-selection-1.0.0/Cardano-CoinSelection-Algorithm-RandomImprove.html) | [Source](https://input-output-hk.github.io/cardano-coin-selection/haddock/cardano-coin-selection-1.0.0/src/Cardano.CoinSelection.Algorithm.RandomImprove.html) |
+| **Haskell** | [Documentation](https://hackage.haskell.org/package/cardano-coin-selection/docs/Cardano-CoinSelection-Algorithm-RandomImprove.html) | [Source](https://hackage.haskell.org/package/cardano-coin-selection/docs/src/Cardano.CoinSelection.Algorithm.RandomImprove.html) |
 
 # External Resources
 


### PR DESCRIPTION
## Related Issue

Issue #19 

## Summary

This PR fixes several broken links to reference implementations of coin selection algorithms in CIP-2.

Rather than linking to GitHub pages, we instead link to [Hackage](https://hackage.haskell.org/), which will always serve content that corresponds to the latest version of the `cardano-coin-selection` package, provided that the package is not removed.