### PR TITLE
CIP-5: script prefixes extension

### DIFF
--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -23,35 +23,35 @@ Therefore, we can leverage bech32 for binary data encoding, with a set of common
 
 We define the following set of common prefixes with their corresponding semantic. Any software willing to represent binary data in a human-friendly way should abide by these guidelines. Should a data-type be missing, we encourage developers to update this CIP and register a new prefix.
 
-| Prefix       | Semantic                                      |
-| ---          | ---                                           |
-| `addr_vk`    | Address verification key                      |
-| `addr_vkh`   | Address verification key hash                 |
-| `addr_sk`    | Address signing key                           |
-| `addr_xvk`   | Address extended verification key             |
-| `addr_xsk`   | Address extended signing key                  |
-| `addr`       | Mainnet address                               |
-| `addr_test`  | Testnet address                               |
-| `stake_vk`   | Stake address verification key                |
-| `stake_vkh`  | Stake address verification key hash           |
-| `stake_sk`   | Stake address signing key                     |
-| `stake_xvk`  | Stake address extended verification key       |
-| `stake_xsk`  | Stake address extended signing key            |
-| `stake`      | Mainnet stake address                         |
-| `stake_test` | Testnet stake address                         |
-| `pool`       | Pool operator verification key hash (pool ID) |
-| `pool_vk`    | Pool operator verification key                |
-| `pool_sk`    | Pool operator signing key                     |
-| `kes_vk`     | KES verification key                          |
-| `kes_vkh`    | KES verification key hash                     |
-| `kes_sk`     | KES signing key                               |
-| `vrf_vk`     | VRF verification key                          |
-| `vrf_vkh`    | VRF verification key hash                     |
-| `vrf_sk`     | VRF signing key                               |
-| `script`     | Script hash                                   |
-| `script_vkh` | Verification key hash used in script          |
-| `script_vk`  | Verification key of key hash used in script   |
-| `script_sk`  | Signing key for vkh used in script            |
+| Prefix       | Semantic                                      | Contents
+| ---          | ---                                           | ---
+| `addr_vk`    | Address verification key                      | Verification/public key
+| `addr_vkh`   | Address verification key hash                 | Hash of verification/public key
+| `addr_sk`    | Address signing key                           | Signing/private key
+| `addr_xvk`   | Address extended verification key             | Verification/public key
+| `addr_xsk`   | Address extended signing key                  | Signing/private key
+| `addr`       | Mainnet address                               | Base address
+| `addr_test`  | Testnet address                               | Base address
+| `stake_vk`   | Stake address verification key                | Verification/public key
+| `stake_vkh`  | Stake address verification key hash           | Hash of verification/public key
+| `stake_sk`   | Stake address signing key                     | Signing/private key
+| `stake_xvk`  | Stake address extended verification key       | Verification/public key
+| `stake_xsk`  | Stake address extended signing key            | Signing/private key
+| `stake`      | Mainnet stake address                         | Stake address (reward account)
+| `stake_test` | Testnet stake address                         | Stake address (reward account)
+| `pool`       | Pool operator verification key hash (pool ID) | Hash of verification/public
+| `pool_vk`    | Pool operator verification key                | Verification/public key
+| `pool_sk`    | Pool operator signing key                     | Signing/private key
+| `kes_vk`     | KES verification key                          | Verification/public key
+| `kes_vkh`    | KES verification key hash                     | Hash of verification/public key
+| `kes_sk`     | KES signing key                               | Signing/private key
+| `vrf_vk`     | VRF verification key                          | Verification/public key
+| `vrf_vkh`    | VRF verification key hash                     | Hash of verification/public key
+| `vrf_sk`     | VRF signing key                               | Signing/private key
+| `script`     | Script hash                                   | Hash of script
+| `script_vk`  | Script verification key                       | Verification key/public key
+| `script_vkh` | Script verification key hash                  | Hash of verification key/public key
+| `script_sk`  | Script signing key                            | Signing/private key
 
 ## Rationale
 

