### PR TITLE
CIP-0030 | Upgrade to latest format & propose version / extension scheme

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -1,72 +1,93 @@
 ---
 CIP: 30
 Title: Cardano dApp-Wallet Web Bridge
-Authors: rooooooooob
-Comments-URI: https://github.com/cardano-foundation/CIPs/pull/88
-Status: Draft
-Type: Standards
+Status: Active
+Category: Wallets
+Authors:
+  - rooooooooob
+Implementors:
+  - Begin <https://begin.is/>
+  - Eternl <https://eternl.io/>
+  - Flint <https://flint-wallet.com/>
+  - GeroWallet <https://www.gerowallet.io/>
+  - Lace <https://www.lace.io/>
+  - Nami <https://namiwallet.io/>
+  - NuFi <https://nu.fi/>
+  - RayWallet <https://raywallet.io/>
+  - Yoroi <https://yoroi-wallet.com/>
+Discussions:
+  - https://github.com/cardano-foundation/CIPs/pull/88
+  - https://github.com/cardano-foundation/CIPs/pull/148
+  - https://github.com/cardano-foundation/CIPs/pull/151
+  - https://github.com/cardano-foundation/CIPs/pull/183
+  - https://github.com/cardano-foundation/CIPs/pull/208
+  - https://github.com/cardano-foundation/CIPs/pull/323
+  - https://github.com/cardano-foundation/CIPs/issues/169
+  - https://github.com/cardano-foundation/CIPs/issues/178
+  - https://github.com/cardano-foundation/CIPs/issues/204
+  - https://github.com/cardano-foundation/CIPs/issues/253
+  - https://github.com/cardano-foundation/CIPs/issues/386
+  - https://github.com/cardano-foundation/CIPs/issues/404
+  - https://github.com/cardano-foundation/CIPs/issues/419
+  - https://github.com/cardano-foundation/CIPs/pull/446
 Created: 2021-04-29
 License: CC-BY-4.0
 ---
 
-# Abstract
+## Abstract
 
 This documents describes a webpage-based communication bridge allowing webpages (i.e. dApps) to interface with Cardano wallets. This is done via injected javascript code into webpages. This specification defines the manner that such code is to be accessed by the webpage/dApp, as well as defining the API for dApps to communicate with the user's wallet. This document currently concerns the Shelley-Mary era but will have a second version once Plutus is supported. This specification is intended to cover similar use cases as web3 for Ethereum or [EIP-0012](https://github.com/ergoplatform/eips/pull/23) for Ergo. The design of this spec was based on the latter.
 
-
-# Motivation
+## Motivation: why is this CIP necessary?
 
 In order to facilitate future dApp development, we will need a way for dApps to communicate with the user's wallet. While Cardano does not yet support smart contracts, there are still various use cases for this, such as NFT management. This will also lay the groundwork for an updated version of the spec once the Alonzo hardfork is released which can extend it to allow for Plutus support.
 
+## Specification
 
+### Data Types
 
-# Specification
+#### Address
 
-## Version
+A string representing an address in either bech32 format, or hex-encoded bytes. All return types containing `Address` must return the hex-encoded bytes format, but must accept either format for inputs.
 
-The API specified in this document will count as version 0.1.0 for version-checking purposes below.
-
-## Data Types
-
-### Address
-
-A string representing an address in either bech32 format, or hex-encoded bytes. All return types containing `Address` must return the bech32 format, but must accept either format for inputs.
-
-### Bytes
+#### Bytes
 
 A hex-encoded string of the corresponding bytes.
 
