### PR TITLE
Add reference implementation to CIP5

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -135,7 +135,7 @@ The only prior work done towards that direction has been [jcli](https://input-ou
 
 ## Reference implementation
 
-N/A
+[cip5-js](https://www.npmjs.com/package/@dcspark/cip5-js)
 
 ## Copyright
 


### PR DESCRIPTION
You can find the repository for the reference implementation [here](https://github.com/dcSpark/cip5-js)

Note: this CIP unfortunately doesn't contain a machine-readable version of the tables so I instead created one in my repo [here](https://github.com/dcSpark/cip5-js/blob/master/cip5.json). Not sure if we want to add this table to the CIP repo instead.