### PR TITLE
Fix CI build for authors without email.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,10 +22,17 @@ handlebars.registerHelper('getAuthors', function (Authors) {
   return Authors.split(',').map(author => {
     const [_, name, link] = author.trim().match(/^([^<]+)<?([^>]+)?>?$/) || []
     let type = 'url'
-    if (link.match(/^[^@]+@[^@]+$/)) {
-      type = 'email'
+    if (link === undefined) {
+      type = 'github'
+    } else {
+      if (link.match(/^[^@]+@[^@]+$/)) {
+        type = 'email'
+      }
     }
-    const authorLink = type === 'email' ? 'mailto:' + link : link
+
+    const authorLink = type === 'email' ? 'mailto:' + link
+      : (type === 'github' ? 'https://github.com/' + name
+      : link)
     const authorName = name.trim()
 
     return ' ' + '<a href="' + authorLink + '" alt="' + authorLink + '">' + authorName + '</a>'


### PR DESCRIPTION
Current builds are failing due to CIP-0030 not having specified an email for the author. 

```
3:33:47 AM: > node ./scripts/build.js
3:33:48 AM: /opt/build/repo/scripts/build.js:25
3:33:48 AM:     if (link.match(/^[^@]+@[^@]+$/)) {
3:33:48 AM:              ^
3:33:48 AM: TypeError: Cannot read property 'match' of undefined
3:33:48 AM:     at Authors.split.map.author (/opt/build/repo/scripts/build.js:25:14)
3:33:48 AM:     at Array.map (<anonymous>)
3:33:48 AM:     at Object.<anonymous> (/opt/build/repo/scripts/build.js:22:29)
3:33:48 AM:     at Object.wrapper (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/internal/wrapHelper.js:15:19)
3:33:48 AM:     at eval (eval at createFunctionContext (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:262:23), <anonymous>:19:114)
3:33:48 AM:     at prog (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/runtime.js:268:12)
3:33:48 AM:     at execIteration (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/helpers/each.js:51:19)
3:33:48 AM:     at Object.<anonymous> (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/helpers/each.js:61:13)
3:33:48 AM:     at Object.wrapper (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/internal/wrapHelper.js:15:19)
3:33:48 AM:     at eval (eval at createFunctionContext (/opt/build/repo/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:262:23), <anonymous>:13:49)
```

While this may be debatable, I've considered this alternative where the rendered website would link to the author's Github profile in the absence of email.