### PR TITLE
CIP-0036 | Not allow duplicated vote-key entries

### DIFF
--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -71,6 +71,8 @@ Recall: Cardano uses the UTXO model so to completely associate a wallet's balanc
 
 Given the above, we choose to associate staking credentials with voting keys. At the moment, the only supported staking credential is a staking key. Since most Cardano wallets only use base addresses for Shelley wallet types, in most cases this should perfectly match the user's wallet.
 
+No duplicated voting key entries are allowed in the voting key delegegation array, to remove weighting confusion and to support hw-wallet handling. HW-Wallets with there limited mem space, have to display the proper weight values for a voting key entry. Registration metadata containing duplicated voting key entries should be handled as invalid.
+
 The voting power that is associated with each delegated voting key is derived from the user's total voting power
 as follows.
 
@@ -79,6 +81,7 @@ as follows.
 3. The voting power associated with each voting key in the delegation array is calculated as the weighted fraction of the
    total voting power (rounded down);
 4. Any remaining voting power is assigned to the last voting key in the delegation array.
+
 
 This ensures that the voter's total voting power is never accidentally reduced through poor choices of weights,
 and that all voting powers are exact ADA.
@@ -113,6 +116,7 @@ considered valid if the following conditions hold:
 - The reward address is a Shelley address discriminated for the same network
   this transaction is submitted to.
 - The delegation array is not empty
+- The delegation array does not contain multiples of the same public voting key
 - The weights in the delegation array are not all zero
 
 

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -116,6 +116,7 @@ considered valid if the following conditions hold:
   this transaction is submitted to.
 - The delegation array is not empty
 - The delegation array does not contain multiples of the same public voting key
+- The stake public key is different from all public voting keys in the delegation array (derived from a different path)
 - The weights in the delegation array are not all zero
 
 

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -71,7 +71,7 @@ Recall: Cardano uses the UTXO model so to completely associate a wallet's balanc
 
 Given the above, we choose to associate staking credentials with voting keys. At the moment, the only supported staking credential is a staking key. Since most Cardano wallets only use base addresses for Shelley wallet types, in most cases this should perfectly match the user's wallet.
 
-No duplicated voting key entries are allowed in the voting key delegegation array, to remove weighting confusion and to support hw-wallet handling. HW-Wallets with there limited mem space, have to display the proper weight values for a voting key entry. Registration metadata containing duplicated voting key entries should be handled as invalid.
+No duplicated voting key entries are allowed in the voting key delegation array. Reason is to remove weighting confusion and to support hw-wallet handling. HW-Wallets - with there limited mem space - have to display the proper weight values for a voting key entry. Registration metadata containing duplicated voting key entries should be handled as invalid.
 
 The voting power that is associated with each delegated voting key is derived from the user's total voting power
 as follows.
@@ -81,7 +81,6 @@ as follows.
 3. The voting power associated with each voting key in the delegation array is calculated as the weighted fraction of the
    total voting power (rounded down);
 4. Any remaining voting power is assigned to the last voting key in the delegation array.
-
 
 This ensures that the voter's total voting power is never accidentally reduced through poor choices of weights,
 and that all voting powers are exact ADA.
@@ -174,6 +173,9 @@ Fund 8:
  - renamed the `voting_key` field to `delegations` and add support for splitting voting power across multiple vote keys.
  - added the `voting_purpose` field to limit the scope of the delegations.
  - rename the `staking_pub_key` field to `stake_credential` and `registration_signature` to `registration_witness` to allow for future credentials additions.
+
+Fund 10:
+ - disallow duplicated voting_key entries in the `delegations`
 
 ## Copyright
 

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -90,11 +90,11 @@ and that all voting powers are exact ADA.
 Voting registration example:
 ```
 61284: {
-  // delegations - CBOR byte array 
+  // delegations - [byte array, weight] 
   1: [["0xa6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663", 1], ["0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee", 3]],
-  // stake_pub - CBOR byte array
+  // stake_pub - byte array
   2: "0xad4b948699193634a39dd56f779a2951a24779ad52aa7916f6912b8ec4702cee",
-  // reward_address - CBOR byte array
+  // reward_address - byte array
   3: "0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee47b60edc7772855324c85033c638364214cbfc6627889f81c4",
   // nonce
   4: 5479467

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -53,7 +53,7 @@ A delegation assigns (a portion of) the ADA controlled by one or more UTxOs on m
 
 Each delegation therefore contains:
   - a voting key: simply an ED25519 public key. This is the spending credential in the sidechain that will receive voting power from this delegation. For direct voting it's necessary to have the corresponding private key to cast votes in the sidechain. How this key is created is up to the wallet.
-  - the weight that is associated with this key: this is a 4-byte unsigned integer (CBOR major type 0, The weight may range from 0 to 2^32-1) that represents the relative weight of this delegation over the total weight of all delegations in the same registration transaction.
+  - the weight that is associated with this key: this is a 4-byte unsigned integer (CBOR major type 0, The weight may range from 1 to 2^32-1) that represents the relative weight of this delegation over the total weight of all delegations in the same registration transaction.
 
 ### Voting key derivation path
 
@@ -117,7 +117,7 @@ considered valid if the following conditions hold:
 - The delegation array is not empty
 - The delegation array does not contain multiples of the same public voting key
 - The stake public key is different from all public voting keys in the delegation array (derived from a different path)
-- The weights in the delegation array are not all zero
+- The weights in the delegation array are all greater than zero
 
 
 Delegation to the voting key `0xa6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663` will have relative weight 1 and delegation to the voting key `0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee` relative weight 3 (for a total weight of 4).


### PR DESCRIPTION
Added lines to make it clear that duplicated voting key entries (delegating weighted voting power) are not allowed in the registration metadata format and should be handled as invalid if such entries are included. This keeps away confusion about how the weight for each voting key should be calculated and its also mandatory for hw-wallets showing the right amount of weight for each voting key entry. @janmazak 