--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -25,44 +25,45 @@ We define the following set of common prefixes with their corresponding semantic
 
 #### Keys
 
-| Prefix       | Meaning                                 | Contents                           |
-| ---          | ---                                     | ---                                |
-| `acct_sk`    | CIP-1852's Account private key          | Ed25519 private key                |
-| `acct_vk`    | CIP-1852's Account public key           | Ed25519 public key                 |
-| `acct_xsk`   | CIP-1852's extended Account private key | Ed25519-bip32 extended private key |
-| `acct_xvk`   | CIP-1852's extended Account public key  | Ed25519 public key with chain code |
-| `addr_sk`    | Address signing key                     | Ed25519 private key                |
-| `addr_vk`    | Address verification key                | Ed25519 public key                 |
-| `addr_xsk`   | Address extended signing key            | Ed25519-bip32 extended private key |
-| `addr_xvk`   | Address extended verification key       | Ed25519 public key with chain code |
-| `kes_sk`     | KES signing key                         | KES signing key                    |
-| `kes_vk`     | KES verification key                    | KES verification key               |
-| `pool_sk`    | Pool operator signing key               | Ed25519 private key                |
-| `pool_vk`    | Pool operator verification key          | Ed25519 public key                 |
-| `root_sk`    | CIP-1852's root private key             | Ed25519 private key                |
-| `root_vk`    | CIP-1852's root public key              | Ed25519 public key                 |
-| `root_xsk`   | CIP-1852's extended root private key    | Ed25519-bip32 extended private key |
-| `root_xvk`   | CIP-1852's extended root public key     | Ed25519 public key with chain code |
-| `script_sk`  | Script signing key                      | Ed25519 private key                |
-| `script_vk`  | Script verification key                 | Ed25519 public key                 |
-| `script_xsk` | Extended script signing key             | Ed25519-bip32 extended private key |
-| `script_xvk` | Extended script verification key        | Ed25519 public key with chain code |
-| `stake_sk`   | Stake address signing key               | Ed25519 private key                |
-| `stake_vk`   | Stake address verification key          | Ed25519 public key                 |
-| `stake_xsk`  | Extended stake address signing key      | Ed25519-bip32 extended private key |
-| `stake_xvk`  | Extended stake address verification key | Ed25519 public key with chain code |
-| `vrf_sk`     | VRF signing key                         | VRF signing key                    |
-| `vrf_vk`     | VRF verification key                    | VRF verification key               |
+| Prefix       | Meaning                                 | Contents                                               |
+| ---          | ---                                     | ---                                                    |
+| `acct_sk`    | CIP-1852's Account private key          | Ed25519 private key                                    |
+| `acct_vk`    | CIP-1852's Account public key           | Ed25519 public key                                     |
+| `acct_xsk`   | CIP-1852's extended Account private key | Ed25519-bip32 extended private key                     |
+| `acct_xvk`   | CIP-1852's extended Account public key  | Ed25519 public key with chain code                     |
+| `addr_sk`    | Address signing key                     | Ed25519 private key                                    |
+| `addr_vk`    | Address verification key                | Ed25519 public key                                     |
+| `addr_xsk`   | Address extended signing key            | Ed25519-bip32 extended private key                     |
+| `addr_xvk`   | Address extended verification key       | Ed25519 public key with chain code                     |
+| `kes_sk`     | KES signing key                         | KES signing key                                        |
+| `kes_vk`     | KES verification key                    | KES verification key                                   |
+| `pool_sk`    | Pool operator signing key               | Ed25519 private key                                    |
+| `pool_vk`    | Pool operator verification key          | Ed25519 public key                                     |
+| `root_sk`    | CIP-1852's root private key             | Ed25519 private key                                    |
+| `root_vk`    | CIP-1852's root public key              | Ed25519 public key                                     |
+| `root_xsk`   | CIP-1852's extended root private key    | Ed25519-bip32 extended private key                     |
+| `root_xvk`   | CIP-1852's extended root public key     | Ed25519 public key with chain code                     |
+| `script_sk`  | Script signing key                      | Ed25519 private key                                    |
+| `script_vk`  | Script verification key                 | Ed25519 public key                                     |
+| `script_xsk` | Extended script signing key             | Ed25519-bip32 extended private key                     |
+| `script_xvk` | Extended script verification key        | Ed25519 public key with chain code                     |
+| `stake_sk`   | Stake address signing key               | Ed25519 private key                                    |
+| `stake_vk`   | Stake address verification key          | Ed25519 public key                                     |
+| `stake_xsk`  | Extended stake address signing key      | Ed25519-bip32 extended private key                     |
+| `stake_xvk`  | Extended stake address verification key | Ed25519 public key with chain code                     |
+| `vrf_sk`     | VRF signing key                         | VRF signing key                                        |
+| `vrf_vk`     | VRF verification key                    | VRF verification key                                   |
 
 #### Hashes
 
