### PR TITLE
CIP-0005, CIP-0036 | Added clarity to voting key definitions

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -45,6 +45,8 @@ We define the following set of common prefixes with their corresponding semantic
 | `addr_shared_xvk`  | CIP-1854's address extended verification key       | Ed25519 public key with chain code |
 | `gov_sk`           | Governance vote signing key                        | Ed25519 private key                |
 | `gov_vk`           | Governance vote verification key                   | Ed25519 public key                 |
+| `vote_sk`          | CIP-36's vote signing key                          | Ed25519 private key                |
+| `vote_vk`          | CIP-36's vote verification key                     | Ed25519 public key                 |
 | `kes_sk`           | KES signing key                                    | KES signing key                    |
 | `kes_vk`           | KES verification key                               | KES verification key               |
 | `policy_sk`        | CIP-1855's policy private key                      | Ed25519 private key                |

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -45,8 +45,8 @@ We define the following set of common prefixes with their corresponding semantic
 | `addr_shared_xvk`  | CIP-1854's address extended verification key       | Ed25519 public key with chain code |
 | `gov_sk`           | Governance vote signing key                        | Ed25519 private key                |
 | `gov_vk`           | Governance vote verification key                   | Ed25519 public key                 |
-| `vote_sk`          | CIP-36's vote signing key                          | Ed25519 private key                |
-| `vote_vk`          | CIP-36's vote verification key                     | Ed25519 public key                 |
+| `cvote_sk`         | CIP-36's vote signing key                          | Ed25519 private key                |
+| `cvote_vk`         | CIP-36's vote verification key                     | Ed25519 public key                 |
 | `kes_sk`           | KES signing key                                    | KES signing key                    |
 | `kes_vk`           | KES verification key                               | KES verification key               |
 | `policy_sk`        | CIP-1855's policy private key                      | Ed25519 private key                |

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -55,11 +55,27 @@ Each delegation therefore contains:
   - a voting key: simply an ED25519 public key. This is the spending credential in the sidechain that will receive voting power from this delegation. For direct voting it's necessary to have the corresponding private key to cast votes in the sidechain. How this key is created is up to the wallet.
   - the weight that is associated with this key: this is a 4-byte unsigned integer (CBOR major type 0, The weight may range from 0 to 2^32-1) that represents the relative weight of this delegation over the total weight of all delegations in the same registration transaction.
 
-### Voting key derivation path
+### Voting key 
+
+The terms voting keys and vote keys should be used interchangeably to indicate the keys described in this specification. The term governance should not be associated with these keys.
+
+#### Derivation path
 
 To avoid linking voting keys directly with Cardano spending keys, the voting key derivation path must start with a specific segment:
 
 `m / 1694' / 1815' / account' / chain / address_index`
+
+We recommend that implementors only use `address_index`=0 to avoid the need for voting key discovery.
+
+#### Tooling
+
+Supporting tooling should clearly define and differentiate this as a unique key type. Using the `vote_sk` and `vote_vk` Bech32 prefixes when encoding, as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005).
+
+Examples of acceptable `keyType` naming for supporting tools:
+- `VotingSigningKey_ed25519`
+- `VotingVerificationKey_ed25519`
+- `VoteSigningKey_ed25519`
+- `VoteVerificationKey_ed25519`
 
 ### Associating voting power with a voting key
 

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -57,9 +57,9 @@ Each delegation therefore contains:
 
 ### Voting key 
 
-The terms voting keys and vote keys should be used interchangeably to indicate the keys described in this specification. But it should be made clear that implementations should favour the term "vote" and that the association of both terms aims to reduce the possibility of confusion.
+The terms "(CIP-36) voting keys" and "(CIP-36) vote keys" should be used interchangeably to indicate the keys described in this specification. But it should be made clear that implementations should favour the term "(CIP-36) vote" and that the association of both terms aims to reduce the possibility of confusion.
 
-The term governance should not be associated with these keys.
+The term governance should not be associated with these keys nor should these keys be associated with other vote or voting keys used in the ecosystem. When discussing these keys in a wider context they should be specified by such terminology as "CIP-36 vote keys" or "CIP-36 style vote keys".
 
 #### Derivation path
 
@@ -71,11 +71,24 @@ We recommend that implementors only use `address_index`=0 to avoid the need for 
 
 #### Tooling
 
-Supporting tooling should clearly define and differentiate this as a unique key type, describing such keys as "vote" keys. Using the `vote_sk` and `vote_vk` Bech32 prefixes when encoding, as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005).
+Supporting tooling should clearly define and differentiate this as a unique key type, describing such keys as "CIP-36 vote keys". When utilizing Bech32 encoding the appropriate `cvote_sk` and `cvote_vk` prefixes should be used as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)
 
