### PR TITLE
Fix status links in top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 
 <p align="right"><i>Last updated on 2023-06-30</i></p>
 
-> 💡 For more details about Statuses, refer to [CIP-0001](./CIP-0001).
+> 💡 For more details about CIP statuses, refer to [CIP-0001](./CIP-0001).
 
 ### Proposals Under Review (CIP)
 
@@ -136,6 +136,8 @@ Below are listed tentative CIPs still under discussion with the community. They 
 | 0005 | [Plutus Script Usability](./CPS-0005) | Open |
 
 <p align="right"><i>Last updated on 2023-06-09</i></p>
+
+> 💡 For more details about CPS statuses, refer to [CIP-9999](./CIP-9999).
 
 ### Proposals Under Review (CPS)
 


### PR DESCRIPTION
In the merge conflict resulting from an old code base for https://github.com/cardano-foundation/CIPs/pull/380, this tip (for the meaning of the "status" field) appeared under the CIP table _or_ the CPS table depending on the source branch.

To avoid creating an incorrect top level README upon merging #380, in fixing that merge conflict I positioned the "tip" correctly...  but (to avoid introducing a content change irrelevant to CIP-1694) I didn't correct the tip for CPS statuses, which are different from CIP statuses.  That fix is done here.

Likewise @KtorZ @Ryun1 we will have to please review and merge this ASAP otherwise the same thing will keep happening for other CIP merges which might update the README file.  At the very least it should be merged before the customary "chore" of promoting CIPs biweekly and updating the CIP/CPS tables.