### PR TITLE
Cardano registration metadata changes and signature specification pt.2

### DIFF
--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -67,7 +67,9 @@ and a nonce, respectively. A registration with these metadata will be
 considered valid if the following conditions hold:
 
 - Nonce should be monotonically rising across all transactions with the same
-  staking key.
+  staking key. The advised way to construct a nonce is to use the current tip
+  slot. This is a simple way to keep nonce rising without having to access the
+  previous transaction data.
 - The reward address is a Shelley address discriminated for the same network
   this transaction is submitted to.
 

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -89,32 +89,13 @@ Signature example:
 }
 ```
 
-### Revocation of a voting key
-
-A previously registered voting key can be revoked by posting another transaction
-with the two metadata fields as above, with the difference that the voting key
-and the reward address fields are absent.
-
-Revocation example:
-```
-61284: {
-  // No voting_key
-  // stake_pub - CBOR byte array
-  2: "0xad4b948699193634a39dd56f779a2951a24779ad52aa7916f6912b8ec4702cee",
-  // slot_number
-  4: 5479468
-}
-```
-
-The signature payload under key 61285 is formed as described above.
-
 ### Metadata schema
 
 The format above can be described by the following CDDL definition:
 
 ```
 registration_cbor = {
-  61284: key_registration / key_revocation,
+  61284: key_registration,
   61285: registration_signature
 }
 
@@ -128,11 +109,6 @@ key_registration = {
   1 : $voting_pub_key,
   2 : $staking_pub_key,
   3 : $reward_address,
-  4 : $slot_number,
-}
-
-key_revocation = {
-  2 : $staking_pub_key,
   4 : $slot_number,
 }
 

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -89,13 +89,32 @@ Signature example:
 }
 ```
 
-#### Metadata schema
+### Revocation of a voting key
+
+A previously registered voting key can be revoked by posting another transaction
+with the two metadata fields as above, with the difference that the voting key
+and the reward address fields are absent.
+
+Revocation example:
+```
+61284: {
+  // No voting_key
+  // stake_pub - CBOR byte array
+  2: "0xad4b948699193634a39dd56f779a2951a24779ad52aa7916f6912b8ec4702cee",
+  // slot_number
+  4: 5479468
+}
+```
+
+The signature payload under key 61285 is formed as described above.
+
+### Metadata schema
 
 The format above can be described by the following CDDL definition:
 
 ```
 registration_cbor = {
-  61284: key_registration,
+  61284: key_registration / key_revocation,
   61285: registration_signature
 }
 
@@ -109,6 +128,11 @@ key_registration = {
   1 : $voting_pub_key,
   2 : $staking_pub_key,
   3 : $reward_address,
+  4 : $slot_number,
+}
+
+key_revocation = {
+  2 : $staking_pub_key,
   4 : $slot_number,
 }
 

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -47,7 +47,7 @@ A Catalyst registration transaction is a regular Cardano transaction with a spec
 
 Notably, there should be four entries inside the metadata map:
 
