### PR TITLE
missing parenthesis in Babbage min utxo calc

### DIFF
--- a/CIP-0055/README.md
+++ b/CIP-0055/README.md
@@ -73,7 +73,7 @@ the current value of `coinsPerUTxOWord` will be converted to
 In the Babbage era, unspent transaction outputs will be required to contain _at least_
 
 ```
-160 + |serialized_output| * coinsPerUTxOByte
+(160 + |serialized_output|) * coinsPerUTxOByte
 ```
 
 many lovelace. The constant overhead of 160 bytes accounts for the transaction input


### PR DESCRIPTION
This fixes a mistake in CIP-55.

The minimum lovelace calculation for the Babbage era was missing needed parenthesis. Credit goes to @lehins for catching this!