### PR TITLE
Update schema/readme with new ticker max length

### DIFF
--- a/CIP-0026/README.md
+++ b/CIP-0026/README.md
@@ -178,7 +178,7 @@ The following properties are considered well-known, and the JSON in their values
 {
   "type": "string",
   "description": "A short identifier for the metadata subject, suitable to show in listings or tiles.",
-  "maxLength": 5,
+  "maxLength": 9,
   "minLength": 2
 }
 ```

--- a/CIP-0026/schema.json
+++ b/CIP-0026/schema.json
@@ -50,7 +50,7 @@
   , "ticker":
     { "type": "string"
     , "description": "A short identifier for the metadata subject, suitable to show in listings or tiles."
-    , "maxLength": 5
+    , "maxLength": 9
     , "minLength": 2
     }
   , "decimals":


### PR DESCRIPTION
In the wild and on other chains, tickers get as long as 9 characters.

Of relevance to me, SUNDAE is 6 characters, but CoinMarketCap recognizes
a MILKSHAKE token with 9 characters.

See https://ethereum.stackexchange.com/questions/25619/is-there-length-limits-on-token-symbols
for real world data.

Also relevant: https://github.com/input-output-hk/offchain-metadata-tools/pull/45