### PR TITLE
CIP-00xx | On-Chain Token Owner Key Registration

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -1,4 +1,7 @@
 [
+  { "transaction_metadatum_label": 178,
+    "description": "CIP-0028 - On-Chain Token Owner Key Registration"
+  },
   {
     "transaction_metadatum_label": 674,
     "description": "CIP-0020 - Transaction message/comment metadata"

--- a/CIP-0028/CIP-0028.md
+++ b/CIP-0028/CIP-0028.md
@@ -1,0 +1,66 @@
+---
+CIP: 28
+Title: On-Chain Token Owner Key Registration
+Authors: Matthias Benkort <matthias.benkort@iohk.io>
+Comments-URI: https://github.com/cardano-foundation/CIPs/pulls/118
+Status: Draft
+Type: Standards
+Created: 2020-08-17
+License: CC-BY-4.0
+---
+
+# Abstract
+  
+This specification defines a new transaction metadata label (i.e. `178`) and entry for [CIP-0010] to associate some arbitrary keys to some assets during a minting transaction.
+
+# Motivation
+
+[CIP-0026] highlights several mechanisms by which a metadata owner may want to associate its data to a particular on-chain event. We consider here the use-case of token minting, for which the relation between an owner (hereby represented by some cryptographic public key) and the metadata is unclear, in particular in the context of minting policies based on phase-2 (a.k.a Plutus) scripts. This proposal makes of the transaction metadata AND, a minting transaction to create this relationship between the owner and the on-chain event corresponding to the token minting. 
+
+# Specification
+
+Applications minting tokens on the Cardano blockchain may choose to associate the following transaction metadata to facilitate association of off-chain metadata with the corresponding on-chain event. When doing so, the transaction metadata MUST be included in the same transaction minting (or burning) the assets referenced in the metadata.
+
+> <sub>NOTE</sub>
+>
+> The following specification is also provided in annexe as a standalone `.cddl` file.
+
+```cddl
+METADATA-ENTRY =
+  { 178: METADATUM }
+
+METADATUM =
+  { * POLICY-ID => (  (0, KEY-HASH) 
+                   // (1, { * ASSET-NAME => * KEY-HASH })
+                   )
+  }
+
+ASSET-NAME =
+  bytes .size (0..32)
+
+KEY-HASH =
+  bytes .size 28
+```
+
+When discovering such a on-chain metadata entry, client application MUST verify that the policy and (when applicable) assets referenced in the metadata are present in the transaction. Then, they MAY automatically trust any off-chain metadata entry signed by one of the private registered counterpart, according to [CIP-0026].
+
+# Rationale
+
+- Ensuring the metadata is included as part of the minting (or burning) transaction ensures that it is also automatically signed by the token issuer. 
+- We only associate certain assets to key hashes, so that we keep the on-chain data rather small and favor off-chain solution for metadata, which can now be authenticated with the registered keys.
+- The specification allows for defining one key per asset or, a key for an entire policy. The latter is likely the most common use-case as we expect a token issuer to use a single key to authenticate all its token metadata. 
+
+# Backwards Compatibility
+
+N/A
+
+# Reference Implementation(s)
+
+N/A
+
+# Copyright
+
+CC-BY-4.0
+
+[CIP-0010]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0010
+[CIP-0026]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0026

--- a/CIP-0028/metadata-label-178.cddl
+++ b/CIP-0028/metadata-label-178.cddl
@@ -1,0 +1,14 @@
+METADATA-ENTRY =
+  { 178: METADATUM }
+
+METADATUM =
+  { * POLICY-ID => (  (0, KEY-HASH)
+                   // (1, { * ASSET-NAME => * KEY-HASH })
+                   )
+  }
+
+ASSET-NAME =
+  bytes .size (0..32)
+
+KEY-HASH =
+  bytes .size 28

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The current process is described in details in [CIP1 - "CIP Process"](./CIP-0001
 | 23 | [Fair Min Fees](./CIP-0023/CIP-0023.md) | Draft |
 | 24 | [Non-Centralizing Rankings](./CIP-0024/CIP-0024.md) | Draft |
 | 25 | [NFT Metadata Standard](./CIP-0025/CIP-0025.md) | Draft |
+| 28 | [On-Chain Token Owner Key Registration](./CIP-0028/CIP-0028.md) | Draft |
 | 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/CIP-1852.md) | Draft |
 | 1853 | [HD (Hierarchy for Deterministic) Stake Pool Cold Keys for Cardano](./CIP-1853/CIP-1853.md) | Draft |
 | 1854 | [Multi-signatures HD Wallets](./CIP-1854/CIP-1854.md) | Draft |


### PR DESCRIPTION
# Abstract
  
This specification defines a new transaction metadata label (i.e. `178`) and entry for [CIP-0010] to associate some arbitrary keys to some assets during a minting transaction.

# Motivation

[CIP-0026] highlights several mechanisms by which a metadata owner may want to associate its data to a particular on-chain event. We consider here the use-case of token minting, for which the relation between an owner (hereby represented by some cryptographic public key) and the metadata is unclear, in particular in the context of minting policies based on phase-2 (a.k.a Plutus) scripts. This proposal makes of the transaction metadata AND, a minting transaction to create this relationship between the owner and the on-chain event corresponding to the token minting. 

# Specification

Applications minting tokens on the Cardano blockchain may choose to associate the following transaction metadata to facilitate association of off-chain metadata with the corresponding on-chain event. When doing so, the transaction metadata MUST be included in the same transaction minting (or burning) the assets referenced in the metadata.

> <sub>NOTE</sub>
>
> The following specification is also provided in annexe as a standalone `.cddl` file.

```cddl
METADATA-ENTRY =
  { 178: METADATUM }

METADATUM =
  { * POLICY-ID => (  (0, KEY-HASH) 
                   // (1, { * ASSET-NAME => * KEY-HASH })
                   )
  }

ASSET-NAME =
  bytes .size (0..32)

KEY-HASH =
  bytes .size 28
```

When discovering such a on-chain metadata entry, client application MUST verify that the policy and (when applicable) assets referenced in the metadata are present in the transaction. Then, they MAY automatically trust any off-chain metadata entry signed by one of the private registered counterpart, according to [CIP-0026].

# Rationale

- Ensuring the metadata is included as part of the minting (or burning) transaction ensures that it is also automatically signed by the token issuer. 
- We only associate certain assets to key hashes, so that we keep the on-chain data rather small and favor off-chain solution for metadata, which can now be authenticated with the registered keys.
- The specification allows for defining one key per asset or, a key for an entire policy. The latter is likely the most common use-case as we expect a token issuer to use a single key to authenticate all its token metadata. 

# Backwards Compatibility

N/A

# Reference Implementation(s)

N/A

# Copyright

CC-BY-4.0

[CIP-0010]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0010
[CIP-0026]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0026