### PR TITLE
absolute paths for remaining cross-CIP relative links

### DIFF
--- a/CIP-0011/README.md
+++ b/CIP-0011/README.md
@@ -11,7 +11,7 @@ License: CC-BY-4.0
 
 ## Abstract
 
-Starting with the Shelley hardfork, Cardano makes use of both the *UTXO model* and the *account model*. To support both transaction models from the same master key, we allocate a new chain for [CIP1852](../CIP-1852)
+Starting with the Shelley hardfork, Cardano makes use of both the *UTXO model* and the *account model*. To support both transaction models from the same master key, we allocate a new chain for [CIP1852](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1852/README.md)
 
 ## Terminology
 
@@ -36,7 +36,7 @@ Generally it's best to only use a cryptographic key for a single purpose, and so
 
 ## Specification
 
-Recall that [CIP1852](../CIP-1852) specifies the following derivation path
+Recall that [CIP1852](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1852/README.md) specifies the following derivation path
 
 ```
 m / purpose' / coin_type' / account' / chain / address_index

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -140,7 +140,7 @@ This proposal deals only with the types of change listed in "Types of change", a
 This proposal recommends that some of the changes listed in "Types of change" (specified below) should:
 
 1. Be proposed in a CIP.
-2. Go through additional process in addition to the [usual CIP process](../CIP-0001/README.md).
+2. Go through additional process in addition to the [usual CIP process](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0001/README.md).
 
 The additional process mostly takes the form of additional information that should be present in the CIP before it moves to particular stages.
 As such, it is up to the CIP Editors to enforce this.


### PR DESCRIPTION
As identified in [#109](https://github.com/cardano-foundation/CIPs/issues/109#issuecomment-1193054082) the relative links between CIPs which work on GitHub are broken on `cips.cardano.org`. Pending some site remediation,  all CIPs referring to content of a different CIP must use absolute links.  The links changed here are the ones identified in https://github.com/cardano-foundation/CIPs/issues/109#issuecomment-1193400948.