-### cbor\<T>
+#### cbor\<T>
 
 A hex-encoded string representing [CBOR](https://tools.ietf.org/html/rfc7049) corresponding to `T` defined via [CDDL](https://tools.ietf.org/html/rfc8610) either inside of the [Shelley Multi-asset binary spec](https://github.com/input-output-hk/cardano-ledger-specs/blob/0738804155245062f05e2f355fadd1d16f04cd56/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl) or, if not present there, from the [CIP-0008 signing spec](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0008/CIP-0008.md).
 This representation was chosen when possible as it is consistent across the Cardano ecosystem and widely used by other tools, such as [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib), which has support to encode every type in the binary spec as CBOR bytes.
 
-### DataSignature
+#### DataSignature
 
 ```
 type DataSignature = {|
-  signature:cbor\<COSE_Sign1>,
+  signature: cbor\<COSE_Sign1>,
   key: cbor\<COSE_Key>,
 |};
 ```
 
-### TransactionUnspentOutput
+#### TransactionUnspentOutput
 
 If we have CBOR specified by the following CDDL referencing the Shelley-MA CDDL:
+
 ```cddl
 transaction_unspent_output = [
   input: transaction_input,
   output: transaction_output,
 ]
 ```
+
 then we define
+
 ```
 type TransactionUnspentOutput = cbor<transaction_unspent_output>
 ```
 
 This allows us to use the output for constructing new transactions using it as an output as the `transaction_output` in the Shelley Multi-asset CDDL does not contain enough information on its own to spend it.
 
-### Paginate
+#### Paginate
 
 ```
 type Paginate = {|
@@ -76,10 +97,17 @@ type Paginate = {|
 ```
 Used to specify optional pagination for some API calls. Limits results to {limit} each page, and uses a 0-indexing {page} to refer to which of those pages of {limit} items each. dApps should be aware that if a wallet is modified between paginated calls that this will change the pagination, e.g. some results skipped or showing up multiple times but otherwise the wallet must respect the pagination order.
 
+#### Extension
 
-## Error Types
+An extension is an object with a single field `"cip"` that describe a CIP number extending the API (as a plain integer, without padding). For example:
 
-### APIError
+```
+{ "cip": 30 }
+```
+
+### Error Types
+
+#### APIError
 
 ```
 APIErrorCode {
@@ -99,7 +127,7 @@ APIError {
 * Refused - The request was refused due to lack of access - e.g. wallet disconnects.
 * AccountChange - The account has changed. The dApp should call `wallet.enable()` to reestablish connection to the new account. The wallet should not ask for confirmation as the user was the one who initiated the account change in the first place.
 
-### DataSignError
+#### DataSignError
 
 ```
 DataSignErrorCode {
@@ -117,7 +145,7 @@ type DataSignError = {
 * AddressNotPK - Address was not a P2PK address and thus had no SK associated with it.
 * UserDeclined - User declined to sign the data
 
-### PaginateError
+#### PaginateError
 
 ```
 type PaginateError = {|
@@ -126,7 +154,7 @@ type PaginateError = {|
 ```
 {maxSize} is the maximum size for pagination and if the dApp tries to request pages outside of this boundary this error is thrown.
 
-### TxSendError
+#### TxSendError
 
 ```
 TxSendErrorCode = {
@@ -142,7 +170,7 @@ type TxSendError = {
 * Refused - Wallet refuses to send the tx (could be rate limiting)
 * Failure - Wallet could not send the tx
 
-### TxSignError
+#### TxSignError
 
 ```
 TxSignErrorCode = {
@@ -158,57 +186,82 @@ type TxSignError = {
 * ProofGeneration - User has accepted the transaction sign, but the wallet was unable to sign the transaction (e.g. not having some of the private keys)
 * UserDeclined - User declined to sign the transaction
 
-
-
-## Initial API
+### Initial API
 
 In order to initiate communication from webpages to a user's Cardano wallet, the wallet must provide the following javascript API to the webpage. A shared, namespaced `cardano` object must be injected into the page if it did not exist already. Each wallet implementing this standard must then create a field in this object with a name unique to each wallet containing a `wallet` object with the following methods. The API is split into two stages to maintain the user's privacy, as the user will have to consent to `cardano.{walletName}.enable()` in order for the dApp to read any information pertaining to the user's wallet with `{walletName}` corresponding to the wallet's namespaced name of its choice.
 
-### cardano.{walletName}.enable(): Promise\<API>
+#### cardano.{walletName}.enable(extensions: Extension[] = []): Promise\<API>
 
 Errors: APIError
 
 This is the entrypoint to start communication with the user's wallet. The wallet should request the user's permission to connect the web page to the user's wallet, and if permission has been granted, the full API will be returned to the dApp to use. The wallet can choose to maintain a whitelist to not necessarily ask the user's permission every time access is requested, but this behavior is up to the wallet and should be transparent to web pages using this API. If a wallet is already connected this function should not request access a second time, and instead just return the `API` object.
 
-### cardano.{walletName}.isEnabled(): Promise\<bool>
+Upon start, dApp can explicitly request a list of additional functionalities they expect as a list of CIP numbers capturing those extensions. This is used as an extensibility mechanism to document what functionalities can be provided by the wallet interface. CIP-0030 provides a set of base interfaces that every wallet must support. Then, new functionalities are introduced via additional CIPs and may be all or partially supported by wallets.
+
+DApps are expected to use this endpoint to perform an initial handshake and ensure that the wallet supports all their required functionalities. Note that it's possible for two extensions to be mutually incompatible (because they provide two conflicting features). While we may try to avoid this as much as possible while designing CIPs, it is also the responsability of wallet providers to assess whether they can support a given combination of extensions, or not. Hence wallets aren't expected to fail should they not recognize or not support a particular combination of extensions. Instead, they should decide what they enable and reflect their choice in the `cardano.{walletName}.extensions` field of the Full API. As a result, dApps may fail and inform their users or may use a different, less-efficient, strategy to cope with a lack of functionality.
+
+##### Can extensions depend on other extensions?
+
+Yes. Extensions may have other extensions as pre-requisite. Some newer extensions may also invalidate functionality introduced by earlier extensions. There's no particular rule or constraints in that regards. Extensions are specified as CIP, and will define what it entails to enable them.
+
+##### Should extensions follow a specific format?
+
+Yes. They all are CIPs.
+
+##### Can extensions add their own endpoints and/or error codes?
+
+Yes. Extensions may introduce new endpoints or error codes, and modify existing ones. Extensions may even change the rules outlined in this very proposal. The idea being that wallet providers should start off implementing this CIP, and then walk their way to implementing their chosen extensions.
+
+##### Are wallet expected to implement all extensions?
+
+No. It's up to wallet providers to decide which extensions they ought to support.
+
+
+#### cardano.{walletName}.isEnabled(): Promise\<bool>
 
 Errors: APIError
 
 Returns true if the dApp is already connected to the user's wallet, or if requesting access would return true without user confirmation (e.g. the dApp is whitelisted), and false otherwise. If this function returns true, then any subsequent calls to `wallet.enable()` during the current session should succeed and return the `API` object.
 
-### cardano.{walletName}.apiVersion: String
+#### cardano.{walletName}.apiVersion: String
 
-The version number of the API that the wallet supports.
+The version number of the API that the wallet supports. Set to `1`.
 
+#### cardano.{walletName}.supportedExtensions: Extension[]
 
-### cardano.{walletName}.name: String
+A list of extensions supported by the wallet. Extensions may be requested by dApps on initialization. Some extensions may be mutually conflicting and this list does not thereby reflect what extensions will be enabled by the wallet. Yet it informs on what extensions are known and can be requested by dApps if needed.
+
+#### cardano.{walletName}.name: String
 
 A name for the wallet which can be used inside of the dApp for the purpose of asking the user which wallet they would like to connect with.
 
-### cardano.{walletName}.icon: String
+#### cardano.{walletName}.icon: String
 
 A URI image (e.g. data URI base64 or other) for img src for the wallet which can be used inside of the dApp for the purpose of asking the user which wallet they would like to connect with.
 
-
-## Full API
+### Full API
 
 Upon successful connection via `cardano.{walletName}.enable()`, a javascript object we will refer to as `API` (type) / `api` (instance) is returned to the dApp with the following methods. All read-only methods (all but the signing functionality) should not require any user interaction as the user has already consented to the dApp reading information about the wallet's state when they agreed to `cardano.{walletName}.enable()`. The remaining methods `api.signTx()` and `api.signData()` must request the user's consent in an informative way for each and every API call in order to maintain security.
 
 The API chosen here is for the minimum API necessary for dApp <-> Wallet interactions without convenience functions that don't strictly need the wallet's state to work. The API here is for now also only designed for Shelley's Mary hardfork and thus has NFT support. When Alonzo is released with Plutus support this API will have to be extended.
 
-### api.getNetworkId(): Promise\<number>
+#### api.getExtensions() : Promise\<Extension[]>
+
+Retrieves the list of extensions enabled by the wallet. This may be influenced by the set of extensions requested in the initial `enable` request.
+
+#### api.getNetworkId(): Promise\<number>
 
 Errors: `APIError`
 
 Returns the network id of the currently connected account. 0 is testnet and 1 is mainnet but other networks can possibly be returned by wallets. Those other network ID values are not governed by this document. This result will stay the same unless the connected account has changed.
 
-### api.getUtxos(amount: cbor\<value> = undefined, paginate: Paginate = undefined): Promise\<TransactionUnspentOutput[] | null>
+#### api.getUtxos(amount: cbor\<value> = undefined, paginate: Paginate = undefined): Promise\<TransactionUnspentOutput[] | null>
 
 Errors: `APIError`, `PaginateError`
 
 If `amount` is `undefined`, this shall return a list of all UTXOs (unspent transaction outputs) controlled by the wallet. If `amount` is not `undefined`, this request shall be limited to just the UTXOs that are required to reach the combined ADA/multiasset value target specified in `amount`, and if this cannot be attained, `null` shall be returned. The results can be further paginated by `paginate` if it is not `undefined`.
 
-### api.getCollateral(params: { amount: cbor\<Coin> }): Promise\<TransactionUnspentOutput[] | null>
+#### api.getCollateral(params: { amount: cbor\<Coin> }): Promise\<TransactionUnspentOutput[] | null>
 
 Errors: `APIError`
 
@@ -225,43 +278,43 @@ The main point is to allow the wallet to encapsulate all the logic required to h
 
 The `amount` parameter is required, specified as a `string` (BigNumber) or a `number`, and the maximum allowed value must be agreed to be something like 5 ADA. Not limiting the maximum possible value might force the wallet to attempt to purify an unreasonable amount of ADA just because the dapp is doing something weird. Since by protocol the required collateral amount is always a percentage of the transaction fee, it seems that the 5 ADA limit should be enough for the foreseeable future.
 
-### api.getBalance(): Promise\<cbor\<value>>
+#### api.getBalance(): Promise\<cbor\<value>>
 
 Errors: `APIError`
 
 Returns the total balance available of the wallet. This is the same as summing the results of `api.getUtxos()`, but it is both useful to dApps and likely already maintained by the implementing wallet in a more efficient manner so it has been included in the API as well.
 
-### api.getUsedAddresses(paginate: Paginate = undefined): Promise\<Address[]>
+#### api.getUsedAddresses(paginate: Paginate = undefined): Promise\<Address[]>
 
 Errors: `APIError`
 
 Returns a list of all used (included in some on-chain transaction) addresses controlled by the wallet. The results can be further paginated by `paginate` if it is not `undefined`.
 
-### api.getUnusedAddresses(): Promise\<Address[]>
+#### api.getUnusedAddresses(): Promise\<Address[]>
 
 Errors: `APIError`
 
 Returns a list of unused addresses controlled by the wallet.
 
-### api.getChangeAddress(): Promise\<Address>
+#### api.getChangeAddress(): Promise\<Address>
 
 Errors: `APIError`
 
 Returns an address owned by the wallet that should be used as a change address to return leftover assets during transaction creation back to the connected wallet. This can be used as a generic receive address as well.
 
-### api.getRewardAddresses(): Promise\<Address[]>
+#### api.getRewardAddresses(): Promise\<Address[]>
 
 Errors: `APIError`
 
 Returns the reward addresses owned by the wallet. This can return multiple addresses e.g. CIP-0018.
 
-### api.signTx(tx: cbor\<transaction>, partialSign: bool = false): Promise\<cbor\<transaction_witness_set>>
+#### api.signTx(tx: cbor\<transaction>, partialSign: bool = false): Promise\<cbor\<transaction_witness_set>>
 
 Errors: `APIError`, `TxSignError`
 
 Requests that a user sign the unsigned portions of the supplied transaction. The wallet should ask the user for permission, and if given, try to sign the supplied body and return a signed transaction. If `partialSign` is true, the wallet only tries to sign what it can. If `partialSign` is false and the wallet could not sign the entire transaction, `TxSignError` shall be returned with the `ProofGeneration` code. Likewise if the user declined in either case it shall return the `UserDeclined` code. Only the portions of the witness set that were signed as a result of this call are returned to encourage dApps to verify the contents returned by this endpoint while building the final transaction.
 
-### api.signData(addr: Address, payload: Bytes): Promise\<DataSignature>
+#### api.signData(addr: Address, payload: Bytes): Promise\<DataSignature>
 
 Errors: `APIError`, `DataSignError`
 
@@ -281,13 +334,13 @@ If the payment key for `addr` is not a P2Pk address then `DataSignError` will be
 * `crv` (-1) - must be set to `Ed25519` (6)
 * `x` (-2) - must be set to the public key bytes of the key used to sign the `Sig_structure`
 
-### api.submitTx(tx: cbor\<transaction>): Promise\<hash32>
+#### api.submitTx(tx: cbor\<transaction>): Promise\<hash32>
 
 Errors: `APIError`, `TxSendError`
 
 As wallets should already have this ability, we allow dApps to request that a transaction be sent through it. If the wallet accepts the transaction and tries to send it, it shall return the transaction id for the dApp to track. The wallet is free to return the `TxSendError` with code `Refused` if they do not wish to send it, or `Failure` if there was an error in sending it (e.g. preliminary checks failed on signatures).
 
-## Experimental API
+### Experimental API
 
 Multiple experimental namespaces are used:
 - under `api` (ex: `api.experimental.myFunctionality`).
@@ -299,8 +352,43 @@ The benefits of this are:
 1. New features can be added to CIP30 as experimental features and only moved to non-experimental once multiple wallets implement it
 1. It provides a clear path to updating the CIP version number (when functions move from experimental -> stable)
 
-# Implementations
+## Rationale: how does this CIP achieve its goals?
 
-[nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)
+See justification and explanations provided with each API endpoint.
 
-[yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-ergo-connector/src/inject.js)
+### Extensions
+
+Extensions provide an extensibility mechanism and a way to negotiate (possibly conflicting) functionality between a DApp and a wallet provider. There's rules enforced as for what extensions a wallet decide to support or enable. The current mechanism only gives a way for wallets to communicate their choice back to a DApp.
+
+We use object as extensions for now to leave room for adding fields in the future without breaking all existing interfaces. At this point in time however, objects are expected to be singleton.
+
+Extensions can be seen as a smart versioning scheme. Except that, instead of being a monotonically increasing sequence of numbers, they are multi-dimensional feature set that can be toggled on and off at will. This is a versioning "à-la-carte" which is useful in a context where:
+
+1. There are multiple concurrent standardization efforts on different fronts to accomodate a rapidly evolving ecosystem;
+2. Not everyone agrees and has desired to support every existing standard;
+3. There's a need from an API consumer standpoint to clearly identify what features are supported by providers.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [x] The interface is implemented and supported by various wallet providers. See also: [cardano-caniuse](https://www.cardano-caniuse.io/).
+- [x] The interface is used by DApps to interact with wallet providers. Few examples:
+  - https://www.jpg.store/
+  - https://app.minswap.org/
+  - https://muesliswap.com/
+  - https://exchange.sundaeswap.finance/
+  - https://app.indigoprotocol.io/
+
+### Implementation Plan
+
+- [x] Provide some reference implementation of wallet providers
+  - [Berry-Pool/nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)
+  - [Emurgo/yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-ergo-connector/src/inject.js)
+
+- [x] Provide some reference implementation of the dapp connector
+  - [cardano-foundation/connect-with-wallet](https://github.com/cardano-foundation/cardano-connect-with-wallet)
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -190,7 +190,7 @@ type TxSignError = {
 
 In order to initiate communication from webpages to a user's Cardano wallet, the wallet must provide the following javascript API to the webpage. A shared, namespaced `cardano` object must be injected into the page if it did not exist already. Each wallet implementing this standard must then create a field in this object with a name unique to each wallet containing a `wallet` object with the following methods. The API is split into two stages to maintain the user's privacy, as the user will have to consent to `cardano.{walletName}.enable()` in order for the dApp to read any information pertaining to the user's wallet with `{walletName}` corresponding to the wallet's namespaced name of its choice.
 
-#### cardano.{walletName}.enable(extensions: Extension[] = []): Promise\<API>
+#### cardano.{walletName}.enable({ extensions: Extension[] } = {}): Promise\<API>
 
 Errors: APIError
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 27 | [CNFT Community Royalties Standard](./CIP-0027/) | Draft |
 | 28 | [Protocol Parameters (Alonzo Era)](./CIP-0028/) | Active |
 | 29 | [Phase-1 Monetary Scripts Serialization Formats](./CIP-0029/) | Active |
-| 30 | [Cardano dApp-Wallet Web Bridge](./CIP-0030/) | Draft |
+| 30 | [Cardano dApp-Wallet Web Bridge](./CIP-0030/) | Active |
 | 31 | [Reference Inputs](./CIP-0031/) | Active |
 | 32 | [Inline Datums](./CIP-0032/) | Active |
 | 33 | [Reference Scripts](./CIP-0033/) | Active |


### PR DESCRIPTION
  This has been a recurring topic regarding extensions of CIP-0030.
  Given that this CIP is effectively active (hence the status change in
  this commit), we can't simply keep modifying it because it then
  becomes hard for DApps to keep track of what is supported by wallet
  providers and what isn't.

  In this commit, I henceforth propose an extension scheme based off
  CIPs. Wallet providers are expected to support the base API given by
  CIP-0030 and new extensions or modifications of that API can be
  brought in through extension CIPs. Upon initialization, Dapps can
  interrogate the wallet about what CIPs extensions it supports and
  process or fail accordingly based on whether the wallet provides the
  desired functionality.