### PR TITLE
CIP-0047? | Proposal for open Daedalus or desktop wallet via URL

### DIFF
--- a/CIP-0035/CIP-0035.md
+++ b/CIP-0035/CIP-0035.md
@@ -1,0 +1,1 @@
+Moved to [CIP-0035/README.md](./README.md).

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -48,5 +48,5 @@ Wrong examples:
 Since Daedalus is shiped for a single network separately (mainnet and testnet) and can be installed alongside a fligt version (mainnet), the url needs to specify what version is being refered.
 
 # ⚠️ Open questions
-1. Most of the DEX relies on timing due to price volatility. If the user is only using a secure full-node wallet and when clicking on a URL handler that opens a wallet, which is not yet synchronized is the wallet, how is a timeout handled?
-2. Similar to 1. what if the starting of the wallet takes 2-10 mins? Is that still acceptable for a DEX? Should be defined timeout parameter to the URL so that the user DOES NOT make a transaction if the dApp runs in a timeout?
+1. Most of the DEX relies on timing due to price volatility. If the user is only using a secure full-node wallet, which is not yet fully synchronized, how is a timeout handled?
+2. Similar to 1. what if the starting of the wallet takes 2-10 mins? Is that still acceptable for a DEX? Should a timeout parameter be defined in the URL so that the user DOES NOT make the transaction if the dApp runs in a timeout?

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -34,5 +34,5 @@ Correct examples:
 
 ## Considerations
 
-- Since Daedalus is shiped for a single network separately (mainnet and testnet) and can be installed alongside a fligt version (mainnet), the url needs to specify what version is being refered.
-- Adding the unix-timestamp-timeout parameter, in other words: the time in (Unix format) in the future where the transaction is no longer valid. This will allow using a desktop wallet that might take minutes to start or not be yet synchronized will avoid the user to send unnecessarily a transaction.
+- Since Daedalus is shipped for a single network separately (mainnet and testnet), and can be installed alongside a flight version (mainnet), the URL needs to specify which version is being referred.
+- Adding the unix-timestamp-timeout parameter, in other words: the time in (Unix format) in the future where the transaction is no longer valid. This will allow using a desktop wallet that might take minutes to start, or not yet be synchronized, will prevent the user from unnecessarily sending a transaction.

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -23,30 +23,16 @@ The usage of a different URL will solve the problem of users, which have multipl
 
 # 📖 Specification
 
-The core implementation should follow the [BIP-21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) standard (with `bitcoin:` replaced with `desktop+cardano:`)
+The core implementation should follow the [BIP-21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) standard (with `bitcoin:` replaced with `web+cardano:`)
 
 Correct examples:
 ```
-<a href="desktop+cardano-mainnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
-<a href="desktop+cardano-testnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
-<a href="desktop+cardano-mainnet-flight://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
-
-<a href="desktop+cardano-mainnet://stake?c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
-<a href="desktop+cardano-mainnet://stake?POOL1=3.14159&POOL2=2.71828">Split between our 2 related pools</a>
-<a href="desktop+cardano-mainnet://stake?COSD">Choose our least saturated pool</a>
-```
-
-Wrong examples:
-```
-<a href="desktop+cardano://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?network=testnet">Buy/Send/Donate</a>
-<a href="desktop+cardano-testnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?network=mainnet">Buy/Send/Donate</a>
-<a href="desktop+cardano-mainnet://stake?POOL1=3.14159&POOL2=2.71828&network=testnet">Split between our 2 related pools</a>
+<a href="web+cardano://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?unix-timestamp-timeout=1647896861">Buy/Send/Donate</a>
+<a href="web+cardano-testnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?unix-timestamp-timeout=1647896861">Buy/Send/Donate (Testnet)</a>
+<a href="web+cardano-flight://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?unix-timestamp-timeout=1647896861">Buy/Send/Donate (Mainnet and using Daedalus Flight)</a>
 ```
 
 ## Considerations
 
