### PR TITLE
CIP-0036 | Changed terminology in schema to match README

### DIFF
--- a/CIP-0034/registry.json
+++ b/CIP-0034/registry.json
@@ -1,14 +1,20 @@
 {
+    "Pre-Production": {
+        "Name": "Pre-Production",
+        "NetworkId": 3,
+        "NetworkMagic": 1,
+        "GenesisHash": "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937"
+    },
+    "Preview": {
+        "Name": "Preview",
+        "NetworkId": 2,
+        "NetworkMagic": 2,
+        "GenesisHash": "72593f260b66f26bef4fc50b38a8f24d3d3633ad2e854eaf73039eb9402706f1"
+    },
     "Mainnet": {
         "Name": "Mainnet",
         "NetworkId": 1,
         "NetworkMagic": 764824073,
         "GenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-    },
-    "Testnet": {
-        "Name": "Testnet",
-        "NetworkId": 0,
-        "NetworkMagic": 1097911063,
-        "GenesisHash": "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471"
     }
 }

--- a/CIP-0036/schema.cddl
+++ b/CIP-0036/schema.cddl
@@ -6,10 +6,10 @@ registration_cbor = {
 $voting_pub_key /= bytes .size 32
 $reward_address /= bytes
 $nonce /= uint
-$proportion /= uint .size 4
+$weight /= uint .size 4
 $voting_purpose /= uint
 legacy_key_registration = $voting_pub_key
-delegation = ($voting_pub_key, $proportion)
+delegation = ($voting_pub_key, $weight)
 
 ; May support other stake credentials in the future.
 ; Such additional credentials should be tagged at the CDDL/CBOR level


### PR DESCRIPTION
Removed the notion of "proportion" from the schema replacing it with the term "weight" since "weight" is used within the specification. cc: @kevinhammond 