### PR TITLE
CIP30: experimental api section

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -247,6 +247,16 @@ Errors: `APIError`, `TxSendError`
 
 As wallets should already have this ability, we allow dApps to request that a transaction be sent through it. If the wallet accepts the transaction and tries to send it, it shall return the transaction id for the dApp to track. The wallet is free to return the `TxSendError` with code `Refused` if they do not wish to send it, or `Failure` if there was an error in sending it (e.g. preliminary checks failed on signatures).
 
+## Experimental API
+
+Functions in this section must be under the `experimental` namespace (ex: `api.experimental.myFunctionality`).
+
+The benefits of this are:
+1. Wallets can non-standardized features while still following the CIP30 structure
+1. dApp developers can use this functions explicitly knowing they are experimental (not stable or standardized)
+1. New features can be added to CIP30 as experimental features and only moved to non-experimental once multiple wallets implement it
+1. Provides a clear path to updating the CIP version number (when functions move from experimental -> stable)
+
 # Implementations
 
 [nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)


### PR DESCRIPTION
# Problem

1. Many wallets have started defining their own functions that aren't part of CIP30. It makes it hard for dApp devs to know which functions are standardized (supported by all wallets) and which are wallet-specific
1. We currently have no clear process for updating the CIP30 api version

Adding an "Experimental API" section to CIP30 aims to solve these issues.

## Experimental API

Functions in this section must be under the `experimental` namespace (ex: `api.experimental.myFunctionality`).

The benefits of this are:
1. Wallets can non-standardized features while still following the CIP30 structure
1. dApp developers can use this functions explicitly knowing they are experimental (not stable or standardized)
1. New features can be added to CIP30 as experimental features and only moved to non-experimental once multiple wallets implement it
1. Provides a clear path to updating the CIP version number (when functions move from experimental -> stable)