-Voting key registration
+Voting registration example:
 ```
 61284: {
   // voting_key - CBOR byte array
@@ -71,7 +71,17 @@ will be considered valid if the following conditions hold:
 - The reward address is a Shelley address discriminated for the same network
   this transaction is submitted to.
 
-Signing the voting public key with the staking private key
+To produce the signature field, the CBOR representation of a map containing
+a single entry with key 61284 and the registration metadata map in the
+format above is formed, designated here as `sign_data`.
+This data is signed with the staking key using one of the two methods,
+discriminated by the key number in the signature metadata map:
+
+1: `sign_data` is signed as is using Ed25519.
+
+2: The blake2b-256 hash of `sign_data` is signed using Ed25519.
+
+Signature example:
 ```
 61285: {
   // signature - ED25119 signature CBOR byte array
@@ -103,7 +113,8 @@ key_registration = {
 }
 
 registration_signature = {
-  1 : $ed25519_signature
+  1 : $ed25519_signature //
+  2 : $ed25519_signature
 }
 ```
 

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -33,15 +33,19 @@ A voting key is simply an ED25519 key. How this key is created is up to the wall
 
 ### Associating stake with a voting key
 
+This method has been used since Fund 2.
+For future fund iterations, a new method making use of time-lock scripts may
+be introduced as described [below][future-development].
+
 Recall: Cardano uses the UTXO model so to completely associate a wallet's balance with a voting key (i.e. including enterprise addresses), we would need to associate every payment key to a voting key individually. Although there are attempts at this (see [CIP8](../CIP-0008/CIP-0008.md)), the resulting data structure is a little excessive for on-chain metadata (which we want to keep small)
 
 Given the above, we choose to only associate staking keys with voting keys. Since most Cardano wallets only use base addresses for Shelley wallet types, in most cases this should perfectly match the user's wallet.
 
 ### Registration metadata format
 
-A Catalyst registration transaction are a regular Cardano transaction with a specific transaction metadata associated with it
+A Catalyst registration transaction is a regular Cardano transaction with a specific transaction metadata associated with it.
 
-Notably, there should be three entries inside the metadata map:
+Notably, there should be four entries inside the metadata map:
 
 Voting key registration
 ```
@@ -50,10 +54,22 @@ Voting key registration
   1: "0xa6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663",
   // stake_pub - CBOR byte array
   2: "0xad4b948699193634a39dd56f779a2951a24779ad52aa7916f6912b8ec4702cee",
-  // address - CBOR byte array
-  3: "0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee47b60edc7772855324c85033c638364214cbfc6627889f81c4"
+  // reward_address - CBOR byte array
+  3: "0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee47b60edc7772855324c85033c638364214cbfc6627889f81c4",
+  // slot_number
+  4: 5479467
 }
 ```
+
+The entries under keys 1, 2, 3, and 4 represent the Catalyst voting key,
+the staking key on the Cardano network, the address to receive rewards,
+and the current slot number, respectively. A registration with these metadata
+will be considered valid if the following conditions hold:
+
+- The slot number of the block including this transaction is equal to
+  the slot number value under key 4 or its increment by one.
+- The reward address is a Shelley address discriminated for the same network
+  this transaction is submitted to.
 
 Signing the voting public key with the staking private key
 ```
@@ -63,23 +79,27 @@ Signing the voting public key with the staking private key
 }
 ```
 
-This corresponds to the following CDDL definition
+#### Metadata schema
+
+The format above can be described by the following CDDL definition:
 
 ```
 registration_cbor = {
-  61284: key_registration
-, 61285: registration_signature
+  61284: key_registration,
+  61285: registration_signature
 }
 
 $voting_pub_key /= bytes .size 32
 $staking_pub_key /= bytes .size 32
 $ed25519_signature /= bytes .size 64