-Since Daedalus is shiped for a single network separately (mainnet and testnet) and can be installed alongside a fligt version (mainnet), the url needs to specify what version is being refered.
-
-# ⚠️ Open questions
-1. Most of the DEX relies on timing due to price volatility. If the user is only using a secure full-node wallet, which is not yet fully synchronized, how is a timeout handled?
-2. Similar to 1. what if the starting of the wallet takes 2-10 mins? Is that still acceptable for a DEX? Should a timeout parameter be defined in the URL so that the user DOES NOT make the transaction if the dApp runs in a timeout?
+- Since Daedalus is shiped for a single network separately (mainnet and testnet) and can be installed alongside a fligt version (mainnet), the url needs to specify what version is being refered.
+- Adding the unix-timestamp-timeout parameter, in other words: the time in (Unix format) in the future where the transaction is no longer valid. This will allow using a desktop wallet that might take minutes to start or not be yet synchronized will avoid the user to send unnecessarily a transaction.

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -1,0 +1,52 @@
+---
+CIP: 35
+Title: Daedalus URI Scheme
+Authors: Daniel Main <daniel.main@iohk.io>
+Comments-URI:
+- https://github.com/cardano-foundation/CIPs/pull/130
+Status: Draft
+Type: Informational
+Created: 2022-03-18
+License: CC-BY-4.0
+---
+
+# Abstract
+
+This proposal is an extension of CIP-0013, which describes a basic URI scheme to handle ada transfers or partial transactions with Daedalus or any desktop Wallet installed in the operating system.
+
+# 💡 Motivation
+
+DEX, Web-dApps and Desktop-dApps (e.g. games or desktop applications) should have the possibility to interact directly with desktop wallets. By defining a URI scheme and registering it in the operating system, it will allow opening Daedalus or any desktop wallet same as when you call or click a mailto:email@sample.com and your email client is opened.
+
+An application could ask for a payment and offer options like PayPal, Visa, cardano-web. Although a user might want to help cardano to get more decentralized using a full-node-wallet that is why the application could also offer payments with a cardano-desktop.
+The usage of a different URL will solve the problem of users, which have multiple wallets: browser-wallet for daily usage and a secure desktop wallet for the savings.
+
+# 📖 Specification
+
+The core implementation should follow the [BIP-21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) standard (with `bitcoin:` replaced with `desktop+cardano:`)
+
+Correct examples:
+```
+<a href="desktop+cardano-mainnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
+<a href="desktop+cardano-testnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
+<a href="desktop+cardano-mainnet-flight://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Buy/Send/Donate</a>
+
+<a href="desktop+cardano-mainnet://stake?c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
+<a href="desktop+cardano-mainnet://stake?POOL1=3.14159&POOL2=2.71828">Split between our 2 related pools</a>
+<a href="desktop+cardano-mainnet://stake?COSD">Choose our least saturated pool</a>
+```
+
+Wrong examples:
+```
+<a href="desktop+cardano://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?network=testnet">Buy/Send/Donate</a>
+<a href="desktop+cardano-testnet://Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd?network=mainnet">Buy/Send/Donate</a>
+<a href="desktop+cardano-mainnet://stake?POOL1=3.14159&POOL2=2.71828&network=testnet">Split between our 2 related pools</a>
+```
+
+## Considerations
+
+Since Daedalus is shiped for a single network separately (mainnet and testnet) and can be installed alongside a fligt version (mainnet), the url needs to specify what version is being refered.
+
+# ⚠️ Open questions
+1. Most of the DEX relies on timing due to price volatility. If the user is only using a secure full-node wallet and when clicking on a URL handler that opens a wallet, which is not yet synchronized is the wallet, how is a timeout handled?
+2. Similar to 1. what if the starting of the wallet takes 2-10 mins? Is that still acceptable for a DEX? Should be defined timeout parameter to the URL so that the user DOES NOT make a transaction if the dApp runs in a timeout?

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The entire process is described in greater detail in [CIP1 - "CIP Process"](./CI
 | 32 | [Inline Datums](./CIP-0032/) | Draft |
 | 33 | [Reference Scripts](./CIP-0033/) | Draft |
 | 34 | [Chain ID Registry](./CIP-0034/) | Draft |
+| 35 | [Desktop wallet application URL](./CIP-0035/) | Draft |
 | 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/) | Draft |
 | 1853 | [HD (Hierarchy for Deterministic) Stake Pool Cold Keys for Cardano](./CIP-1853/) | Draft |
 | 1854 | [Multi-signatures HD Wallets](./CIP-1854/) | Draft |


### PR DESCRIPTION
This PR introduces CIP-0035 where the standard is defined of how websites or desktop applications can open and interact with the installed desktop wallet like Daedalus using a URL.

This is a replacement of the previously [draft PR](https://github.com/cardano-foundation/CIPs/pull/130) created on 16 Sep 2021 by @tomislavhoracek

