### PR TITLE
CIP-???? | No Datum Is Unit

### DIFF
--- a/CIP-NoDatumIsDatum/README.md
+++ b/CIP-NoDatumIsDatum/README.md
@@ -1,0 +1,17 @@
+---
+CIP: ????
+Title: No Datum Is Unit
+Author: Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>
+Status: Draft
+Type: Standards Track
+Created: 2022-08-23
+License: CC-BY-4.0
+---
+
+## Simple Summary / Abstract
+
+The CIP changes interpretation of how the absence of a datum hash or inline datum is interpreted. The entire scope of what is does is make it so that such a UTXO is equivalent to a one that has `()` as the datum for the purpose of script evaluation.
+
+## Motivation / History
+
+Currently if a transaction is sent to a script without a datum it means that even if the script is `alwaysTrue` then that utxo is unable to be consumed. This enables the use case of spending scrips without datums

--- a/CIP-NoDatumIsDatum/README.md
+++ b/CIP-NoDatumIsDatum/README.md
@@ -14,4 +14,20 @@ The CIP changes interpretation of how the absence of a datum hash or inline datu
 
 ## Motivation / History
 
-Currently if a transaction is sent to a script without a datum it means that even if the script is `alwaysTrue` then that utxo is unable to be consumed. This enables the use case of spending scrips without datums
+Currently if a transaction is sent to a script without a datum it means that even if the script is `alwaysTrue` then that utxo is unable to be consumed. This enables the use case of spending scrips without datums and lets us design scripts that are more fault-tolerant.
+
+## Specification
+
+When trying to consume a utxo without a datum hash or an inline datum, the node would substitute a unit datum as an argument instead.
+
+## Rationale
+
+The scripts always failing on a missing datum seems like an oversight, especially for spending scripts that make no use of datums which are forced to include the unit datum anyway and increase the likelihood of an erroneous transaction be made. 
+
+## Backwards compatibility
+
+This change can be made to the node without creating a new language version as every utxo locked in this way was forever lost anyway.
+
+## Copyright
+
+This CIP is licensed under Apache-2.0


### PR DESCRIPTION
This CIP is a simple quality of life change. It defines a default interpretation of a utxo with no datum (defaulting to `()`) for the purposes of scripts that were either erroneously created or make no use of datums.

---

([draft proposal in branch](https://github.com/zygomeb/CIPs/tree/empty/CIP-NoDatumIsDatum))