### PR TITLE
CIP-0055 correction: constant overhead in babbageMinUTxOValue

### DIFF
--- a/CIP-0055/README.md
+++ b/CIP-0055/README.md
@@ -73,10 +73,11 @@ the current value of `coinsPerUTxOWord` will be converted to
 In the Babbage era, unspent transaction outputs will be required to contain _at least_
 
 ```
-|serialized_output| * coinsPerUTxOByte
+160 + |serialized_output| * coinsPerUTxOByte
 ```
 
-many lovelace.
+many lovelace. The constant overhead of 160 bytes accounts for the transaction input
+and the entry in the UTxO map data structure (20 words * 8 bytes).
 
 ## Rationale
 


### PR DESCRIPTION
CIP-55 was an information CIP regarding the Babbage era protocol parameters. In it, it was explained how the new parameter
`coinsPerUTxOByte` is used. The explanation contained a mistake, namely not accounting for the constant overhead.

Thank you @gitmachtl for pointing this out! https://github.com/cardano-foundation/CIPs/pull/265#issuecomment-1179338845