### PR TITLE
CIP-0005 | Add prefixes for output datum hash and script data hash

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -70,19 +70,20 @@ We define the following set of common prefixes with their corresponding semantic
 
 #### Hashes
 
-| Prefix             | Meaning                                            | Contents                                               |
-| ---                | ---                                                | ---                                                    |
-| `asset`            | Fingerprint of a native asset for human comparison | See [CIP-0014]                                         |
-| `pool`             | Pool operator verification key hash (pool ID)      | blake2b\_224 digest of an operator verification key    |
-| `script`           | Script hash                                        | blake2b\_224 digest of a serialized transaction script |
-| `addr_vkh`         | Address verification key hash                      | blake2b\_224 digest of a payment verification key      |
-| `addr_shared_vkh`  | Shared address verification key hash               | blake2b\_224 digest of a payment verification key      |
-| `policy_vkh`       | Policy verification key hash                       | blake2b\_224 digest of a policy verification key       |
-| `stake_vkh`        | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key   |
-| `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key   |
-| `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key          |
-| `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                    |
-| `script_data`      | Script data hash                                   | blake2b\_256 digest of script data                     |
+| Prefix             | Meaning                                            | Contents                                                 |
+| ---                | ---                                                | ---                                                      |
+| `asset`            | Fingerprint of a native asset for human comparison | See [CIP-0014]                                           |
+| `pool`             | Pool operator verification key hash (pool ID)      | blake2b\_224 digest of an operator verification key       |
+| `script`           | Script hash                                        | blake2b\_224 digest of a serialized transaction script    |
+| `addr_vkh`         | Address verification key hash                      | blake2b\_224 digest of a payment verification key         |
+| `addr_shared_vkh`  | Shared address verification key hash               | blake2b\_224 digest of a payment verification key         |
+| `policy_vkh`       | Policy verification key hash                       | blake2b\_224 digest of a policy verification key          |
+| `stake_vkh`        | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key      |
+| `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key      |
+| `signer_vkh`       | Required signer verification key hash              | blake2b\_224 digest of a required signer verification key |
+| `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key             |
+| `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                       |
+| `script_data`      | Script data hash                                   | blake2b\_256 digest of script data                        |
 
 #### Miscellaneous 
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -81,6 +81,8 @@ We define the following set of common prefixes with their corresponding semantic
 | `stake_vkh`        | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key   |
 | `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key   |
 | `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key          |
+| `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                    |
+| `redeemer`         | Script data hash                                   | blake2b\_256 digest of script data                     |
 
 #### Miscellaneous 
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -80,7 +80,7 @@ We define the following set of common prefixes with their corresponding semantic
 | `policy_vkh`       | Policy verification key hash                       | blake2b\_224 digest of a policy verification key          |
 | `stake_vkh`        | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key      |
 | `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key      |
-| `signer_vkh`       | Required signer verification key hash              | blake2b\_224 digest of a required signer verification key |
+| `req_signer_vkh`   | Required signer verification key hash              | blake2b\_224 digest of a required signer verification key |
 | `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key             |
 | `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                       |
 | `script_data`      | Script data hash                                   | blake2b\_256 digest of script data                        |

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -82,7 +82,7 @@ We define the following set of common prefixes with their corresponding semantic
 | `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key   |
 | `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key          |
 | `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                    |
-| `redeemer`         | Script data hash                                   | blake2b\_256 digest of script data                     |
+| `script_data`      | Script data hash                                   | blake2b\_256 digest of script data                     |
 
 #### Miscellaneous 
 


### PR DESCRIPTION
We're suggesting the additions mainly for HW wallets.

For "Output datum hash" we also considered using `output_data`.
For "Script data hash" we also considered using `script_data` or `redeemers` (the plural rather than singular).

The `datum` and `redeemer` prefixes were actually proposed to us by @KtorZ, with the reasoning that this naming was used from the start in regard to the eUTXO model.