### PR TITLE
CIP-0001 | add Path to Active to Table of Contents

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -49,6 +49,7 @@ The CIP process does not _by itself_ offer any form of governance. For example, 
     - [Status: Proposed](#status-proposed)
     - [Status: Active](#status-active)
     - [Status: Inactive](#status-inactive)
+  - [Path to Active](#path-to-active)
   - [Categories](#categories)
   - [Project Enlisting](#project-enlisting)
 - [Process](#process)


### PR DESCRIPTION
Thanks @KtorZ for merging https://github.com/cardano-foundation/CIPs/pull/450 so quickly, but I didn't notice till now that although I'd linked the new _Path to Active_ section inline I hadn't added it to the Table of Contents.