-Examples of acceptable `keyType` naming for supporting tools:
-- `VoteSigningKey_ed25519`
-- `VoteVerificationKey_ed25519`
+Examples of acceptable `keyType`s for supporting tools:
+
+| `keyType` | Description |
+| --------- | ----------- |
+| `CIP36VoteSigningKey_ed25519` | Catalyst Vote Signing Key |
+| `CIP36VoteExtendedSigningKey_ed25519` | Catalyst Vote Signing Key |
+| `CIP36VoteVerificationKey_ed25519` | Catalyst Vote Verification Key |
+| `CIP36VoteExtendedVerificationKey_ed25519` | Catalyst Vote Verification Key |
+
+For hardware implementations:
+| `keyType` | Description |
+| --------- | ----------- |
+| `CIP36VoteVerificationKey_ed25519` | Hardware Catalyst Vote Verification Key |
+| `CIP36VoteHWSigningFile_ed25519` | Hardware Catalyst Vote Signing File |
+
+The intention with this design is that if projects beyond Catalyst implement this specification they are able to add to themselves `keyType` **Description**s.
 
 ### Associating voting power with a voting key
 

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -57,7 +57,9 @@ Each delegation therefore contains:
 
 ### Voting key 
 
-The terms voting keys and vote keys should be used interchangeably to indicate the keys described in this specification. The term governance should not be associated with these keys.
+The terms voting keys and vote keys should be used interchangeably to indicate the keys described in this specification. But it should be made clear that implementations should favour the term "vote" and that the association of both terms aims to reduce the possibility of confusion.
+
+The term governance should not be associated with these keys.
 
 #### Derivation path
 
@@ -69,11 +71,9 @@ We recommend that implementors only use `address_index`=0 to avoid the need for 
 
 #### Tooling
 
-Supporting tooling should clearly define and differentiate this as a unique key type. Using the `vote_sk` and `vote_vk` Bech32 prefixes when encoding, as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005).
+Supporting tooling should clearly define and differentiate this as a unique key type, describing such keys as "vote" keys. Using the `vote_sk` and `vote_vk` Bech32 prefixes when encoding, as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005).
 
 Examples of acceptable `keyType` naming for supporting tools:
-- `VotingSigningKey_ed25519`
-- `VotingVerificationKey_ed25519`
 - `VoteSigningKey_ed25519`
 - `VoteVerificationKey_ed25519`
 


### PR DESCRIPTION
## Motivation
- Concerns were raised around the definition of CIP-36's voting keys and how these should be represented in supporting tooling (good spot from @janmazak and @gitmachtl). 
- Avoid confusion with current and future protocol governance.

## Proposed Changes
CIP-05
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): Added `cvote_sk` and `cvote_vk` prefixes to be used when Bech32 encoding CIP-36's voting keys. As per [gitmachtl's suggestion](https://github.com/cardano-foundation/CIPs/pull/427#issuecomment-1383960821).

CIP-36 
- Added clarity for voting / vote key terminology. Linking to CIP-05 prefixes.
- Gave examples of potential naming supporting tooling could use.
- [4f6b879](https://github.com/cardano-foundation/CIPs/pull/427/commits/4f6b8794e51ce1f04dc808199b4223fcd7bc59ef): Added preference for implementations to use term "vote".
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): Added more example keyTypes with descriptions, as per [gitmachtl's suggestion](https://github.com/cardano-foundation/CIPs/pull/427#issuecomment-1383960821).
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): Added explanation for how other projects can add themselves to current keyType descriptions, as per [gitmachtl's suggestion](https://github.com/cardano-foundation/CIPs/pull/427#issuecomment-1383960821).

## Rationale
With these changes we are trying to avoid confusion of CIP-36's vote keys with current and future protocol governance keys and processes.

CIP-05
- The previously added `gov_sk` and `gov_vk` which were intended to relate to such keys, are likely to cause confusion, so I have added new prefixes.
- By leaving `gov_sk` and `gov_vk` - we intend to reserves these prefixes for potential use in the future protocol governance.
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): By leaving `vote_sk` and `vote_vk` - we intend to reserves these prefixes for potential use in the future protocol governance.

CIP-36
- By associating both the terms vote and voting, we attempt to avoid future confusion by not allowing other standards to utilize one term.
-  Adding explicit `keyType`'s was the level of clarity that was requested, I believe.
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): By encouraging the use of terms such as "CIP-36 vote keys" we leave the base "vote key" for use by future standards.
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19):  Adding a fuller list of `keyType` with descriptions better satisfied the concerns raised in comments on this PR.
- [825d54d](https://github.com/cardano-foundation/CIPs/pull/427/commits/825d54da6487fa84eb398604df335928881f4d19): By allowing future projects to update `keyType` descriptions we cater for future use of these CIP-36 vote keys. This was suggested by gitmachtl [here](https://github.com/cardano-foundation/CIPs/pull/427#issuecomment-1383960821).

**Note**: Submitted as one PR so the related changes are kept together, but if its preferable to have 2 PR's please advise.