### PR TITLE
Script to update CIPs list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cardano Improvement Proposals (CIPs)
 
-Cardano Improvement Proposals (CIPs) describe standards, processes; or provide general guidelines or information to the Cardano Community. It is a formal, technical communication process that exists off-chain. 
-The current process is described in details in [CIP1 - "CIP Process"](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0001/CIP-0001.md).  
+Cardano Improvement Proposals (CIPs) describe standards, processes; or provide general guidelines or information to the Cardano Community. It is a formal, technical communication process that exists off-chain.
+The current process is described in details in [CIP1 - "CIP Process"](./CIP-0001/CIP-0001.md).
 
 ### Current CIPs (as of 06/02/21) 
 
@@ -28,15 +28,16 @@ The current process is described in details in [CIP1 - "CIP Process"](https://gi
 | 1853              | [HD Stake Pool Cold Keys](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1853)                                                    | Draft                 |
 | 1854              | [Multi-signatures HD Wallets](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1854)                                                | Draft                 |
 
-:bulb: -  For more details about Statuses, refer to [CIP1](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0001).
+> 💡 For more details about Statuses, refer to [CIP1](./CIP-0001/CIP-0001.md).
 
 
-### CIP creation process as a Sequence Diagram  
-_"Alice has a Cardano idea she'd like to build more formally":_
-![Mary interacting with community and editors for a Cardano Proposal](./BiweeklyMeetings/sequence_diagram.png?raw=true "sequence_diagram.png")
+### CIP creation process as a Sequence Diagram
 
-Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.org/c/developers/cips/122), Cardano’s Official [Developer Telegram Group](https://t.me/CardanoDevelopersOfficial) or in #developers in Cardano Ambassadors Slack.  
-CIP Editors meetings are [public](https://www.crowdcast.io/cips-biweekly), [recorded](https://www.crowdcast.io/cips-biweekly) and [summarized](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings): do join and participate for discussions/PRs of significances to you.  
+  “_Alice has a Cardano idea she'd like to build more formally…_”
 
-=> To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/). <= 
+![Diagram: Mary interacting with community and editors for a Cardano Proposal](./BiweeklyMeetings/sequence_diagram.png?raw=true "sequence_diagram.png")
 
+Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.org/c/developers/cips/122), Cardano’s Official [Developer Telegram Group](https://t.me/CardanoDevelopersOfficial) or in `#developers` in Cardano Ambassadors Slack.
+CIP Editors meetings are [public](https://www.crowdcast.io/cips-biweekly), [recorded](https://www.crowdcast.io/cips-biweekly) and [summarized](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings): do join and participate for discussions/PRs of significances to you.
+
+> 🛈 To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).

--- a/README.md
+++ b/README.md
@@ -3,30 +3,30 @@
 Cardano Improvement Proposals (CIPs) describe standards, processes; or provide general guidelines or information to the Cardano Community. It is a formal, technical communication process that exists off-chain.
 The current process is described in details in [CIP1 - "CIP Process"](./CIP-0001/CIP-0001.md).
 
-### Current CIPs (as of 06/02/21) 
+### Current CIPs (as of 2021-05-11)
 
 | #                 | Title                                                                                                                                         | Status                |
 | ----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------- |
-| 1                 | [CIP Process](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0001)                                                                | Active                |
-| 2                 | [Coin Selection Algorithms](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0002)                                                  | Draft                 |
-| 3                 | [Wallet key generation](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0003)                                                      | Draft                 |
-| 4                 | [Wallet Checksum](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0004)                                                            | Draft                 |
-| 5                 | [Common Bech32 Prefixes](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)                                                     | Draft                 |
-| 6                 | [Stake Pool Extended Metadata](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0006)                                               | Draft                 |
-| 7                 | [Curve Pledge Benefit](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0007)                                                       | Draft                 |
-| 8                 | [Message Signing](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0008)                                                            | Draft                 |
-| 9                 | [Initial Parameters](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0009)                                                         | Draft                 |
-| 10                | [Transaction Metadata Label Registry](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0010)                                        | Draft                 |
-| 11                | [Staking key chain for HD wallets](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0011)                                           | Draft                 |
-| 12                | [On-chain stake pool operator to delegates communication](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0012)                    | Draft                 |
-| 13                | [Cardano URI Scheme](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0013)                                                         | Draft                 |
-| 14                | [User-facing Asset Fingerprint](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0014)                                              | Draft                 |
-| 15                | [Catalyst Registration Transaction](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0015)                                          | Draft                 |
-| 16                | [Cryptographic Key Serialisation Formats](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0016)                                    | Draft                 |
-| 19                | [Cardano Addresses](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019)                                                          | Draft                 |
-| 1852              | [HD Wallets for Cardano](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1852)                                                     | Draft                 |
-| 1853              | [HD Stake Pool Cold Keys](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1853)                                                    | Draft                 |
-| 1854              | [Multi-signatures HD Wallets](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1854)                                                | Draft                 |
+| 1 | [CIP process](./CIP-0001/CIP-0001.md) | Active |
+| 2 | [Coin Selection Algorithms for Cardano](./CIP-0002/CIP-0002.md) | Draft |
+| 3 | [Wallet key generation](./CIP-0003/CIP-0003.md) | Draft |
+| 4 | [Wallet Checksums](./CIP-0004/CIP-0004.md) | Draft |
+| 5 | [Common Bech32 Prefixes](./CIP-0005/CIP-0005.md) | Draft |
+| 6 | [Stake Pool Extended Metadata](./CIP-0006/CIP-0006.md) | Draft |
+| 7 | [Curve Pledge Benefit](./CIP-0007/CIP-0007.md) | Draft |
+| 8 | [Message Signing](./CIP-0008/CIP-0008.md) | Draft |
+| 9 | [Protocol Parameters](./CIP-0009/CIP-0009.md) | Draft |
+| 10 | [Transaction Metadata Label Registry](./CIP-0010/CIP-0010.md) | Draft |
+| 11 | [Staking key chain for HD wallets](./CIP-0011/CIP-0011.md) | Draft |
+| 12 | [On-chain stake pool operator to delegates communication](./CIP-0012/CIP-0012.md) | Draft |
+| 13 | [Cardano URI Scheme](./CIP-0013/CIP-0013.md) | Draft |
+| 14 | [User-Facing Asset Fingerprint](./CIP-0014/CIP-0014.md) | Draft |
+| 15 | [Catalyst Registration Transaction Metadata Format](./CIP-0015/CIP-0015.md) | Draft |
+| 16 | [Cryptographic Key Serialisation Formats](./CIP-0016/CIP-0016.md) | Draft |
+| 19 | [Cardano Addresses](./CIP-0019/CIP-0019.md) | Active |
+| 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/CIP-1852.md) | Draft |
+| 1853 | [HD (Hierarchy for Deterministic) Stake Pool Cold Keys for Cardano](./CIP-1853/CIP-1853.md) | Draft |
+| 1854 | [Multi-signatures HD Wallets](./CIP-1854/CIP-1854.md) | Draft |
 
 > 💡 For more details about Statuses, refer to [CIP1](./CIP-0001/CIP-0001.md).
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -64,7 +64,8 @@ function getTableOfContents (lines, { children = [], headingType = -1 } = {}) {
 }
 
 function loadFrontmatter (filePath) {
-  const contents = fs.readFileSync(filePath, { encoding: 'utf8' })
+  const raw = fs.readFileSync(filePath, { encoding: 'utf8' })
+  const contents = raw.replace(/\.\/.*CIP-0*([^\.]+)\.md/g, '/cips/cip$1')
   const parsed = matter(contents)
   parsed.html = converter.makeHtml(parsed.content)
   return parsed

--- a/scripts/update-toc.sh
+++ b/scripts/update-toc.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# A script to update the CIPs list in README.md.
+# If it works there will be no output - it edits the file directly.
+# Requires: coreutils findutils git gnused jq pandoc
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+pandoc_template="$(mktemp template.XXXXX.gfm)"
+trap 'rm -f "$pandoc_template"' EXIT
+
+get_last_update() {
+  git log --date=local --format=%cs -1 -- CIP-*/CIP-*.md
+}
+
+all_metadata_jsonlines() {
+  # shellcheck disable=SC2016
+  echo '$for(sourcefile)${"sourcefile":"$sourcefile$","meta":$meta-json$}$endfor$' > "$pandoc_template"
+  find CIP-* -type f -name 'CIP-*.md' | sort -n | while read -r cip; do
+    pandoc --from=gfm --to=gfm --template="$pandoc_template" "$cip"
+  done
+}
+
+table_lines() {
+  jq --raw-output '"| \(.meta.CIP) | [\(.meta.Title)](./\(.sourcefile)) | \(.meta.Status) |"'
+}
+
+replace_table() {
+  sed -i '/^|.----/,/^$/!b;//!d;0,/^|.----/r /dev/stdin' "$1"
+  sed -i 's/(as of [^)]*)/(as of '"$(get_last_update)"')/' "$1"
+}
+
+all_metadata_jsonlines | table_lines | replace_table README.md


### PR DESCRIPTION
The links in `README.md` were bothering me a little because they show the folder instead of the document.

This changes the link format and adds a script to regenerate the list based on the latest CIP metadata.
The "last updated date" is also changed to YYYY-MM-DD so that nobody gets confused.

I also tested it out with the static site (`npm run build`), and it seems to be an improvement. I also did some minor reformatting to make the front page display better.

* Link to [rendered form](https://github.com/rvl/CIPs/blob/update-toc-script/README.md)