-| Prefix       | Meaning                                       | Contents                                             |
-| ---          | ---                                           | ---                                                  |
-| `addr_vkh`   | Address verification key hash                 | blake2b\_224 digest of a payment verification key    |
-| `pool`       | Pool operator verification key hash (pool ID) | blake2b\_224 digest of an operator verification key  |
-| `script_vkh` | Script verification key hash                  | blake2b\_224 digest of a script verification key     |
-| `stake_vkh`  | Stake address verification key hash           | blake2b\_224 digest of a delegation verification key |
-| `vrf_vkh`    | VRF verification key hash                     | blake2b\_256 digest of a VRF verification key        |
+| Prefix       | Meaning                                       | Contents                                               |
+| ---          | ---                                           | ---                                                    |
+| `pool`       | Pool operator verification key hash (pool ID) | blake2b\_224 digest of an operator verification key    |
+| `script`     | Script hash                                   | blake2b\_224 digest of a serialized transaction script |
+| `addr_vkh`   | Address verification key hash                 | blake2b\_224 digest of a payment verification key      |
+| `script_vkh` | Script verification key hash                  | blake2b\_224 digest of a script verification key       |
+| `stake_vkh`  | Stake address verification key hash           | blake2b\_224 digest of a delegation verification key   |
+| `vrf_vkh`    | VRF verification key hash                     | blake2b\_256 digest of a VRF verification key          |
 
 
 #### Miscellaneous 
@@ -73,7 +74,6 @@ We define the following set of common prefixes with their corresponding semantic
 | `addr_test`  | Testnet address       | Network tag, payment credential and optional stake credential |
 | `stake`      | Mainnet stake address | Network tag and stake credential                              |
 | `stake_test` | Testnet stake address | Network tag and stake credential                              |
-| `script`     | Script hash           | blake2b\_224 digest of a serialized transaction script        |
 
 
 ## Rationale

--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -56,14 +56,15 @@ We define the following set of common prefixes with their corresponding semantic
 
 #### Hashes
 
-| Prefix       | Meaning                                       | Contents                                               |
-| ---          | ---                                           | ---                                                    |
-| `pool`       | Pool operator verification key hash (pool ID) | blake2b\_224 digest of an operator verification key    |
-| `script`     | Script hash                                   | blake2b\_224 digest of a serialized transaction script |
-| `addr_vkh`   | Address verification key hash                 | blake2b\_224 digest of a payment verification key      |
-| `script_vkh` | Script verification key hash                  | blake2b\_224 digest of a script verification key       |
-| `stake_vkh`  | Stake address verification key hash           | blake2b\_224 digest of a delegation verification key   |
-| `vrf_vkh`    | VRF verification key hash                     | blake2b\_256 digest of a VRF verification key          |
+| Prefix       | Meaning                                            | Contents                                               |
+| ---          | ---                                                | ---                                                    |
+| `asset`      | Fingerprint of a native asset for human comparison | See [CIP-0014]                                         |
+| `pool`       | Pool operator verification key hash (pool ID)      | blake2b\_224 digest of an operator verification key    |
+| `script`     | Script hash                                        | blake2b\_224 digest of a serialized transaction script |
+| `addr_vkh`   | Address verification key hash                      | blake2b\_224 digest of a payment verification key      |
+| `script_vkh` | Script verification key hash                       | blake2b\_224 digest of a script verification key       |
+| `stake_vkh`  | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key   |
+| `vrf_vkh`    | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key          |
 
 
 #### Miscellaneous 
