### PR TITLE
CIP-0067 | add ADA Handles Virtual SubHandle

### DIFF
--- a/CIP-0067/registry.json
+++ b/CIP-0067/registry.json
@@ -10,6 +10,11 @@
     "description": "CIP-0068 - Datum Metadata Standard (222 sub standard)"
   },
   {
+    "asset_name_label": 314,
+    "class": "Virtual_SubHandle",
+    "description": "ADA Handles Virtual SubHandle"
+  },
+  {
     "asset_name_label": 333,
     "class": "FT",
     "description": "CIP-0068 - Datum Metadata Standard (333 sub standard)"


### PR DESCRIPTION
Reserving a label for Virtual SubHandles. These are Handles that the issuer (root Handle owner) retains ownership over, but still allows for address resolution to a specified wallet, and personalization features.