### PR TITLE
[paradiso.app] reserve transaction metadatum labels

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -19,9 +19,17 @@
     "transaction_metadatum_label": 721,
     "description": "CIP-0025 - NFT Metadata Standard"
   },
-    {
+  {
     "transaction_metadatum_label": 777,
     "description": "CIP-0027 - Royalties Standard"
+  },
+  {
+    "transaction_metadatum_label": 1188,
+    "description": "paradiso.app marketplace metadata"
+  },
+  {
+    "transaction_metadatum_label": 1189,
+    "description": "paradiso.app services metadata"
   },
   {
     "transaction_metadatum_label": 1967,


### PR DESCRIPTION
Greetings Cardano Foundation team,

The team at [paradiso.app](https://paradiso.app) would like to reserve our transaction metadatum entries in the CIP-0010 registry.

We are using the entries below for storing our onchain metadata.

```
{
    "transaction_metadatum_label": 1188,
    "description": "paradiso.app marketplace metadata"
},
{
    "transaction_metadatum_label": 1189,
    "description": "paradiso.app services metadata"
}
```