### PR TITLE
Update registry.json - Shareslake bridge metadata key

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -8,6 +8,10 @@
     "description": "milkomeda.com - the destination address in the sidechain"
   },
   {
+    "transaction_metadatum_label": 123,
+    "description": "shareslake.com - Bridge routing information"
+  },
+  {
     "transaction_metadatum_label": 309,
     "description": "Proof of Existence record"
   },


### PR DESCRIPTION
Signed-off-by: Miguel Angel Cabrera Minagorri <devgorri@gmail.com>

Update `registry.json` to add a metadata key to route Shareslake's bridge transactions.

We will introduce an object as the value of the key containing the destination/origin network and the destination address / original network Tx.  