### PR TITLE
Remove Frederic Johnson from CIP editors

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -335,12 +335,11 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 
 Current editors are listed here below:
 
-| Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Frederic Johnson <br/> [@crptmppt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] |
-| ---                               | ---                                           | ---                                  | ---                            | ---                            |
+| Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] |
+| ---                               | ---                                           | ---                            | ---                            |
 
 [@KtorZ]: https://github.com/KtorZ
 [@SebastienGllmt]: https://github.com/SebastienGllmt
-[@crptmppt]: https://github.com/crptmppt
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,9 @@ The following list contains proposals that have been under review and for which 
 
 ## Editors
 
-| Frederic Johnson <br/> [@crptmppt][] | Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] |
-| ---                                  | ---                               | ---                                           | ---                            | ---                            |
+| Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] |
+| ---                               | ---                                           | ---                            | ---                            |
 
-[@crptmppt]: https://github.com/crptmppt
 [@KtorZ]: https://github.com/KtorZ
 [@SebastienGllmt]: https://github.com/SebastienGllmt
 [@rphair]: https://github.com/rphair


### PR DESCRIPTION
@crptmppt hasn't been active for more than a year; which is a requirement for being an editor. We need to know we can rely on people for meetings and driving the CIP process. 

Thanks for kickstarting the CIP process and the work done; it's been crucial to the success of the CIP process. Feel free to re-apply if and once your focus becomes once again Cardano.