### PR TITLE
Add CIP14-js as a reference implementation

### DIFF
--- a/CIP-0014/CIP-0014.md
+++ b/CIP-0014/CIP-0014.md
@@ -63,6 +63,10 @@ N/A
 
 # Reference Implementation
 
+## Javascript
+
+[cip14-js](https://www.npmjs.com/package/@emurgo/cip14-js)
+
 ## Haskell (GHC >= 8.6.5)
 
 <details>


### PR DESCRIPTION
Probably a lot of people looking at this CIP want a JS implementation for their dApp so it's probably best to include the link in the CIP