### PR TITLE
CIP-0030 | Added `walletExperimentalApiVersion`

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -26,6 +26,8 @@ In order to facilitate future dApp development, we will need a way for dApps to 
 
 The API specified in this document will count as version 0.1.0 for version-checking purposes below.
 
+Note that wallets can have their own separate API version number as well, [see below](https://github.com/cardano-foundation/CIPs/edit/master/CIP-0030/README.md#cardanowalletnamewalletexperimentalapiversion-string).
+
 ## Data Types
 
 ### Bytes
@@ -167,8 +169,13 @@ Returns true if the dApp is already connected to the user's wallet, or if reques
 
 ### cardano.{walletName}.apiVersion: String
 
-The version number of the API that the wallet supports.
+The version number of the **specification** API that the wallet supports.
+This document has it's own version ([see above](https://github.com/cardano-foundation/CIPs/edit/master/CIP-0030/README.md#version)), this parameter indicates which latest version of the specification that wallet supports.
 
+### cardano.{walletName}.walletExperimentalApiVersion: String
+
+The version number of the wallet own API implementation.
+Various wallets might support additional features on top of the specification, but different users might have a different version of that specific wallet installed locally. This parameter indicates which exact version of the API implementation is injected at the moment when a dapp works with it.
 
 ### cardano.{walletName}.name: String
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -26,7 +26,7 @@ In order to facilitate future dApp development, we will need a way for dApps to 
 
 The API specified in this document will count as version 0.1.0 for version-checking purposes below.
 
-Note that wallets can have their own separate API version number as well, [see below](https://github.com/cardano-foundation/CIPs/edit/master/CIP-0030/README.md#cardanowalletnamewalletexperimentalapiversion-string).
+Note that wallets can have their own separate API version number as well, [see below](#cardanowalletnamewalletexperimentalapiversion-string).
 
 ## Data Types
 
@@ -170,7 +170,7 @@ Returns true if the dApp is already connected to the user's wallet, or if reques
 ### cardano.{walletName}.apiVersion: String
 
 The version number of the **specification** API that the wallet supports.
-This document has it's own version ([see above](https://github.com/cardano-foundation/CIPs/edit/master/CIP-0030/README.md#version)), this parameter indicates which latest version of the specification that wallet supports.
+This document has it's own version ([see above](#version)), this parameter indicates which latest version of the specification that wallet supports.
 
 ### cardano.{walletName}.walletExperimentalApiVersion: String
 


### PR DESCRIPTION
There must be two separate version parameters:
1. The version of the supported spec API
2. The version of the wallet API implementation itself

Example usage:

- A dapp knows a specific wallet supports a new experimental feature that they want to utilize, they check `.specificWallet.walletExperimentalApiVersion` and compare it to the version in the wallet documentation, since when the feature has appeared, because even if the user has the `.specificWallet` installed - they might have an older version, before the feature were added.