### PR TITLE
[CIP-1852] Fixed term usage `role` instead of `chain` for consistency

### DIFF
--- a/CIP-1852/CIP-1852.md
+++ b/CIP-1852/CIP-1852.md
@@ -48,7 +48,7 @@ m / purpose' / coin_type' / account' / role / index
 
 Example: `m / 1852' / 1815' / 0' / 0 / 0`
 
-Here, `chain` can be the following
+Here, `role` can be the following
 
 | Name           | Value | Description
 |----------------|-------|-------------


### PR DESCRIPTION
Before it was still using `chain`, even tho in the diagram of derivation and in the rest of the document it says `role`

![image](https://user-images.githubusercontent.com/5585355/127764932-ffbcd215-12c1-4929-a860-8211d53144d5.png)

So replaced it with `role` as well.