### PR TITLE
CIP-1855: fix policy index range

### DIFF
--- a/CIP-1855/CIP-1855.md
+++ b/CIP-1855/CIP-1855.md
@@ -44,7 +44,7 @@ We can summarize the various paths and their respective domain in the following 
 
 | `purpose` | `coin_type` | `policy_ix`         |
 | ---       | ---         | ---                 |
-| `1855'`   | `1815'`     | `[2^31 .. 2^32-1]'` |
+| `1855'`   | `1815'`     | `[2^31 .. 2^32-1]` |
 
 
 ### Rationale


### PR DESCRIPTION
I noticed that the `policy_ix` range was "hardened twice", which it probably shouldn't be.