### PR TITLE
Fix website build

### DIFF
--- a/CIP-0049/README.md
+++ b/CIP-0049/README.md
@@ -1,25 +1,15 @@
 ---
-CIP: 49 
-Title: ECDSA and Schnorr signatures in Plutus Core  
-Authors: Koz Ross (koz@mlabs.city), 
-         Michael Peyton-Jones (michael.peyton-jones@iohk.io), 
-         Iñigo Querejeta Azurmendi (querejeta.azurmendi@iohk.io)
+CIP: 49
+Title: ECDSA and Schnorr signatures in Plutus Core
+Authors: Koz Ross (koz@mlabs.city), Michael Peyton-Jones (michael.peyton-jones@iohk.io), Iñigo Querejeta Azurmendi (querejeta.azurmendi@iohk.io)
 Discussions-To: koz@mlabs.city
-Comments-Summary: 
-Comments-URI:  
 Status: Proposed
 Type: Standards Track
-Created: 2022-04-27  
-* License: 
-* License-Code:
-* Post-History:
-* Requires:
-* Replaces:
-* Superseded-By:
+Created: 2022-04-27
 ---
 ## Simple Summary
 
-Support ECDSA and Schnorr signatures over the SECP256k1 curve in Plutus Core; 
+Support ECDSA and Schnorr signatures over the SECP256k1 curve in Plutus Core;
 specifically, allow validation of such signatures as builtins.
 
 ## Abstract

--- a/CIP-0074/README.md
+++ b/CIP-0074/README.md
@@ -1,7 +1,7 @@
 ---
 CIP: 74
 Title: Set minPoolCost to 0
-Author: Robin of Loxley <adarobinhood@tutanota.com>
+Authors: Robin of Loxley <adarobinhood@tutanota.com>
 Comments-URI: https://forum.cardano.org/t/cip-69-set-minpoolcost-to-0/109309
 Status: Proposed
 Type: Standards

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -103,7 +103,7 @@ function renderHTML(uriPath, template, data) {
   fs.writeFileSync(path.join(publicPath, uriPath, 'index.html'), hbTemplate(data), { encoding: 'utf8' })
 }
 
-const types = { All: [] }
+const categories = { All: [] }
 
 function slugify(string) {
   return string.toLowerCase().replace(/\s/g, '-')
@@ -121,9 +121,10 @@ function build() {
       if (asset === 'README.md') {
         const cip = loadFrontmatter(assetPath)
         cip.tableOfContents = getTableOfContents(cip.content.split('\n'))
-        types[cip.data.Type] = types[cip.data.Type] || []
-        types[cip.data.Type].push(cip)
-        types.All.push(cip)
+        const category = cip.data.Category || "Unclassified";
+        categories[category] = categories[category] || []
+        categories[category].push(cip)
+        categories.All.push(cip)
       } else {
         const name = item.toLowerCase().replace(/cip-0*([1-9][0-9]*)/g, 'cip$1')
         const title = `${name.replace(/cip/g, 'CIP ')} - Annexe`;
@@ -147,20 +148,23 @@ function build() {
 
   const headerData = []
 
-  Object.keys(types).forEach(type => {
-    headerData.push({ label: type, path: `/${slugify(type)}/` })
+  Object.keys(categories).sort((a, b) => {
+    if ([a,b].includes("All")) { return a === "All" ? -1 : 1 }
+    if ([a,b].includes("Unclassified")) { return a === "Unclassified" ? 1 : -1 }
+    return a > b ? 1 : -1;
+  }).forEach(category => {
+    headerData.push({ label: category, path: `/${slugify(category)}/` })
   })
 
-  Object.keys(types).forEach(type => {
+  Object.keys(categories).forEach(category => {
 
-    renderHTML(`/${slugify(type)}/`, 'cips', {
+    renderHTML(`/${slugify(category)}/`, 'cips', {
       headerData,
-      cips: types[type],
-      type,
-      title: type
+      cips: categories[category],
+      category
     })
 
-    types[type].forEach(cip => {
+    categories[category].forEach(cip => {
       renderHTML(`/cips/cip${cip.data.CIP}/`, 'cip', {
         headerData,
         cip,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,12 +14,16 @@ handlebars.registerHelper('dateFormat', (d, f) => {
   return moment(d).format(f);
 });
 
-handlebars.registerHelper('getAuthors', function (Authors) {
+handlebars.registerHelper('getAuthors', function (data) {
+  if (data.Authors == undefined) {
+    throw new Error(`No authors: ${JSON.stringify(data)}`);
+  }
 
-  // Temporary fallback for CI to not fail
-  if(!Authors) return '';
+  const authors = Array.isArray(data.Authors)
+    ? data.Authors
+    : data.Authors.split(',');
 
-  return Authors.split(',').map(author => {
+  return authors.map(author => {
     const [_, name, link] = author.trim().match(/^([^<]+)<?([^>]+)?>?$/) || []
     let type = 'url'
     if (link === undefined) {

--- a/templates/cips.hbs
+++ b/templates/cips.hbs
@@ -14,7 +14,7 @@
         <td>{{{cip.data.Title}}}</td>
         <td>{{dateFormat cip.data.Created "DD MMMM YYYY"}}</td>
         <td>
-          {{{getAuthors cip.data.Authors}}}
+          {{{getAuthors cip.data}}}
         </td>
         <td>{{cip.data.Status}}</td>
       </tr>


### PR DESCRIPTION
Fixes #436 

- :round_pushpin: **Fix editors parsing + provide better debugging on malformed input data.**
  
- :round_pushpin: **Display CIPs by category, if it exists.**
    This also sorts categories such that 'All' is always first and 'Unclassified' is always last.
