### PR TITLE
Add Proof of Existence record label to registry.json

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -8,6 +8,10 @@
     "description": "milkomeda.com - the destination address in the sidechain"
   },
   {
+    "transaction_metadatum_label": 309,
+    "description": "Proof of Existence record"
+  },
+  {
     "transaction_metadatum_label": 674,
     "description": "CIP-0020 - Transaction message/comment metadata"
   },


### PR DESCRIPTION
Proof of Existence (PoE) claims are something at which blockchains can excel, and  a dedicated metadata label would be a natural addition to this registry.

Certain digital assets, such as NFTs already carry a measure of existence proof via the combination of 721-format metadata and basic transaction timestamp.
For other digital assets PoE claim options seem to be less formalized. And while the 674 metadata message label could be used for Proof of Existence claims,  such embedding could also prove semantically confusing.

A dedicated label would also allow for more flexibility in the record format (note: this proposal is just for the label, and not for any particular record format).
I propose using the label "309" as it is short, otherwise unallocated and (trivially) resembles the mirror image of "PoE".

------------------------
e.g., (again, just an example of how a 309 record might be used, not a proposal of record format):
{
	"309": {
		"claims":{
			< hash of a digital asset > : { "name": < an asset name or ID > }
		},
		"ids":[{
			"creator": < a creator name >,
                       "pubkeys": [{ "fingerprint": < a public key fingerprint > }],
                       < other ID-oriented per-entry items >
		}],
		"refs":{
			< social media reference > : < account name >,
                       and/or 
                      <arbitrary commit scheme key> : <commit scheme hash>
		},
		"v": "1.0"
	}
}