### PR TITLE
CIP-0033 | update to ban reference scripts in the presence of old scripts

### DIFF
--- a/CIP-0033/README.md
+++ b/CIP-0033/README.md
@@ -46,8 +46,8 @@ Changing the script context will require a new Plutus language version in the le
 The change is: a new optional field is added to outputs and inputs to represent reference scripts.
 Reference scripts are represented by their hash in the script context.
 
-Old versions of the language will retain the old interface.
-We do not propose to try and include information about reference scripts in the old interface.
+The interface for old versions of the language will not be changed. 
+Scripts with old versions cannot be spent in transactions that include reference scripts, attempting to do so will be a phase 1 transaction validation failure.
 
 ### CDDL 
 
@@ -115,3 +115,9 @@ We could simply omit any information about reference scripts carried by outputs.
 This would mean that we don't need to change the interface.
 
 We don't have obvious use cases for the information about reference scripts, but the community may come up with use cases, and our general policy is to try and include as much information about the transaction as we can, unless there is a good reason not to.
+
+We also have the question of what to do about old scripts.
+We can't really present the information about reference scripts to them in a faithful way, there is nowhere to put hte information.
+We could omit the information entirely, but this is dangerous in a different way.
+Omitting information may lead scripts to make assumptions about the transaction that are untrue; for this reason we prefer not to silently omit information as a general principle.
+That leaves us only one option: reject transactions where we would have to present information about reference scripts to old scripts.


### PR DESCRIPTION
This matches the recent changes to CIP-31 and 32.

See https://github.com/cardano-foundation/CIPs/pull/161#issuecomment-1030181440.
