### PR TITLE
CIP30: getUtxos null instead of undefined

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -191,11 +191,11 @@ Errors: `APIError`
 
 Returns the network id of the currently connected account. 0 is testnet and 1 is mainnet but other networks can possibly be returned by wallets. Those other network ID values are not governed by this document. This result will stay the same unless the connected account has changed.
 
-### api.getUtxos(amount: cbor\<value> = undefined, paginate: Paginate = undefined): Promise\<TransactionUnspentOutput[] | undefined>
+### api.getUtxos(amount: cbor\<value> = undefined, paginate: Paginate = undefined): Promise\<TransactionUnspentOutput[] | null>
 
 Errors: `APIError`, `PaginateError`
 
-If `amount` is `undefined`, this shall return a list of all UTXOs (unspent transaction outputs) controlled by the wallet. If `amount` is not `undefined`, this request shall be limited to just the UTXOs that are required to reach the combined ADA/multiasset value target specified in `amount`, and if this cannot be attained, `undefined` shall be returned. The results can be further paginated by `paginate` if it is not `undefined`.
+If `amount` is `undefined`, this shall return a list of all UTXOs (unspent transaction outputs) controlled by the wallet. If `amount` is not `undefined`, this request shall be limited to just the UTXOs that are required to reach the combined ADA/multiasset value target specified in `amount`, and if this cannot be attained, `null` shall be returned. The results can be further paginated by `paginate` if it is not `undefined`.
 
 ### api.getBalance(): Promise\<cbor\<value>>
 


### PR DESCRIPTION
Currently CIP30 defines the `getUtxos` endpoint should return `undefined` if the requested amount can't be satisfied

The problem is that browser message passing uses JSON and `undefined` is not valid JSON. This can easily introduce subtle bugs (some libraries silently convert `undefined` to `null`) and it's needless complexity when we could just define the spec to return null instead.

Strictly speaking this is a breaking change, but I'm not sure if it will affect app at the moment.

Another option would be to return an error instead of null which I think also makes sense