### PR TITLE
CIP-0005 | Add governance vote key prefix

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -43,6 +43,8 @@ We define the following set of common prefixes with their corresponding semantic
 | `addr_shared_vk`   | CIP-1854's address verification key                | Ed25519 public key                 |
 | `addr_shared_xsk`  | CIP-1854's address extended signing key            | Ed25519-bip32 extended private key |
 | `addr_shared_xvk`  | CIP-1854's address extended verification key       | Ed25519 public key with chain code |
+| `gov_sk`           | Governance vote signing key                        | Ed25519 private key                |
+| `gov_vk`           | Governance vote verification key                   | Ed25519 public key                 |
 | `kes_sk`           | KES signing key                                    | KES signing key                    |
 | `kes_vk`           | KES verification key                               | KES verification key               |
 | `policy_sk`        | CIP-1855's policy private key                      | Ed25519 private key                |


### PR DESCRIPTION
- add 'gov_sk' as the prefix for a governacne_signing/secret_key
- add 'gov_vk' as the prefix for a governacne_verification/public_key

can be used f.e. with CIP-0036 to export vote(governance)-public-keys from wallets for delegation purpose in a format like: `gov_vk12a6cjyf98a4nrhe2slqsavy29jdcg5rk3jud6rfh3kfl0shzyrcqkwgdzk`