### PR TITLE
Fix broken links from CIPs to hydra.iohk.io

### DIFF
--- a/CIP-0006/README.md
+++ b/CIP-0006/README.md
@@ -16,7 +16,7 @@ This CIP defines the concept of extended metadata for pools that is referenced f
 
 ## Motivation
 
-As the ecosystem around Cardano stake pools proliferate so will the desire to slice, organize and search pool information dynamically.  Currently the metadata referenced on chain provides 512 bytes that can be allocated across the four information categories ([delegation-design-specification Section 4.2)](https://hydra.iohk.io/build/790053/download/1/delegation_design_spec.pdf):
+As the ecosystem around Cardano stake pools proliferate so will the desire to slice, organize and search pool information dynamically.  Currently the metadata referenced on chain provides 512 bytes that can be allocated across the four information categories ([delegation-design-specification Section 4.2)](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-delegation.pdf):
 
 | key           | Value                                |  Rules  |
 | ---           | ---                                  |  ---  |

--- a/CIP-0025/README.md
+++ b/CIP-0025/README.md
@@ -24,7 +24,7 @@ Cardano has the ability to send metadata in a transaction, that's the way we can
 > are always created in specific forging operations, we can always trace them back through their
 > transaction graph to their origin.
 
-(Section 4.1 in the paper: https://hydra.iohk.io/build/5400786/download/1/eutxoma.pdf)
+(Section 4 in the paper: https://iohk.io/en/research/library/papers/utxomautxo-with-multi-asset-support/)
 
 ## Considerations
 

--- a/CIP-0059/README.md
+++ b/CIP-0059/README.md
@@ -34,7 +34,7 @@ and were only intended to be used as
 for a very specific abstraction used in the ledger code.
 (The story is even a bit more confusing, since the Allegra and Mary era share a lot of code
 and are specified together in the "Shelley-MA
-[specification](https://hydra.iohk.io/job/Cardano/cardano-ledger/specs.shelley-ma/latest/download-by-type/doc-pdf/shelley-ma).
+[specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf).
 The letters "MA" can hilariously refer to both "Mary Allegra" and "Multi-Assets".)
 How did we then go from poets to Alonzo?
 Recall that "Goguen" was the only non-poet named in the phases on the Cardano roadmap.
@@ -80,7 +80,7 @@ align with the protocol version described in this CIP.
 
 Note also that the protocol version present inside of each block header indicates the maximum supported protocol version
 that the block producer is capable of supporting (see section 13, Software Updates, of the
-[Shelley ledger specification](https://hydra.iohk.io/job/Cardano/cardano-ledger/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)).
+[Shelley ledger specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf)).
 
 ## Specification
 

--- a/CIP-0074/README.md
+++ b/CIP-0074/README.md
@@ -55,8 +55,8 @@ This proposed change is fully backwards compatible and will not require a hard-f
 
 ### Research and References
 
-Engineering Design Specification for Delegation and Incentives in Cardano–Shelley
-https://hydra.iohk.io/build/790053/download/1/delegation_design_spec.pdf
+Design Specification for Delegation and Incentives in Cardano
+https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-delegation.pdf
 
 Reward Sharing Schemes for Stake Pools
 https://arxiv.org/pdf/1807.11218.pdf

--- a/CIP-1854/README.md
+++ b/CIP-1854/README.md
@@ -228,7 +228,7 @@ Description                                  | Link
 BIP-0032 - HD Wallets                        | https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 CIP-5 - Common Bech32 Prefixes               | https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005
 CIP-1852 - Cardano HD Wallets                | https://github.com/cardano-foundation/CIPs/tree/master/CIP-1852
-A Formal Specification of the Cardano Ledger | https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
+A Formal Specification of the Cardano Ledger | https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf
 
 
 # Copyright
@@ -241,5 +241,5 @@ CC-BY-4.0
 [CIP-5]: https://github.com/cardano-foundation/CIPs/tree/master/CIP5
 [CIP-1852]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-1852
 [CIP-11]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0011
-[ledger-spec.pdf]: https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
+[ledger-spec.pdf]: https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf
 [SLIP-0044]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md

--- a/CIP-1855/README.md
+++ b/CIP-1855/README.md
@@ -99,7 +99,7 @@ Description                                  | Link
 BIP-0032 - HD Wallets                        | https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 CIP-5 - Common Bech32 Prefixes               | https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005
 CIP-1852 - Cardano HD Wallets                | https://github.com/cardano-foundation/CIPs/tree/master/CIP-1852
-A Formal Specification of the Cardano Ledger | https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
+A Formal Specification of the Cardano Ledger | https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf
 
 
 # Copyright
@@ -109,5 +109,5 @@ CC-BY-4.0
 [BIP-0032]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 [CIP-0005]: https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005
 [CIP-1852]: https://github.com/cardano-foundation/CIPs/blob/master/CIP-1852
-[ledger-spec.pdf]: https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
+[ledger-spec.pdf]: https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf
 [SLIP-0044]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md


### PR DESCRIPTION
Fixes https://github.com/cardano-foundation/CIPs/issues/485.  Readers and authors on CIP repository and Developer Portal reported links from CIPs to reference papers were out of date due to `hydra.iohk.io` being superseded.

@Ryun1 identified https://github.com/input-output-hk/cardano-ledger/commit/7bb099326546f910539b75e835b07322fdf88bc5 which has been helpful in narrowing down the target documents at their new locations.  Before we merge this I hope we can get approval or correction from the CIP authors and representative paper authors that the new link targets are appropriate:

cc @gufmar @alessandrokonrad @SmaugPool @JaredCorduan @ADARobinHood @KtorZ @disassembler @dcoutts @WhatisRT

CIPs affected (see reference issue for details):

- CIP-0006
- CIP-0025
- CIP-0059
- CIP-0074
- CIP-1854
- CIP-1855