### PR TITLE
CIP-0030 | Better describe API extension compatibility

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -169,13 +169,13 @@ APIError {
 
 ```ts
 DataSignErrorCode {
- ProofGeneration: 1,
- AddressNotPK: 2,
- UserDeclined: 3,
+	ProofGeneration: 1,
+	AddressNotPK: 2,
+	UserDeclined: 3,
 }
 type DataSignError = {
- code: DataSignErrorCode,
- info: String
+	code: DataSignErrorCode,
+	info: String
 }
 ```
 
@@ -197,12 +197,12 @@ type PaginateError = {|
 
 ```ts
 TxSendErrorCode = {
- Refused: 1,
- Failure: 2,
+	Refused: 1,
+	Failure: 2,
 }
 type TxSendError = {
- code: TxSendErrorCode,
- info: String
+	code: TxSendErrorCode,
+	info: String
 }
 ```
 
@@ -213,12 +213,12 @@ type TxSendError = {
 
 ```ts
 TxSignErrorCode = {
- ProofGeneration: 1,
- UserDeclined: 2,
+	ProofGeneration: 1,
+	UserDeclined: 2,
 }
 type TxSignError = {
- code: TxSignErrorCode,
- info: String
+	code: TxSignErrorCode,
+	info: String
 }
 ```
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -100,7 +100,7 @@ Used to specify optional pagination for some API calls. Limits results to {limit
 
 #### Extension
 
-An extension is an object with a single field `"cip`"` that describes a CIP number extending the API (as a plain integer, without padding). For example:
+An extension is an object with a single field `"cip"` that describes a CIP number extending the API (as a plain integer, without padding). For example:
 
 ```json
 { "cip": 30 }

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -256,7 +256,7 @@ The wallet may also enable extensions that it *prefers* for any extensions which
 Conversely, it would then disable the non-preferred conflicting extensions.
 
 *Note:* If an extension list is supplied, extension `{"cip":30}` (or the preferred replacement in the case of a conflict) **MUST** always be enabled, even if it's not explicitly listed.
-This is because the [`cardano.{walletName}.extensions`](#cardanowalletnamesupportedextensions-extension) property of the API is necessary for the dApp to query what extensions are available for it to use.
+This is because the [`api.getExtensions()`](#apigetextensions--promiseextension) method of the API is necessary for the dApp to query what extensions are available for it to use.
 If `CIP-30` (or its successor) is NOT always enabled, then the dApp would have no capability to determine what extensions were available.
 Any conflicting extension to `CIP-30` **MUST** supply this property.
 
@@ -271,7 +271,7 @@ Incompatibilities can arise for example:
 
 While conflicting extensions should be avoided where reasonable while designing CIPs, it is also the responsibility of wallet providers to assess whether they can support a given combination of extensions, or not.
 Wallets *MUST NOT* fail to enable the API should they not recognize or not support a particular combination of extensions.
-Instead, they should decide what they enable and reflect their choice in the [`cardano.{walletName}.extensions`](#cardanowalletnamesupportedextensions-extension) property of the Full API.
+Instead, they should decide what they enable and reflect their choice in the [`api.getExtensions()`](#apigetextensions--promiseextension) method of the Full API.
 DApps will use the extensions reported by that property to decide how to proceed.
 For example, they can fail and inform their users that necessary wallet features are unavailable, or may use a different, less-efficient, strategy to cope with a lack of functionality.
 This may require the wallet to re-request a different set of extensions.
@@ -287,7 +287,7 @@ For example, if `CIP-9999` needs `CIP-8123` and a request is made to ONLY enable
 
 Yes.
 It would be a legitimate implementation of this CIP for a wallet to **ALWAYS** enable every extension it supports, regardless of the requested list of extensions.
-The only caveat is that the [`cardano.{walletName}.extensions`](#cardanowalletnamesupportedextensions-extension) property must faithfully reflect the extensions which the wallet API object supports.
+The only caveat is that the [`api.getExtensions()`](#apigetextensions--promiseextension) method must faithfully reflect the extensions which the wallet API object supports.
 
 ##### Should extensions follow a specific format?
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -149,14 +149,14 @@ For example, a wallet that supported both CIP-62 final and draft would only enab
 
 ```ts
 APIErrorCode {
- InvalidRequest: -1,
- InternalError: -2,
- Refused: -3,
- AccountChange: -4,
+	InvalidRequest: -1,
+	InternalError: -2,
+	Refused: -3,
+	AccountChange: -4,
 }
 APIError {
- code: APIErrorCode,
- info: string
+	code: APIErrorCode,
+	info: string
 }
 ```
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -160,10 +160,10 @@ APIError {
 }
 ```
 
-* InvalidRequest - Inputs do not conform to this spec or are otherwise invalid.
-* InternalError - An error occurred during execution of this API call.
-* Refused - The request was refused due to lack of access - e.g. wallet disconnects.
-* AccountChange - The account has changed. The dApp should call `wallet.enable()` to reestablish connection to the new account. The wallet should not ask for confirmation as the user was the one who initiated the account change in the first place.
+- InvalidRequest - Inputs do not conform to this spec or are otherwise invalid.
+- InternalError - An error occurred during execution of this API call.
+- Refused - The request was refused due to lack of access - e.g. wallet disconnects.
+- AccountChange - The account has changed. The dApp should call `wallet.enable()` to reestablish connection to the new account. The wallet should not ask for confirmation as the user was the one who initiated the account change in the first place.
 
 #### DataSignError
 
@@ -179,9 +179,9 @@ type DataSignError = {
 }
 ```
 
-* ProofGeneration - Wallet could not sign the data (e.g. does not have the secret key associated with the address)
-* AddressNotPK - Address was not a P2PK address and thus had no SK associated with it.
-* UserDeclined - User declined to sign the data
+- ProofGeneration - Wallet could not sign the data (e.g. does not have the secret key associated with the address)
+- AddressNotPK - Address was not a P2PK address and thus had no SK associated with it.
+- UserDeclined - User declined to sign the data
 
 #### PaginateError
 
@@ -206,8 +206,8 @@ type TxSendError = {
 }
 ```
 
-* Refused - Wallet refuses to send the tx (could be rate limiting)
-* Failure - Wallet could not send the tx
+- Refused - Wallet refuses to send the tx (could be rate limiting)
+- Failure - Wallet could not send the tx
 
 #### TxSignError
 
@@ -222,8 +222,8 @@ type TxSignError = {
 }
 ```
 
-* ProofGeneration - User has accepted the transaction sign, but the wallet was unable to sign the transaction (e.g. not having some of the private keys)
-* UserDeclined - User declined to sign the transaction
+- ProofGeneration - User has accepted the transaction sign, but the wallet was unable to sign the transaction (e.g. not having some of the private keys)
+- UserDeclined - User declined to sign the transaction
 
 ### Initial API
 
@@ -264,9 +264,9 @@ DApps are expected to use this endpoint to perform an initial handshake and ensu
 *Note:* Extensions can be mutually incompatible.
 Incompatibilities can arise for example:
 
-* When extensions provide conflicting features.
-* If a newer extension wholly replaces the functionality of an older one.
-* A draft `"x-cip"` is replaced by a final `"cip"`.
+- When extensions provide conflicting features.
+- If a newer extension wholly replaces the functionality of an older one.
+- A draft `"x-cip"` is replaced by a final `"cip"`.
 
 While conflicting extensions should be avoided where reasonable while designing CIPs, it is also the responsibility of wallet providers to assess whether they can support a given combination of extensions, or not.
 Wallets *MUST NOT* fail to enable the API should they not recognize or not support a particular combination of extensions.
@@ -404,19 +404,19 @@ Errors: `APIError`, `DataSignError`
 
 This endpoint utilizes the [CIP-0008 signing spec](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0008/CIP-0008.md) for standardization/safety reasons. It allows the dApp to request the user to sign a payload conforming to said spec. The user's consent should be requested and the message to sign shown to the user. The payment key from `addr` will be used for base, enterprise and pointer addresses to determine the EdDSA25519 key used. The staking key will be used for reward addresses. This key will be used to sign the `COSE_Sign1`'s `Sig_structure` with the following headers set:
 
-* `alg` (1) - must be set to `EdDSA` (-8)
-* `kid` (4) - Optional, if present must be set to the same value as in the `COSE_key` specified below. It is recommended to be set to the same value as in the `"address"` header.
-* `"address"` - must be set to the raw binary bytes of the address as per the binary spec, without the CBOR binary wrapper tag
+- `alg` (1) - must be set to `EdDSA` (-8)
+- `kid` (4) - Optional, if present must be set to the same value as in the `COSE_key` specified below. It is recommended to be set to the same value as in the `"address"` header.
+- `"address"` - must be set to the raw binary bytes of the address as per the binary spec, without the CBOR binary wrapper tag
 
 The payload is not hashed and no `external_aad` is used.
 
 If the payment key for `addr` is not a P2Pk address then `DataSignError` will be returned with code `AddressNotPK`. `ProofGeneration` shall be returned if the wallet cannot generate a signature (i.e. the wallet does not own the requested payment private key), and `UserDeclined` will be returned if the user refuses the request. The return shall be a `DataSignature` with `signature` set to the hex-encoded CBOR bytes of the `COSE_Sign1` object specified above and `key` shall be the hex-encoded CBOR bytes of a `COSE_Key` structure with the following headers set:
 
-* `kty` (1) - must be set to `OKP` (1)
-* `kid` (2) - Optional, if present must be set to the same value as in the `COSE_Sign1` specified above.
-* `alg` (3) - must be set to `EdDSA` (-8)
-* `crv` (-1) - must be set to `Ed25519` (6)
-* `x` (-2) - must be set to the public key bytes of the key used to sign the `Sig_structure`
+- `kty` (1) - must be set to `OKP` (1)
+- `kid` (2) - Optional, if present must be set to the same value as in the `COSE_Sign1` specified above.
+- `alg` (3) - must be set to `EdDSA` (-8)
+- `crv` (-1) - must be set to `Ed25519` (6)
+- `x` (-2) - must be set to the public key bytes of the key used to sign the `Sig_structure`
 
 #### api.submitTx(tx: cbor\<transaction>): Promise\<hash32>
 
@@ -428,8 +428,8 @@ As wallets should already have this ability, we allow dApps to request that a tr
 
 Multiple experimental namespaces are used:
 
-* under `api` (ex: `api.experimental.myFunctionality`).
-* under `cardano.{walletName}` (ex: `window.cardano.{walletName}.experimental.myFunctionality`)
+- under `api` (ex: `api.experimental.myFunctionality`).
+- under `cardano.{walletName}` (ex: `window.cardano.{walletName}.experimental.myFunctionality`)
 
 The benefits of this are:
 
@@ -458,22 +458,22 @@ Extensions can be seen as a smart versioning scheme. Except that, instead of bei
 
 ### Acceptance Criteria
 
-* [x] The interface is implemented and supported by various wallet providers. See also: [cardano-caniuse](https://www.cardano-caniuse.io/).
-* [x] The interface is used by DApps to interact with wallet providers. Few examples:
-  * <https://www.jpg.store/>
-  * <https://app.minswap.org/>
-  * <https://muesliswap.com/>
-  * <https://exchange.sundaeswap.finance/>
-  * <https://app.indigoprotocol.io/>
+- [x] The interface is implemented and supported by various wallet providers. See also: [cardano-caniuse](https://www.cardano-caniuse.io/).
+- [x] The interface is used by DApps to interact with wallet providers. Few examples:
+  - <https://www.jpg.store/>
+  - <https://app.minswap.org/>
+  - <https://muesliswap.com/>
+  - <https://exchange.sundaeswap.finance/>
+  - <https://app.indigoprotocol.io/>
 
 ### Implementation Plan
 
-* [x] Provide some reference implementation of wallet providers
-  * [Berry-Pool/nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)
-  * [Emurgo/yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-ergo-connector/src/inject.js)
+- [x] Provide some reference implementation of wallet providers
+  - [Berry-Pool/nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)
+  - [Emurgo/yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-ergo-connector/src/inject.js)
 
-* [x] Provide some reference implementation of the dapp connector
-  * [cardano-foundation/connect-with-wallet](https://github.com/cardano-foundation/cardano-connect-with-wallet)
+- [x] Provide some reference implementation of the dapp connector
+  - [cardano-foundation/connect-with-wallet](https://github.com/cardano-foundation/cardano-connect-with-wallet)
 
 ## Copyright
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -108,7 +108,7 @@ An extension is an object with a single field `"cip`"` that describes a CIP numb
 
 ##### Draft or Experimental Extensions
 
-Extensions that are draft, in development or prototyped should not use official "cip" numbering.
+Extensions that are draft, in development, or prototyped should not use official "cip" numbering.
 
 They should instead be referred to as "x-cip" and the number can be arbitrary and should not be expected to be unique.
 "x-cip" numbers should NOT be used which overlap official CIP or draft CIP assignments unless they are the draft extension for the respective CIP.
@@ -131,13 +131,14 @@ would be an experimental extension that has not been assigned an official CIP nu
 would be used to enable the draft extension for `CIP-62`.
 
 When a CIP is ratified, the wallet may continue to recognize the "x-cip" extension.
-In this example, it would now be `{ "cip": 62 }`.
+In this example, the finalized cip that replaces the draft would be `{ "cip": 62 }`.
 This will allow for a graceful transition from draft to official status of extensions.
 How long a wallet or dApp will recognize the draft or experimental extension object is up to the individual wallet and dApp.
 
 The reason for using `x-cip` for drafts with an official number is to clearly distinguish between draft implementations and the official version.
 The official CIP can have differences from the final draft that both the dApp and wallet may need to accommodate.
-Clearly distinguishing between them prevents avoidable compatibility errors.
+Avoiding using the official CIP extension until ratified disambiguates the draft process at the time of ratification.
+Clearly distinguishing between them prevents avoidable compatibility errors should the final draft and ratified CIP differ.
 
 If a wallet is requested to enable both the draft and ratified CIP, it should **ALWAYS** prefer the ratified CIP.
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -278,7 +278,7 @@ This may require the wallet to re-request a different set of extensions.
 
 ##### Can extensions depend on other extensions?
 
-Yes. Extensions may have other extensions as pre-requisite. Some newer extensions may also invalidate functionality introduced by earlier extensions. There are no particular rules or constraints in that regard. Extensions are specified as a CIP, and will define what it entails to enable them.
+Yes. Extensions may have other extensions as pre-requisite, extension dependencies should be unambiguously defined in their respective CIPs. Some newer extensions may also invalidate functionality introduced by earlier extensions. There are no particular rules or constraints in that regard. Extensions are specified as a CIP, and will define what it entails to enable them.
 
 Wallets should attempt to enable all extensions necessary to enable the extensions requested, even if they were not specifically requested.
 For example, if `CIP-9999` needs `CIP-8123` and a request is made to ONLY enable `[{"cip":9999}]` then the wallet should automatically enable `CIP-8123` as if the request was actually for `[{"cip":8123},{"cip":9999}]`.


### PR DESCRIPTION
Adds specification to better describe the "Extensions Enable" API, with an effort to better control backwards and forwards compatibility.
Define a way to specify experimental extensions that do not compete with official extensions, and describe the path forward.
Add language tags to code blocks.
Use `-` consistently for unordered lists.
Properly declare HTTP urls.

------------------------------------

[CIP-0030 with this update, rendered in branch](https://github.com/stevenj/CIPs/tree/cip-30-backward-compat/CIP-0030)