### PR TITLE
CIP-0069? | Plutus Script Type Uniformization

### DIFF
--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -2,7 +2,7 @@
 CIP: 69
 Title: Script Signature Unification 
 Authors: Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>
-Status: Draft
+Status: Proposed
 Type: Standards Track
 Created: 2022-08-23
 License: CC-BY-4.0

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: 0069
+CIP: 69
 Title: Script Signature Unification 
 Authors: Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>
 Status: Draft

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -28,49 +28,21 @@ Use Case 2 (taken from Optim's Liquidity Bonds): Unique NFT is minted to give a 
 
 Use Case 3 (taken from Minswap's Dex V1): NFT is minted for the same reason as above. It allows a minting policy to later mint LP tokens with that unique id token name.
 
-We see a similar pattern repeating over and over again, as I bid you, the developer reading this to provide witness. By allowing the multi-purpose policies (spending and any other) we increase the security of Cardano by giving us more confidence and allowing to design protocols that have their design driven by cardano's features, not limited by cardano's language. 
+We see a similar pattern repeating over and over again as witnessed by dapp developers and auditors alike. By allowing the multi-purpose policies (spending and any other) we increase the security of Cardano by giving us more confidence and allowing to design protocols that have their architecture driven by Cardano's features, not limited by Cardano's language. 
 
 ## Specification
 
 ### Removing the datum argument
 
-All the sctipt purposes have a form of `Redeemer -> ScriptContext -> ()` except the `Spending` one.
-It has form of `Datum -> Redeemer -> ScriptContext -> ()`. This is enforced by the cardano node. 
+All the sctipt purposes have a form of `Redeemer -> ScriptContext -> exists a. a` except the `Spending` one.
+It has form of `Datum -> Redeemer -> ScriptContext -> exists a. a`. This is enforced by the Cardano node. 
 
-We make it conform to the general pattern by having it also have a 'signature' of `Redeemer -> ScriptContext -> ()`
-
-### (Optional) Providing the Datum in ScriptPurpose
-
-The datatype in question defined as
-
-```
-data ScriptPurpose
-  = Minting CurrencySymbol
-  | Spending TxOutRef
-  | Rewarding StakingCredential
-  | Certifying DCert
-```
-
-to be redefined to
-
-```
-data ScriptPurpose
-  = Minting CurrencySymbol
-  | Spending TxOutRef Datum
-  | Rewarding StakingCredential
-  | Certifying DCert
-```
-
-which will allow a script to easily match on its purpose and pick the datum out as it would do so normally.
-
-If this change is to not be added, the Datum can be picked out of `ScriptConext`. Adding unnecessary boilerplate and clock cycles. 
-
-Cardano node would naturally verify that the correct `Datum` is given, as it does currently. 
+We make it conform to the general pattern by having it also have a type of `Redeemer -> ScriptContext -> ()`
 
 ## Rationale
 
 Unifying of the script signature is a very elegant solution to the problem, streamlining the experience of developing on cardano.
-Given that accessing the datum is almost always made by a spending script, it makes sense to intdoduce that argument back to the `ScriptPurpose` that now plays a more important role.
+Given that accessing the datum is almost always made by a spending script, it makes sense to introduce that argument back to the `ScriptPurpose` that now plays a more important role.
 It begs the question if it should be added as an argument to all validators, to further emphasize that fact. 
 
 ## Backwards compatibility

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -1,30 +1,34 @@
 ---
 CIP: 69
-Title: Script Signature Unification 
-Authors: Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>
+Title: Script Signature Unification
+Category: Plutus
+Authors:
+  - Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>
+Implementors: N/A
 Status: Proposed
-Type: Standards Track
+Discussions:
+  - https://github.com/cardano-foundation/CIPs/pull/321
 Created: 2022-08-23
 License: CC-BY-4.0
 ---
 
-## Simple Summary / Abstract
+## Abstract
 
 This CIP unifies the arguments given to all types of Plutus scripts currently available (spending, certifying, rewarding, minting) by removing the argument of a datum.
 
-For a while now every builder, myself included have struggled with the mutual dependency issue (two validators that need to know each other's hash) when designing dapps and it is widely considered a substantial barrier to safe protocols and one that limits our design space considerably. 
+For a while now every builder, myself included have struggled with the mutual dependency issue (two validators that need to know each other's hash) when designing dapps and it is widely considered a substantial barrier to safe protocols and one that limits our design space considerably.
 
-The exact change would be to have every validator take as argument the redeemer and then the script context. Datums, only relevant to locking validators would be able to be provided by either looking them up in the ScriptContext or by extending the `Spending` constructor of `TxInfo` to carry `(TxOutRef, Datum)`. 
+The exact change would be to have every validator take as argument the redeemer and then the script context. Datums, only relevant to locking validators would be able to be provided by either looking them up in the ScriptContext or by extending the `Spending` constructor of `TxInfo` to carry `(TxOutRef, Datum)`.
 
-## Motivation / History
+## Motivation: why is this CIP necessary?
 
 As it stands the scripts being made on cardano often suffer this problem, and the tokens usually are made to be able to be minted at any time. This leads to further checks being made on the frontend and further fragilitiy of the systems we create. When a mutual dependency arises we are forced to choose which script gets to statically know what's the hash of the other, and which has to be provided 'during runtime'.
 
-Use Case 1: Minting validator checks datum given to spending validator. The spending validator requires the token be present as witness of the datum's correctness.
+- Use Case 1: Minting validator checks datum given to spending validator. The spending validator requires the token be present as witness of the datum's correctness.
 
-Use Case 2 (taken from Optim's Liquidity Bonds): Unique NFT is minted to give a unique identifier to a loan, that then gets reused by Bond Tokens. The spending validators require that NFT be present. 
+- Use Case 2 (taken from Optim's Liquidity Bonds): Unique NFT is minted to give a unique identifier to a loan, that then gets reused by Bond Tokens. The spending validators require that NFT be present.
 
-Use Case 3 (taken from Minswap's Dex V1): NFT is minted for the same reason as above. It allows a minting policy to later mint LP tokens with that unique id token name.
+- Use Case 3 (taken from Minswap's Dex V1): NFT is minted for the same reason as above. It allows a minting policy to later mint LP tokens with that unique id token name.
 
 We see a similar pattern repeating over and over again as witnessed by dapp developers and auditors alike. By allowing the multi-purpose policies (spending and any other) we increase the security of Cardano by giving us more confidence and allowing to design protocols that have their architecture driven by Cardano's features, not limited by Cardano's language.
 
@@ -34,10 +38,10 @@ This primarily manifests in the ability to use a single validator for both minti
 
 ### Removing the datum argument
 
-All the script purposes have a form of `Redeemer -> ScriptContext -> exists a. a` except the `Spending` one.
-It has the following form: `Datum -> Redeemer -> ScriptContext -> exists a. a`. This is enforced by the Cardano ledger. 
+All the script purposes have a form of `Redeemer -> ScriptContext -> a` except the `Spending` one.
+It has the following form: `Datum -> Redeemer -> ScriptContext -> a`. This is enforced by the Cardano ledger.
 
-We modify the general signature to be `ScriptArgs -> ScriptContext -> exists a. a`.
+We modify the general signature to be `ScriptArgs -> ScriptContext -> a`.
 
 ```hs
 data ScriptArgs =
@@ -45,11 +49,11 @@ data ScriptArgs =
   | RedeemerAndDatum Redeemer Datum
 ```
 
-## Rationale
+## Rationale: how does this CIP achieve its goals?
 
 Unifying of the script signature is a very elegant solution to the problem, streamlining the experience of developing on cardano.
 Given that accessing the datum is almost always made by a spending script, it makes sense to introduce that argument back to the `ScriptPurpose` that now plays a more important role.
-It begs the question if it should be added as an argument to all validators, to further emphasize that fact. 
+It begs the question if it should be added as an argument to all validators, to further emphasize that fact.
 
 ## Backwards compatibility
 
@@ -58,7 +62,13 @@ Node code must be modified.
 
 ## Path to Active
 
-The appropriate changes need to be made to the node code and a new language major version be introduced. 
+### Acceptance Criteria
+
+- [ ] The change has been implemented in the Plutus codebase, integrated in the ledger and released through a hard-fork.
+
+### Implementation Plan
+
+None.
 
 ## Copyright
 


### PR DESCRIPTION
The aim of the CIP is to allow more secure designs, streamline the developer experience and increase the design space of Cardano validators. 

All three purposes are achieved by removing the `Datum` out of a spending script's signature, to be the exact same as every other type of script. Datum is made available in `ScriptPurpose` instead. 

This change lets us use one script as both a spending and a minting validator, meaning that we resolve a well known protocol design problem of 'mutually dependent' validators, where a minting validator needs as parameter a spending validator, and the spending validator needs as parameter the minting one. 
With this CIP, they can be merged into a single script, enabling us to enable the two-way (or more) dependency where necessary. 

---

[see rendered Markdown](https://github.com/zygomeb/CIPs/blob/master/CIP-0069/README.md)