### PR TITLE
CIP-0060 | Fix relative links

### DIFF
--- a/CIP-0060/README.md
+++ b/CIP-0060/README.md
@@ -21,7 +21,7 @@ Music tokens on Cardano can be either NFTs or FTs and contain links to audio fil
 
 This CIP divides the additional metadata parameters into two categories of `Required` and `Optional`. When minting a music token on Cardano, you are expected to include ALL of the required fields. If you choose to include one or more of the optional fields, they must be named exactly as defined in this CIP. This will properly allow indexing apps and music players to utilize as much of your token metadata as possible without issues.
 
-[CDDL Spec Version 2](./cddl/version-2.cddl)
+[CDDL Spec Version 2](./cddl/version-2.cddl)<br/>
 [CDDL Spec Version 1 (deprecated)](./cddl/version-1.cddl)
 
 ## Summary of v2 Changes ##

--- a/CIP-0060/README.md
+++ b/CIP-0060/README.md
@@ -21,8 +21,8 @@ Music tokens on Cardano can be either NFTs or FTs and contain links to audio fil
 
 This CIP divides the additional metadata parameters into two categories of `Required` and `Optional`. When minting a music token on Cardano, you are expected to include ALL of the required fields. If you choose to include one or more of the optional fields, they must be named exactly as defined in this CIP. This will properly allow indexing apps and music players to utilize as much of your token metadata as possible without issues.
 
-[CDDL Spec Version 2](cddl/version-2.cddl)
-[CDDL Spec Version 1 (deprecated)](cddl/version-1.cddl)
+[CDDL Spec Version 2](./cddl/version-2.cddl)
+[CDDL Spec Version 1 (deprecated)](./cddl/version-1.cddl)
 
 ## Summary of v2 Changes ##
 In version 2 of the CIP-60 spec, `album_title` has been renamed to `release_title`. `release` is a more generic name that covers all types of releases from Albums, EPs, LPs, Singles, and Compilations. At the top level, we are grouping those metadata items that relate to the release under a new key `release`. At the file for each song, there is a new `song` key that holds the metadata specific to the individual song. These changes separate the music-specific metadata from the general CIP-25/CIP-68 NFT metadata. A music player can look at just the information necessary instead of having to ignore extra NFT-related fields. CIP-68 NFTs are officially supported and an example specific to CIP-68 has been added below.


### PR DESCRIPTION
The Developer Portal build of the CIP directory structure depends on relative links being prefixed by `./` so this is a routine fix that comes up from time to time (we are gradually getting to all of these).

Not sure why these problems aren't all exposed at once, but local builds of the Dev Poral generate warnings like these for relative pathnames and often expand the absolute URL wrong (cc @katomm):
```
[WARNING] Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /docs/governance/cardano-improvement-proposals/CIP-0060:
   -> linking to cddl/version-2.cddl (resolved as: /docs/governance/cardano-improvement-proposals/cddl/version-2.cddl)
```