-$address /= bytes
+$reward_address /= bytes
+$slot_number /= uint
 
 key_registration = {
-  1 : $voting_pub_key
-, 2 : $staking_pub_key
-, 3 : $address
+  1 : $voting_pub_key,
+  2 : $staking_pub_key,
+  3 : $reward_address,
+  4 : $slot_number,
 }
 
 registration_signature = {
@@ -90,11 +110,24 @@ registration_signature = {
 # Test vector
 
 See [test vector file](./test-vector.md)
-Here an example using CBOR diagnostic notation
+
+### Future development
+
+[future-development]: #future-development
+
+A future change of the Catalyst system may make use of a time-lock script to commit ADA on the mainnet for the duration of a voting period. The voter registration metadata in this method will not need an association
+with the staking key. Therefore, the `staking_pub_key` map entry
+and the `registration_signature` payload with key 61285 will no longer
+be required.
 
 ## Changelog
 
-Fund 3 added the `address` inside the `key_registration` field.
+Fund 3 added the `reward_address` inside the `key_registration` field.
+
+Fund 4 added the `slot_number` field to prevent replay attacks.
+
+It was planned that since Fund 4, `registration_signature` and the `staking_pub_key` entry inside the `key_registration` field will be deprecated.
+This has been deferred to a future revision of the protocol.
 
 ## Copyright
 

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -56,18 +56,18 @@ Voting registration example:
   2: "0xad4b948699193634a39dd56f779a2951a24779ad52aa7916f6912b8ec4702cee",
   // reward_address - CBOR byte array
   3: "0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee47b60edc7772855324c85033c638364214cbfc6627889f81c4",
-  // slot_number
+  // nonce
   4: 5479467
 }
 ```
 
 The entries under keys 1, 2, 3, and 4 represent the Catalyst voting key,
 the staking key on the Cardano network, the address to receive rewards,
-and the current slot number, respectively. A registration with these metadata
-will be considered valid if the following conditions hold:
+and a nonce, respectively. A registration with these metadata will be
+considered valid if the following conditions hold:
 
-- The slot number of the block including this transaction is equal to
-  the slot number value under key 4 or its increment by one.
+- Nonce should be monotonically rising across all transactions with the same
+  staking key.
 - The reward address is a Shelley address discriminated for the same network
   this transaction is submitted to.
 
@@ -103,13 +103,13 @@ $voting_pub_key /= bytes .size 32
 $staking_pub_key /= bytes .size 32
 $ed25519_signature /= bytes .size 64
 $reward_address /= bytes
-$slot_number /= uint
+$nonce /= uint
 
 key_registration = {
   1 : $voting_pub_key,
   2 : $staking_pub_key,
   3 : $reward_address,
-  4 : $slot_number,
+  4 : $nonce,
 }
 
 registration_signature = {
@@ -135,7 +135,7 @@ be required.
 
 Fund 3 added the `reward_address` inside the `key_registration` field.
 
-Fund 4 added the `slot_number` field to prevent replay attacks.
+Fund 4 added the `nonce` field to prevent replay attacks.
 
 It was planned that since Fund 4, `registration_signature` and the `staking_pub_key` entry inside the `key_registration` field will be deprecated.
 This has been deferred to a future revision of the protocol.

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -76,12 +76,11 @@ considered valid if the following conditions hold:
 To produce the signature field, the CBOR representation of a map containing
 a single entry with key 61284 and the registration metadata map in the
 format above is formed, designated here as `sign_data`.
-This data is signed with the staking key using one of the two methods,
-discriminated by the key number in the signature metadata map:
-
-1: `sign_data` is signed as is using Ed25519.
-
-2: The blake2b-256 hash of `sign_data` is signed using Ed25519.
+This data is signed with the staking key as follows: first, the
+blake2b-256 hash of `sign_data` is obtained. This hash is then signed
+using the Ed25519 signature algorithm. The signature metadata entry is
+added to the transaction under key 61285 as a CBOR map with a single entry
+that consists of the integer key 1 and signature as obtained above as the byte array value.
 
 Signature example:
 ```
@@ -115,8 +114,7 @@ key_registration = {
 }
 
 registration_signature = {
-  1 : $ed25519_signature //
-  2 : $ed25519_signature
+  1 : $ed25519_signature
 }
 ```
 
@@ -137,7 +135,10 @@ be required.
 
 Fund 3 added the `reward_address` inside the `key_registration` field.
 
-Fund 4 added the `nonce` field to prevent replay attacks.
+Fund 4:
+- added the `nonce` field to prevent replay attacks;
+- changed the signature algorithm from one that signed `sign_data` directly
+  to signing the Blake2b hash of `sign_data` to accommodate memory-constrained hardware wallet devices.
 
 It was planned that since Fund 4, `registration_signature` and the `staking_pub_key` entry inside the `key_registration` field will be deprecated.
 This has been deferred to a future revision of the protocol.

--- a/CIP-0015/CIP-0015.md
+++ b/CIP-0015/CIP-0015.md
@@ -66,10 +66,11 @@ the staking key on the Cardano network, the address to receive rewards,
 and a nonce, respectively. A registration with these metadata will be
 considered valid if the following conditions hold:
 
-- Nonce should be monotonically rising across all transactions with the same
-  staking key. The advised way to construct a nonce is to use the current tip
-  slot. This is a simple way to keep nonce rising without having to access the
-  previous transaction data.
+- The nonce is an unsigned integer (of CBOR major type 0) that should be 
+  monotonically rising across all transactions with the same staking key.
+  The advised way to construct a nonce is to use the current slot number.
+  This is a simple way to keep the nonce increasing without having to access
+  the previous transaction data.
 - The reward address is a Shelley address discriminated for the same network
   this transaction is submitted to.
 


### PR DESCRIPTION
Extends #75. Replaces `slot_number` with `nonce` since we cannot know in advance what slot a transaction will be included into.