### PR TITLE
CIP-0068: Small change in 333 FT sub standard 

### DIFF
--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -171,6 +171,8 @@ This is a low-level representation of the metadata, following closely the struct
 
 ```
 ; Explanation here: https://developers.cardano.org/docs/native-tokens/token-registry/cardano-token-registry/
+; NOTE: logo is an exception and is not a PNG bytestring, but a URI, so that links and data uris with all image types are possible (see below)
+
 
 metadata = 
   {
@@ -178,8 +180,8 @@ metadata =
     description : bounded_bytes, ; UTF-8
     ? ticker: bounded_bytes, ; UTF-8
     ? url: bounded_bytes, ; UTF-8
-    ? logo: bounded_bytes, ; UTF-8
-    ? decimals: big_int
+    ? logo: bounded_bytes, ; UTF-8, URI (not a PNG bytestring like in the explanation. Valid formats: ("https://...", "ipfs://...", "data:...", etc.))
+    ? decimals: int
   }
   
 datum = #6.121([metadata, 1]) ; version 1

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -182,7 +182,7 @@ metadata =
     description : long_bytes, ; UTF-8
     ? ticker: bounded_bytes, ; UTF-8
     ? url: long_bytes, ; UTF-8
-    ? logo: uri
+    ? logo: uri,
     ? decimals: int
   }
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -171,8 +171,7 @@ This is a low-level representation of the metadata, following closely the struct
 
 ```
 ; Explanation here: https://developers.cardano.org/docs/native-tokens/token-registry/cardano-token-registry/
-; NOTE: logo is an exception and is not a PNG bytestring, but a URI, so that links and data uris with all image types are possible (see below)
-
+; NOTE: 'logo' is an exception and is not a PNG bytestring, but a URI, so that links and data uris with all image types are possible (see below)
 
 metadata = 
   {

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -101,21 +101,19 @@ Example:\
 This is a low-level representation of the metadata, following closely the structure of CIP-0025. All UTF-8 encoded keys and values need to be converted into their respective byte's representation when creating the datum on-chain.
 
 ```
-long_bytes = bounded_bytes / [ * bounded_bytes ]
-
 files_details = 
   {
     ? name : bounded_bytes, ; UTF-8
     mediaType : bounded_bytes, ; UTF-8
-    src : long_bytes ; UTF-8
+    src : bounded_bytes ; UTF-8
   }
 
 metadata = 
   {
     name : bounded_bytes, ; UTF-8
-    image : long_bytes, ; UTF-8
+    image : bounded_bytes, ; UTF-8
     ? mediaType : bounded_bytes, ; UTF-8
-    ? description : long_bytes, ; UTF-8
+    ? description : bounded_bytes, ; UTF-8
     ? files : [* files_details]
   }
   
@@ -174,14 +172,12 @@ This is a low-level representation of the metadata, following closely the struct
 ```
 ; Explanation here: https://developers.cardano.org/docs/native-tokens/token-registry/cardano-token-registry/
 
-long_bytes = bounded_bytes / [ * bounded_bytes ]
-
 metadata = 
   {
     name : bounded_bytes, ; UTF-8
-    description : long_bytes, ; UTF-8
+    description : bounded_bytes, ; UTF-8
     ? ticker: bounded_bytes, ; UTF-8
-    ? url: long_bytes, ; UTF-8
+    ? url: bounded_bytes, ; UTF-8
     ? logo: uri,
     ? decimals: int
   }
@@ -191,7 +187,7 @@ metadata =
 ; Do not encode plain file payloads as URI.
 ; 'logo' does not follow the explanation of the token-registry, it needs to be a valid URI and not a plain bytestring.
 ; Only use the following media types: `image/png`, `image/jpeg`, `image/svg+xml`
-uri = long_bytes 
+uri = bounded_bytes 
   
 datum = #6.121([metadata, 1]) ; version 1
 ```

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -101,19 +101,21 @@ Example:\
 This is a low-level representation of the metadata, following closely the structure of CIP-0025. All UTF-8 encoded keys and values need to be converted into their respective byte's representation when creating the datum on-chain.
 
 ```
+long_bytes = bounded_bytes / [ * bounded_bytes ]
+
 files_details = 
   {
     ? name : bounded_bytes, ; UTF-8
     mediaType : bounded_bytes, ; UTF-8
-    src : bounded_bytes ; UTF-8
+    src : long_bytes ; UTF-8
   }
 
 metadata = 
   {
     name : bounded_bytes, ; UTF-8
-    image : bounded_bytes, ; UTF-8
+    image : long_bytes, ; UTF-8
     ? mediaType : bounded_bytes, ; UTF-8
-    ? description : bounded_bytes, ; UTF-8
+    ? description : long_bytes, ; UTF-8
     ? files : [* files_details]
   }
   
@@ -171,17 +173,25 @@ This is a low-level representation of the metadata, following closely the struct
 
 ```
 ; Explanation here: https://developers.cardano.org/docs/native-tokens/token-registry/cardano-token-registry/
-; NOTE: 'logo' is an exception and is not a PNG bytestring, but a URI, so that links and data uris with all image types are possible (see below)
+
+long_bytes = bounded_bytes / [ * bounded_bytes ]
 
 metadata = 
   {
     name : bounded_bytes, ; UTF-8
-    description : bounded_bytes, ; UTF-8
+    description : long_bytes, ; UTF-8
     ? ticker: bounded_bytes, ; UTF-8
-    ? url: bounded_bytes, ; UTF-8
-    ? logo: bounded_bytes, ; UTF-8, URI (not a PNG bytestring like in the explanation. Valid formats: ("https://...", "ipfs://...", "data:...", etc.))
+    ? url: long_bytes, ; UTF-8
+    ? logo: uri
     ? decimals: int
   }
+
+; A URI as a UTF-8 encoded bytestring.
+; The URI scheme must be one of `https`, `ipfs` or `data`
+; Do not encode plain file payloads as URI.
+; 'logo' does not follow the explanation of the token-registry, it needs to be a valid URI and not a plain bytestring.
+; Only use the following media types: `image/png`, `image/jpeg`, `image/svg+xml`
+uri = long_bytes 
   
 datum = #6.121([metadata, 1]) ; version 1
 ```


### PR DESCRIPTION
`decimals` in metadata don't need to be `big_int`, but can be `int` also. @KtorZ pointed that out before for the`version` field, but I have overseen it for `decimals`.
I also realized it makes little sense to follow the same constraints of the cardano-token-registry for `logo`, which only allows you to use PNGs as bytestrings. Here the image is in the datum and potentially in an inline datum. Having only the option to store the image as bytestring on-chain wouldn't be ideal. A `URI` is much better suited here, which gives more flexibility and allows you to use also other image types e.g. `.jpg`
@rphair 