### PR TITLE
Cip 0010 cardahub metadata

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -29,11 +29,11 @@
   },
   {
     "transaction_metadatum_label": 1988,
-    "description": "cardabase.io marketplace metadata"
+    "description": "cardahub.io marketplace metadata"
   },
   {
     "transaction_metadatum_label": 1989,
-    "description": "cardabase.io services metadata"
+    "description": "cardahub.io services metadata"
   },
   {
     "transaction_metadatum_label": 6770,

--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -28,6 +28,14 @@
     "description": "nut.link metadata oracles data points"
   },
   {
+    "transaction_metadatum_label": 1988,
+    "description": "cardabase.io marketplace metadata"
+  },
+  {
+    "transaction_metadatum_label": 1989,
+    "description": "cardabase.io services metadata"
+  },
+  {
     "transaction_metadatum_label": 6770,
     "description": "fortunes.coconutpool.com fortune teller"
   },


### PR DESCRIPTION
Hi Cardano Foundation team

The team cardahub.io would like to reserve our transaction metadatum entries in the CIP-0010 registry. We are using those entries for storing our onchain metadata.
```
  {
    "transaction_metadatum_label": 1988,
    "description": "cardahub.io marketplace metadata"
  },
  {
    "transaction_metadatum_label": 1989,
    "description": "cardahub.io services metadata"
  }
```