### PR TITLE
CIP-0010 | Add Agora proposal creation metadata to registry

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -28,6 +28,10 @@
     "description": "CIP-0027 - Royalties Standard"
   },
   {
+    "transaction_metadatum_label": 839,
+    "description": "Agora - Proposal creation metadata"
+  },
+  {
     "transaction_metadatum_label": 888,
     "description": "finitum.io token bridge transactions metadata"
   },


### PR DESCRIPTION
This is a reduced version of https://github.com/cardano-foundation/CIPs/pull/511 that only adds the tag to the registry.