### PR TITLE
Top-Level README | Fix CIP-0005 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The entire process is described in greater detail in [CIP1 - "CIP Process"](./CI
 | 2 | [Coin Selection Algorithms for Cardano](./CIP-0002/) | Active |
 | 3 | [Wallet key generation](./CIP-0003/) | Active |
 | 4 | [Wallet Checksums](./CIP-0004/) | Draft |
-| 5 | [Common Bech32 Prefixes](./CIP-0005/) | Draft |
+| 5 | [Common Bech32 Prefixes](./CIP-0005/) | Active |
 | 6 | [Stake Pool Extended Metadata](./CIP-0006/) | Draft |
 | 7 | [Curve Pledge Benefit](./CIP-0007/) | Proposed |
 | 8 | [Message Signing](./CIP-0008/) | Draft |


### PR DESCRIPTION
The CIP-0005 information doesn't reflect the correct status. It's supposed to be `Active` as mentioned in #145. I assume the revert back to `Draft` is done by accident in #164 as there isn't any discussion regarding the CIP-0005. The mistake occurred in the [Current CIPs Status Table](https://github.com/danivideda/CIPs/blob/67fb3222f93e6603bf761d5148eb6e3447302c4a/BiweeklyMeetings/2021-11-23.md#current-cips-in-the-cip-repository-and-their-status) section within the `BiweeklyMeetings/2021-11-23.md` file.