### PR TITLE
CIP-0036 | Fix CDDL naming to match changes in spec from #427 

### DIFF
--- a/CIP-0036/schema.cddl
+++ b/CIP-0036/schema.cddl
@@ -3,13 +3,13 @@ registration_cbor = {
   61285: registration_witness
 }
 
-$voting_pub_key /= bytes .size 32
+$cip36_vote_pub_key /= bytes .size 32
 $payment_address /= bytes
 $nonce /= uint
 $weight /= uint .size 4
 $voting_purpose /= uint
-legacy_key_registration = $voting_pub_key
-delegation = [$voting_pub_key, $weight]
+legacy_key_registration = $cip36_vote_pub_key
+delegation = [$cip36_vote_pub_key, $weight]
 
 ; May support other stake credentials in the future.
 ; Such additional credentials should be tagged at the CDDL/CBOR level


### PR DESCRIPTION
### Motivation
Changes #427 introduced proposed that tool makers supporting this CIP should call the keys described within it "(CIP-36) vote keys" over "voting keys". This change was reflected in the specification and testvectors file, but not accurately reflected in the CDDL schema.

### Proposed Change
Rename `voting_pub_key` to be `cip36_vote_pub_key` in the CDDL schema file.

### Rationale
This change matches the CDDL schema to naming suggested within the CIP specification itself.

**Note**: Thank you @janmazak for spotting this.