### PR TITLE
CIP-0086 | Fix relative links to asset files

### DIFF
--- a/CIP-0086/README.md
+++ b/CIP-0086/README.md
@@ -453,10 +453,10 @@ representing policy IDs and token name:
 
 -   In version 1,
 policy IDs and token names must be expressed as text
-(see [cddl/version_1.cddl](cddl/version_1.cddl)).
+(see [cddl/version_1.cddl](./cddl/version_1.cddl)).
 -   In version 2,
 policy IDs and token names must be expressed as raw bytes
-(see [cddl/version_2.cddl](cddl/version_2.cddl)).
+(see [cddl/version_2.cddl](./cddl/version_2.cddl)).
 
 By default, all CIP-86 metadata updates use version 1.
 However, version 2 can be used if the `version` field of the object


### PR DESCRIPTION
Places where CIP web content is built, particularly the Developer Portal, can use different defaults as the root of relative pathnames.  Therefore links to local asset files must begin with `./` which we generally have for CIPs & only notice when e.g. the build process for the Dev Portal generates a warning and then links to an incorrect URL:

```
Exhaustive list of all broken links found:

- On source page path = /docs/governance/cardano-improvement-proposals/CIP-0086:
   -> linking to cddl/version_1.cddl (resolved as: /docs/governance/cardano-improvement-proposals/cddl/version_1.cddl)
   -> linking to cddl/version_2.cddl (resolved as: /docs/governance/cardano-improvement-proposals/cddl/version_2.cddl)
```

For now I guess editors should just keep aware of this during the review process, along with ensuring web sites are prefixed as URLs with protocol (e.g. https://github.com/cardano-foundation/CIPs/pull/514).  I guess we could write a script to check for these, but for some reason CIP authors tend to prefix the web sites & relative pathnames this way already... and otherwise will be caught by builders of the Dev Portal 😅 cc @katomm