### PR TITLE
Remove RSS category, use Ledger for CIP-0075 & CIP-0082

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -212,7 +212,6 @@ At present, we consider the following list of initial categories:
 Category               | Description
 ---                    | ---
 Meta                   | Designates meta-CIPs, such as this one, which typically serves another category or group of categories.
-Reward-Sharing Schemes | For CIPs discussing the reward & incentive mechanisms of the protocol.
 Wallets                | For standardisation across wallets (hardware, full-node or light).
 Tokens                 | About tokens (fungible or non-fungible) and minting policies in general.
 Metadata               | For proposals around metadata (on-chain or off-chain).
@@ -225,7 +224,7 @@ Registered categories for explicitly enlisted projects are otherwise listed belo
 Category | Description
 ---      | ---
 Plutus   | Changes or additions to Plutus, following the process described in [CIP-0035][]
-Ledger   | For proposals regarding the Cardano ledger, following the process described in ?
+Ledger   | For proposals regarding the Cardano ledger, following the process described in [CIP-0084][https://github.com/cardano-foundation/CIPs/pull/456]
 Catalyst | For proposals affecting Project Catalyst or the Jörmungandr project, following the process described in ?
 
 #### Project Enlisting

--- a/CIP-0075/README.md
+++ b/CIP-0075/README.md
@@ -2,7 +2,7 @@
 CIP: 75
 Title: Fair Stake Pool Rewards
 Status: Inactive (project area not enlisted for CIP process)
-Category: Reward-Sharing Scheme
+Category: Ledger
 Authors:
     - Tobias Fancee <tobiasfancee@gmail.com>
 Implementors: []

--- a/CIP-0082/README.md
+++ b/CIP-0082/README.md
@@ -2,7 +2,7 @@
 CIP: 82
 Title: Improved Rewards Scheme Parameters
 Status: Inactive (project area not enlisted for CIP process)
-Category: Reward-Sharing Scheme
+Category: Ledger
 Authors:
     - Tobias Fancee <tobiasfancee@gmail.com>
 Implementors: []


### PR DESCRIPTION
I believe that this better reflects the latest discussions on the topic. But that is up-to-debate. We could keep the more specific "RSS" category and simply mark all CIPs directed towards this category as "Inactive"; this would ease their finding later on although there aren't so many "Ledger" CIPs either. 

It just has been bothering me that this category exists, is clearly targeted at some specific areas of the ledger, yet is not embracing the CIP process. Unlike other pre-registered categories that tend to have multi-tenant ownership (e.g. wallets).   