### PR TITLE
CIP-0036 | Changed terminology in schema to match README specification

### DIFF
--- a/CIP-0036/schema.cddl
+++ b/CIP-0036/schema.cddl
@@ -6,10 +6,10 @@ registration_cbor = {
 $voting_pub_key /= bytes .size 32
 $reward_address /= bytes
 $nonce /= uint
-$proportion /= uint .size 4
+$weight /= uint .size 4
 $voting_purpose /= uint
 legacy_key_registration = $voting_pub_key
-delegation = ($voting_pub_key, $proportion)
+delegation = ($voting_pub_key, $weight)
 
 ; May support other stake credentials in the future.
 ; Such additional credentials should be tagged at the CDDL/CBOR level


### PR DESCRIPTION
Removed the notion of "proportion" from the schema replacing it with the term "weight" since "weight" is used within the specification. cc: @kevinhammond