@@ -124,3 +125,5 @@ N/A
 ## Copyright
 
 This CIP is licensed under Apache-2.0.
+
+[CIP-0014]: https://github.com/cardano-foundation/CIPs/blob/645243e30b5aae109a70ec2b47af70dcc808bc56/CIP-0014/CIP-0014.md

--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -48,6 +48,10 @@ We define the following set of common prefixes with their corresponding semantic
 | `vrf_vk`     | VRF verification key                          |
 | `vrf_vkh`    | VRF verification key hash                     |
 | `vrf_sk`     | VRF signing key                               |
+| `script`     | Script hash                                   |
+| `script_vkh` | Verification key hash used in script          |
+| `script_vk`  | Verification key of key hash used in script   |
+| `script_sk`  | Signing key for vkh used in script            |
 
 ## Rationale
 

--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -23,35 +23,58 @@ Therefore, we can leverage bech32 for binary data encoding, with a set of common
 
 We define the following set of common prefixes with their corresponding semantic. Any software willing to represent binary data in a human-friendly way should abide by these guidelines. Should a data-type be missing, we encourage developers to update this CIP and register a new prefix.
 
-| Prefix       | Meaning                                       | Contents                            |
-| ---          | ---                                           | ---                                 |
-| `addr_vk`    | Address verification key                      | Verification/public key             |
-| `addr_vkh`   | Address verification key hash                 | Hash of verification/public key     |
-| `addr_sk`    | Address signing key                           | Signing/private key                 |
-| `addr_xvk`   | Address extended verification key             | Verification/public key             |
-| `addr_xsk`   | Address extended signing key                  | Signing/private key                 |
-| `addr`       | Mainnet address                               | Base address                        |
-| `addr_test`  | Testnet address                               | Base address                        |
-| `stake_vk`   | Stake address verification key                | Verification/public key             |
-| `stake_vkh`  | Stake address verification key hash           | Hash of verification/public key     |
-| `stake_sk`   | Stake address signing key                     | Signing/private key                 |
-| `stake_xvk`  | Stake address extended verification key       | Verification/public key             |
-| `stake_xsk`  | Stake address extended signing key            | Signing/private key                 |
-| `stake`      | Mainnet stake address                         | Stake address (reward account)      |
-| `stake_test` | Testnet stake address                         | Stake address (reward account)      |
-| `pool`       | Pool operator verification key hash (pool ID) | Hash of verification/public         |
-| `pool_vk`    | Pool operator verification key                | Verification/public key             |
-| `pool_sk`    | Pool operator signing key                     | Signing/private key                 |
-| `kes_vk`     | KES verification key                          | Verification/public key             |
-| `kes_vkh`    | KES verification key hash                     | Hash of verification/public key     |
-| `kes_sk`     | KES signing key                               | Signing/private key                 |
-| `vrf_vk`     | VRF verification key                          | Verification/public key             |
-| `vrf_vkh`    | VRF verification key hash                     | Hash of verification/public key     |
-| `vrf_sk`     | VRF signing key                               | Signing/private key                 |
-| `script`     | Script hash                                   | Hash of script                      |
-| `script_vk`  | Script verification key                       | Verification key/public key         |
-| `script_vkh` | Script verification key hash                  | Hash of verification key/public key |
-| `script_sk`  | Script signing key                            | Signing/private key                 |
+#### Keys
+
+| Prefix       | Meaning                                 | Contents                           |
+| ---          | ---                                     | ---                                |
+| `acct_sk`    | CIP-1852's Account private key          | Ed25519 private key                |
+| `acct_vk`    | CIP-1852's Account public key           | Ed25519 public key                 |
+| `acct_xsk`   | CIP-1852's extended Account private key | Ed25519-bip32 extended private key |
+| `acct_xvk`   | CIP-1852's extended Account public key  | Ed25519 public key with chain code |
+| `addr_sk`    | Address signing key                     | Ed25519 private key                |
+| `addr_vk`    | Address verification key                | Ed25519 public key                 |
+| `addr_xsk`   | Address extended signing key            | Ed25519-bip32 extended private key |
+| `addr_xvk`   | Address extended verification key       | Ed25519 public key with chain code |
+| `kes_sk`     | KES signing key                         | KES signing key                    |
+| `kes_vk`     | KES verification key                    | KES verification key               |
+| `pool_sk`    | Pool operator signing key               | Ed25519 private key                |
+| `pool_vk`    | Pool operator verification key          | Ed25519 public key                 |
+| `root_sk`    | CIP-1852's root private key             | Ed25519 private key                |
+| `root_vk`    | CIP-1852's root public key              | Ed25519 public key                 |
+| `root_xsk`   | CIP-1852's extended root private key    | Ed25519-bip32 extended private key |
+| `root_xvk`   | CIP-1852's extended root public key     | Ed25519 public key with chain code |
+| `script_sk`  | Script signing key                      | Ed25519 private key                |
+| `script_vk`  | Script verification key                 | Ed25519 public key                 |
+| `script_xsk` | Extended script signing key             | Ed25519-bip32 extended private key |
+| `script_xvk` | Extended script verification key        | Ed25519 public key with chain code |
+| `stake_sk`   | Stake address signing key               | Ed25519 private key                |
+| `stake_vk`   | Stake address verification key          | Ed25519 public key                 |
+| `stake_xsk`  | Extended stake address signing key      | Ed25519-bip32 extended private key |
+| `stake_xvk`  | Extended stake address verification key | Ed25519 public key with chain code |
+| `vrf_sk`     | VRF signing key                         | VRF signing key                    |
+| `vrf_vk`     | VRF verification key                    | VRF verification key               |
+
+#### Hashes
+
+| Prefix       | Meaning                                       | Contents                                             |
+| ---          | ---                                           | ---                                                  |
+| `addr_vkh`   | Address verification key hash                 | blake2b\_224 digest of a payment verification key    |
+| `pool`       | Pool operator verification key hash (pool ID) | blake2b\_224 digest of an operator verification key  |
+| `script_vkh` | Script verification key hash                  | blake2b\_224 digest of a script verification key     |
+| `stake_vkh`  | Stake address verification key hash           | blake2b\_224 digest of a delegation verification key |
+| `vrf_vkh`    | VRF verification key hash                     | blake2b\_256 digest of a VRF verification key        |
+
+
+#### Miscellaneous 
+
+| Prefix       | Meaning               | Contents                                                      |
+| ---          | ---                   | ---                                                           |
+| `addr`       | Mainnet address       | Network tag, payment credential and optional stake credential |
+| `addr_test`  | Testnet address       | Network tag, payment credential and optional stake credential |
+| `stake`      | Mainnet stake address | Network tag and stake credential                              |
+| `stake_test` | Testnet stake address | Network tag and stake credential                              |
+| `script`     | Script hash           | blake2b\_224 digest of a serialized transaction script        |
+
 
 ## Rationale
 

