### PR TITLE
[paradiso.app] remove transaction metadatum labels

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -32,14 +32,6 @@
     "description": "finitum.io token bridge transactions metadata"
   },
   {
-    "transaction_metadatum_label": 1188,
-    "description": "paradiso.app marketplace metadata"
-  },
-  {
-    "transaction_metadatum_label": 1189,
-    "description": "paradiso.app services metadata"
-  },
-  {
     "transaction_metadatum_label": 1564,
     "description": "Marlowe - a DSL for writing and executing financial contracts"
   },


### PR DESCRIPTION
Requesting removal of paradiso.app metadatum labels.

We are shutting down this month, and would like to free these labels up.

Original PR which reserved these labels is listed below for reference:
https://github.com/cardano-foundation/CIPs/pull/272