### PR TITLE
Turn CIP-0002, CIP-0003 & CIP-0005 into 'active'

### DIFF
--- a/CIP-0002/README.md
+++ b/CIP-0002/README.md
@@ -2,8 +2,8 @@
 CIP: 2
 Title: Coin Selection Algorithms for Cardano
 Authors: Jonathan Knowles <jonathan.knowles@iohk.io>
-Comments-URI: https://github.com/cardano-foundation/CIPs/wiki/Comments:CIP-0002
-Status: Draft
+Comments-URI: https://github.com/cardano-foundation/CIPs/issues
+Status: Active
 Type: Informational
 Created: 2020-05-04
 License: CC-BY-4.0
@@ -1017,7 +1017,7 @@ are available in the following languages:
 > |:--|:--|
 > | **Author** | [Edsko de Vries](http://www.edsko.net/) |
 > | **Year** | 2018 |
-> | **Location** | https://cardanofoundation.org/en/news/self-organisation-in-coin-selection/ |
+> | **Location** | https://iohk.io/en/blog/posts/2018/07/03/self-organisation-in-coin-selection/ |
 >
 > This article introduces the [Random-Improve](#random-improve) coin selection
 > algorithm, invented by [Edsko de Vries](http://www.edsko.net/).

--- a/CIP-0003/README.md
+++ b/CIP-0003/README.md
@@ -3,8 +3,8 @@ CIP: 3
 Title: Wallet key generation
 Authors: Matthias Benkort <matthias.benkort@iohk.io>, Sebastien Guillemot <sebastien@emurgo.io>
 Comments-Summary: No comments yet.
-Comments-URI: https://github.com/cardano-foundation/CIPs/wiki/Comments:CIP-0003
-Status: Draft
+Comments-URI: https://github.com/cardano-foundation/CIPs/wiki/issues
+Status: Active
 Type: Standards
 Created: 2020-05-07
 License: CC-BY-4.0

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -4,7 +4,7 @@ Title: Common Bech32 Prefixes
 Authors: Matthias Benkort <matthias.benkort@iohk.io>
 Comments-URI: https://forum.cardano.org/t/cip5-common-bech32-prefixes/35189
 Status: Draft
-Type: Standards
+Type: Active
 Created: 2020-05-28
 License: Apache-2.0
 ---

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ The current process is described in details in [CIP1 - "CIP Process"](./CIP-0001
 | # | Title | Status | 
 | --- | --- | --- |
 | 1 | [CIP process](./CIP-0001) | Active |
-| 2 | [Coin Selection Algorithms for Cardano](./CIP-0002) | Draft |
-| 3 | [Wallet key generation](./CIP-0003) | Draft |
+| 2 | [Coin Selection Algorithms for Cardano](./CIP-0002) | Active |
+| 3 | [Wallet key generation](./CIP-0003) | Active |
 | 4 | [Wallet Checksums](./CIP-0004) | Draft |
-| 5 | [Common Bech32 Prefixes](./CIP-0005) | Draft |
+| 5 | [Common Bech32 Prefixes](./CIP-0005) | Active |
 | 6 | [Stake Pool Extended Metadata](./CIP-0006) | Draft |
 | 7 | [Curve Pledge Benefit](./CIP-0007) | Draft |
 | 8 | [Message Signing](./CIP-0008) | Draft |


### PR DESCRIPTION
  Also, fixed a dead-link in CIP-0002 and changed the comment URI (pointing to nothing) to github issues, for lack of a better alternative.