### PR TITLE
CIP-0052 | Add public keys to auditor table

### DIFF
--- a/CIP-0052/README.md
+++ b/CIP-0052/README.md
@@ -216,13 +216,13 @@ DApps are used by *DApp users*, and built by *DApp developers*. Audit is perform
 
 ### 3. Cardano auditors
 
-| Audit company   | URL                                     | Contact email      |
-| -----------     | -----------                             | -----------        |
-| FYEO Inc.       | https://gofyeo.com/blockchain-security  | sales@gofyeo.com  |
-| Hachi           | https://hachi.one                       | team@hachi.one        |
-| MLabs           | https://mlabs.city                      | info@mlabs.city      |
-| Runtime Verification           | https://www.runtimeverification.com | contact@runtimeverification.com  |
-| Tweag                | https://www.tweag.io                  | sales@tweag.io                  |
+| Audit company   | URL                                     | Contact email      | Public key      |
+| -----------     | -----------                             | -----------        | -----------        |
+| FYEO Inc.       | https://gofyeo.com/blockchain-security  | sales@gofyeo.com  | |
+| Hachi           | https://hachi.one                       | team@hachi.one        | |
+| MLabs           | https://mlabs.city                      | info@mlabs.city      | |
+| Runtime Verification           | https://www.runtimeverification.com | contact@runtimeverification.com  | |
+| Tweag                | https://www.tweag.io                  | sales@tweag.io                  | |
 
 ### 4. A sample audit report
 

--- a/CIP-0052/README.md
+++ b/CIP-0052/README.md
@@ -220,7 +220,7 @@ DApps are used by *DApp users*, and built by *DApp developers*. Audit is perform
 | -----------     | -----------                             | -----------        | -----------        |
 | FYEO Inc.       | https://gofyeo.com/blockchain-security  | sales@gofyeo.com  | |
 | Hachi           | https://hachi.one                       | team@hachi.one        | |
-| MLabs           | https://mlabs.city                      | info@mlabs.city      | |
+| MLabs           | https://mlabs.city                      | info@mlabs.city      | 64BC640B5454215D12165EEAEEFF303D2643ABA2 (PGP, ed25519) |
 | Runtime Verification           | https://www.runtimeverification.com | contact@runtimeverification.com  | |
 | Tweag                | https://www.tweag.io                  | sales@tweag.io                  | |
 


### PR DESCRIPTION
Added field for public key information for auditors. This to be used to verify signed audit certification metadata.