--- a/CIP-0005/CIP-0005.md
+++ b/CIP-0005/CIP-0005.md
@@ -23,35 +23,35 @@ Therefore, we can leverage bech32 for binary data encoding, with a set of common
 
 We define the following set of common prefixes with their corresponding semantic. Any software willing to represent binary data in a human-friendly way should abide by these guidelines. Should a data-type be missing, we encourage developers to update this CIP and register a new prefix.
 
-| Prefix       | Semantic                                      | Contents
-| ---          | ---                                           | ---
-| `addr_vk`    | Address verification key                      | Verification/public key
-| `addr_vkh`   | Address verification key hash                 | Hash of verification/public key
-| `addr_sk`    | Address signing key                           | Signing/private key
-| `addr_xvk`   | Address extended verification key             | Verification/public key
-| `addr_xsk`   | Address extended signing key                  | Signing/private key
-| `addr`       | Mainnet address                               | Base address
-| `addr_test`  | Testnet address                               | Base address
-| `stake_vk`   | Stake address verification key                | Verification/public key
-| `stake_vkh`  | Stake address verification key hash           | Hash of verification/public key
-| `stake_sk`   | Stake address signing key                     | Signing/private key
-| `stake_xvk`  | Stake address extended verification key       | Verification/public key
-| `stake_xsk`  | Stake address extended signing key            | Signing/private key
-| `stake`      | Mainnet stake address                         | Stake address (reward account)
-| `stake_test` | Testnet stake address                         | Stake address (reward account)
-| `pool`       | Pool operator verification key hash (pool ID) | Hash of verification/public
-| `pool_vk`    | Pool operator verification key                | Verification/public key
-| `pool_sk`    | Pool operator signing key                     | Signing/private key
-| `kes_vk`     | KES verification key                          | Verification/public key
-| `kes_vkh`    | KES verification key hash                     | Hash of verification/public key
-| `kes_sk`     | KES signing key                               | Signing/private key
-| `vrf_vk`     | VRF verification key                          | Verification/public key
-| `vrf_vkh`    | VRF verification key hash                     | Hash of verification/public key
-| `vrf_sk`     | VRF signing key                               | Signing/private key
-| `script`     | Script hash                                   | Hash of script
-| `script_vk`  | Script verification key                       | Verification key/public key
-| `script_vkh` | Script verification key hash                  | Hash of verification key/public key
-| `script_sk`  | Script signing key                            | Signing/private key
+| Prefix       | Meaning                                       | Contents                            |
+| ---          | ---                                           | ---                                 |
+| `addr_vk`    | Address verification key                      | Verification/public key             |
+| `addr_vkh`   | Address verification key hash                 | Hash of verification/public key     |
+| `addr_sk`    | Address signing key                           | Signing/private key                 |
+| `addr_xvk`   | Address extended verification key             | Verification/public key             |
+| `addr_xsk`   | Address extended signing key                  | Signing/private key                 |
+| `addr`       | Mainnet address                               | Base address                        |
+| `addr_test`  | Testnet address                               | Base address                        |
+| `stake_vk`   | Stake address verification key                | Verification/public key             |
+| `stake_vkh`  | Stake address verification key hash           | Hash of verification/public key     |
+| `stake_sk`   | Stake address signing key                     | Signing/private key                 |
+| `stake_xvk`  | Stake address extended verification key       | Verification/public key             |
+| `stake_xsk`  | Stake address extended signing key            | Signing/private key                 |
+| `stake`      | Mainnet stake address                         | Stake address (reward account)      |
+| `stake_test` | Testnet stake address                         | Stake address (reward account)      |
+| `pool`       | Pool operator verification key hash (pool ID) | Hash of verification/public         |
+| `pool_vk`    | Pool operator verification key                | Verification/public key             |
+| `pool_sk`    | Pool operator signing key                     | Signing/private key                 |
+| `kes_vk`     | KES verification key                          | Verification/public key             |
+| `kes_vkh`    | KES verification key hash                     | Hash of verification/public key     |
+| `kes_sk`     | KES signing key                               | Signing/private key                 |
+| `vrf_vk`     | VRF verification key                          | Verification/public key             |
+| `vrf_vkh`    | VRF verification key hash                     | Hash of verification/public key     |
+| `vrf_sk`     | VRF signing key                               | Signing/private key                 |
+| `script`     | Script hash                                   | Hash of script                      |
+| `script_vk`  | Script verification key                       | Verification key/public key         |
+| `script_vkh` | Script verification key hash                  | Hash of verification key/public key |
+| `script_sk`  | Script signing key                            | Signing/private key                 |
 
 ## Rationale
 


### PR DESCRIPTION
Hereby, we propose the prefixes for:
- script hash itself
- verification key hashes that are used inside the script
- signing key corresponding to verification key  used in the script