### PR TITLE
updates to CIP meeting links and text since Discord migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The entire process is described in greater detail in [CIP1 - "CIP Process"](./CI
 
 ### Proposals Under Review
 
-Below are listed tentative CIPs still under discussion with the community. Discussions and progress will be reviewed by CIP editors in bi-weekly meetings held [on Discord](https://discord.com/channels/971785110770831360/973185848759701504) ([invite](https://discord.gg/qd6jE9Xj)), then transcribed and summarized [here](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings). Note that they are listed below for easing navigation and also, tentatively allocating numbers to avoid clashes later on.
+Below are listed tentative CIPs still under discussion with the community. Discussions and progress will be reviewed by CIP editors in bi-weekly meetings held [on Discord](https://discord.com/channels/971785110770831360/973185848759701504) ([invite](https://discord.gg/qd6jE9Xj)), then transcribed and summarized [here](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings). Note that they are listed below for easing navigation and also tentatively allocating numbers to avoid clashes later on.
 
 | **#** | **Title** | 
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The entire process is described in greater detail in [CIP1 - "CIP Process"](./CI
 
 ### Proposals Under Review
 
-Below are listed tentative CIPs still under discussion with the community. Discussions and progress will be reviewed by CIP editors in [bi-weekly meetings](https://www.crowdcast.io/cips-biweekly). Note that they are listed below for easing navigation and also, tentatively allocating numbers to avoid clashes later on.
+Below are listed tentative CIPs still under discussion with the community. Discussions and progress will be reviewed by CIP editors in bi-weekly meetings held [on Discord](https://discord.com/channels/971785110770831360/973185848759701504) ([invite](https://discord.gg/qd6jE9Xj)), then transcribed and summarized [here](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings). Note that they are listed below for easing navigation and also, tentatively allocating numbers to avoid clashes later on.
 
 | **#** | **Title** | 
 | --- | --- |
@@ -103,9 +103,9 @@ Below are listed tentative CIPs still under discussion with the community. Discu
 ![Diagram: Mary interacting with community and editors for a Cardano Proposal](https://raw.githubusercontent.com/cardano-foundation/CIPs/master/BiweeklyMeetings/sequence_diagram.png "sequence_diagram.png")
 
 Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.org/c/developers/cips/122), Cardano’s Official [Developer Telegram Group](https://t.me/CardanoDevelopersOfficial) or in `#developers` in Cardano Ambassadors Slack.
-CIP Editors meetings are [public](https://www.crowdcast.io/cips-biweekly), [recorded](https://www.crowdcast.io/cips-biweekly) and [summarized](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings): do join and participate for discussions/PRs of significances to you.
+CIP Editors meetings are public and recorded: do join and participate for discussions/PRs of significance to you.
 
-> 🛈 To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
+> To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
 
 ### Current Editors
 


### PR DESCRIPTION
Some things have gone out of date on the top-level `README` mostly due to the migration from Crowdcast to Discord:

- The link to the meeting forum itself has changed.
- Since this document was written, meetings are transcribed as well as summarised.
- We aren't making the recordings of the Discord meetings available yet (right?) so there's nothing to link to under "recorded".
- Some minor cleanup: grammar and the index character 🛈 before the blockquote: which sometimes renders as "info" (i-in-a-circle) but shows up as tofu on my own system so isn't universally valid.

Please let me know if we should still include the Crowdcast link because of the old meeting recordings.  I've not included it because there was talk in one of our last process meetings about dropping the Crowdcast subscription, which would drop that archive along with it (?).  If necessary I'll work that link back into the text as appropriate.