### PR TITLE
CIP-0034 | Include legacy testnet

### DIFF
--- a/CIP-0034/registry.json
+++ b/CIP-0034/registry.json
@@ -1,13 +1,13 @@
 {
     "PreProduction": {
         "Name": "Pre-Production",
-        "NetworkId": 3,
+        "NetworkId": 0,
         "NetworkMagic": 1,
         "GenesisHash": "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937"
     },
     "Preview": {
         "Name": "Preview",
-        "NetworkId": 2,
+        "NetworkId": 0,
         "NetworkMagic": 2,
         "GenesisHash": "72593f260b66f26bef4fc50b38a8f24d3d3633ad2e854eaf73039eb9402706f1"
     },

--- a/CIP-0034/registry.json
+++ b/CIP-0034/registry.json
@@ -18,7 +18,7 @@
         "GenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
     },
     "LegacyTestnet": {
-        "Name": "LegacyTestnet",
+        "Name": "Legacy Testnet",
         "NetworkId": 0,
         "NetworkMagic": 1097911063,
         "GenesisHash": "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471"

--- a/CIP-0034/registry.json
+++ b/CIP-0034/registry.json
@@ -16,5 +16,11 @@
         "NetworkId": 1,
         "NetworkMagic": 764824073,
         "GenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+    },
+    "LegacyTestnet": {
+        "Name": "LegacyTestnet",
+        "NetworkId": 0,
+        "NetworkMagic": 1097911063,
+        "GenesisHash": "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471"
     }
 }


### PR DESCRIPTION
Some applications may still want to refer to the legacy testnet even though it's not running anymore for things like error messages or migrating old configs, but this was made difficult by https://github.com/cardano-foundation/CIPs/pull/332 removing the legacy testnet from the registry.

I propose we keep it there, and just rename it to "legacy testnet"

----

Additionally, I noticed the networkIDs specified for the new testnets were incorrect. You can see in the Cardano codebase that [creating an address](https://github.com/input-output-hk/cardano-node/blob/f4dc7c4a8f21f4912903ad71a7ad485225141e20/cardano-api/src/Cardano/Api/Address.hs#L301) calls [toShelleyNetwork](https://github.com/input-output-hk/cardano-node/blob/853a5607bf8ee3d7e0d0859f910081a8fe0d0a9f/cardano-api/src/Cardano/Api/NetworkId.hs#L75) which sets "Testnet" to 0 in [cardano-ledger](https://github.com/input-output-hk/cardano-ledger/blob/bb50c2b748393f041cd3653383a5c1fa6ef62b97/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs#L613..L619). If you look at the genesis configs for [preprod](https://book.world.dev.cardano.org/environments/preprod/shelley-genesis.json) and [preview](https://book.world.dev.cardano.org/environments/preview/shelley-genesis.json), they use "Testnet" as the network ID

You can confirm this by looking at explorers like [cexplorer](https://preprod.cexplorer.io/address/addr_test1vqn77x6z6mld25h99mznyxxz9lvvpajq0hzw5hwmtdvdragrtwqxm) which properly show the network ID used in testnets as `0`