### PR TITLE
reserve entries in the metadata mapping for mikomeda protocol

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -1,5 +1,13 @@
 [
   {
+    "transaction_metadatum_label": 87,
+    "description": "milkomeda.com - The protocol magic for the milkomeda protocol"
+  },
+  {
+    "transaction_metadatum_label": 88,
+    "description": "milkomeda.com - the destination address in the sidechain"
+  },
+  {
     "transaction_metadatum_label": 674,
     "description": "CIP-0020 - Transaction message/comment metadata"
   },


### PR DESCRIPTION
Hi Cardano Foundation

we would like to reserve a few entries in the CIP10 registry. These are necessary metadata to allow our milkomeda.com protocol to work with Cardano blockchain.

```json
  {
    "transaction_metadatum_label": 87,
    "description": "milkomeda.com - The protocol magic for the milkomeda protocol"
  },
  {
    "transaction_metadatum_label": 88,
    "description": "milkomeda.com - the destination address in the sidechain"
  }
```