### PR TITLE
Register new CIP-10 metadatum label for Open Badges v2.0 compliant transaction metadata

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -32,6 +32,10 @@
     "description": "paradiso.app services metadata"
   },
   {
+    "transaction_metadatum_label": 1870,
+    "description": "Open Badges v2.0 compliant metadata"
+  },
+  {
     "transaction_metadatum_label": 1967,
     "description": "nut.link metadata oracles registry"
   },


### PR DESCRIPTION
We intend to register a new transaction metadatum label `1870` which identifies [Open Badges v2.0](https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html) compliant metadata.

Open Badges is an open standard originally developed by the Mozilla Foundation and now maintained by [IMS Global](https://www.imsglobal.org/activity/digital-badges) to represent verifiable achievements (e.g. educational certificates or certificates from instructional lectures).

_Open Badges are information-rich visual tokens of verifiable achievements earned by recipients and easily shared on the web and via social media. The Open Badges standard describes a method for packaging information about accomplishments, embedding it into portable image files as digital badges, and includes resources for web-based validation and verification. Open Badges describe who earned it, who issued it, the criteria required, and in many cases even the evidence and demonstrations of the relevant skills._

The standard has a [widespread adoption](https://en.wikipedia.org/wiki/Mozilla_Open_Badges). A first use case we intend to build is the issuance of achievement badges for the [UZH Summer School 2022](https://www.summerschools.uzh.ch/programs/deep-dive-into-blockchain/).

The intention is not to set the one-and-only metadata standard for those kind of certificates for Cardano but only to support this specific already well adopted standard and use cases built on top of that.