### PR TITLE
Top README: update for CIP-0084 consequences to RSS proposals

### DIFF
--- a/.github/CIP-TEMPLATE.md
+++ b/.github/CIP-TEMPLATE.md
@@ -14,15 +14,14 @@ License: CC-BY-4.0
 
 <!-- Existing categories:
 
-- Meta                   | For meta-CIPs which typically serves another category or group of categories.
-- Reward-Sharing Schemes | For CIPs discussing the reward & incentive mechanisms of the protocol.
-- Wallets                | For standardisation across wallets (hardware, full-node or light).
-- Tokens                 | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata               | For proposals around metadata (on-chain or off-chain).
-- Tools                  | A broad category for ecosystem tools not falling into any other category.
-- Plutus                 | Changes or additions to Plutus
-- Ledger                 | For proposals regarding the Cardano ledger
-- Catalyst               | For proposals affecting Project Catalyst / the Jörmungandr project
+- Meta     | For meta-CIPs which typically serves another category or group of categories.
+- Wallets  | For standardisation across wallets (hardware, full-node or light).
+- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata | For proposals around metadata (on-chain or off-chain).
+- Tools    | A broad category for ecosystem tools not falling into any other category.
+- Plutus   | Changes or additions to Plutus
+- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
 
 -->
 

--- a/.github/CPS-TEMPLATE.md
+++ b/.github/CPS-TEMPLATE.md
@@ -13,15 +13,14 @@ Created: YYYY-MM-DD
 
 <!-- Existing categories:
 
-- Meta                   | For meta-CIPs which typically serves another category or group of categories.
-- Reward-Sharing Schemes | For CIPs discussing the reward & incentive mechanisms of the protocol.
-- Wallets                | For standardisation across wallets (hardware, full-node or light).
-- Tokens                 | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata               | For proposals around metadata (on-chain or off-chain).
-- Tools                  | A broad category for ecosystem tools not falling into any other category.
-- Plutus                 | Changes or additions to Plutus
-- Ledger                 | For proposals regarding the Cardano ledger
-- Catalyst               | For proposals affecting Project Catalyst / the Jörmungandr project
+- Meta     | For meta-CIPs which typically serves another category or group of categories.
+- Wallets  | For standardisation across wallets (hardware, full-node or light).
+- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata | For proposals around metadata (on-chain or off-chain).
+- Tools    | A broad category for ecosystem tools not falling into any other category.
+- Plutus   | Changes or additions to Plutus
+- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
 
 -->
 

--- a/CIP-0075/README.md
+++ b/CIP-0075/README.md
@@ -177,7 +177,7 @@ Before implementation, engineering and research teams must review the feasibilit
 4. Transaction is submitted.
 5. Protocol update is confirmed.
 
-## Implementation Plan
+### Implementation Plan
 
 Implementation can be staged to reduce shock to the network:
 

--- a/CIP-0075/README.md
+++ b/CIP-0075/README.md
@@ -1,7 +1,7 @@
 ---
 CIP: 75
 Title: Fair Stake Pool Rewards
-Status: Inactive (project area not enlisted for CIP process)
+Status: Proposed
 Category: Ledger
 Authors:
     - Tobias Fancee <tobiasfancee@gmail.com>

--- a/CIP-0082/README.md
+++ b/CIP-0082/README.md
@@ -1,7 +1,7 @@
 ---
 CIP: 82
 Title: Improved Rewards Scheme Parameters
-Status: Inactive (project area not enlisted for CIP process)
+Status: Proposed
 Category: Ledger
 Authors:
     - Tobias Fancee <tobiasfancee@gmail.com>

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 0020 | [Transaction message/comment metadata](./CIP-0020/) | Active |
 | 0021 | [Transaction requirements for interoperability with hardware wallets](./CIP-0021/) | Draft |
 | 0022 | [Pool operator verification](./CIP-0022/) | Active |
-| 0023 | [Fair Min Fees](./CIP-0023/) | Draft |
-| 0024 | [Non-Centralizing Rankings](./CIP-0024/) | Draft |
+| 0023 | [Fair Min Fees](./CIP-0023/) | Proposed |
+| 0024 | [Non-Centralizing Daedalus Rankings](./CIP-0024/) | Proposed |
 | 0025 | [Media NFT Metadata Standard](./CIP-0025/) | Active |
 | 0026 | [Cardano Off-Chain Metadata](./CIP-0026/) | Draft |
 | 0027 | [CNFT Community Royalties Standard](./CIP-0027/) | Draft |
@@ -79,9 +79,9 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 0071 | [Non-Fungible Token (NFT) Proxy Voting Standard](./CIP-0071) | Proposed |
 | 0072 | [DApp Registration](./CIP-0072) | Proposed |
 | 0074 | [Set min-pool-cost to 0](./CIP-0074) | Proposed |
-| 0075 | <strike>[Fair Stake Pool Rewards](./CIP-0075)</strike> | Inactive |
+| 0075 | [Fair Stake Pool Rewards](./CIP-0075) | Proposed |
 | 0080 | [Transaction Serialization Deprecation Cycle](./CIP-0080) | Active |
-| 0082 | <strike>[Improved Rewards Scheme Parameters](./CIP-0082)</strike> | Inactive |
+| 0082 | [Improved Rewards Scheme Parameters](./CIP-0082) | Proposed |
 | 0083 | [Encrypted Transaction message/comment metadata (Addendum to CIP-0020)](./CIP-0083) | Active |
 | 0084 | [Cardano Ledger Evolution](./CIP-0084) | Active |
 | 0085 | [Sums-of-products in Plutus Core](./CIP-0085) | Proposed |
@@ -95,7 +95,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 1694 | [A proposal for entering the Voltaire phase](./CIP-1694) | Proposed |
 | 9999 | [Cardano Problem Statements](./CIP-9999/) | Active |
 
-<p align="right"><i>Last updated on 2023-07-01</i></p>
+<p align="right"><i>Last updated on 2023-07-02</i></p>
 
 > 💡 For more details about CIP statuses, refer to [CIP-0001](./CIP-0001).
 
@@ -133,8 +133,9 @@ Below are listed tentative CIPs still under discussion with the community. They 
 | #    | Title | Status |
 | ---- | --- | --- |
 | 0005 | [Plutus Script Usability](./CPS-0005) | Open |
+| 0007 | [Voltaire era Governance](./CPS-0007) | Open |
 
-<p align="right"><i>Last updated on 2023-06-09</i></p>
+<p align="right"><i>Last updated on 2023-07-02</i></p>
 
 > 💡 For more details about CPS statuses, refer to [CIP-9999](./CIP-9999).
 
@@ -149,9 +150,8 @@ Below are listed tentative CPSs still under discussion with the community. They 
 | 0003? | [Smart Tokens](https://github.com/cardano-foundation/CIPs/pull/382) |
 | 0004? | [Spending Script Redundant Execution](https://github.com/cardano-foundation/CIPs/pull/418/) |
 | 0006? | [Governance Security](https://github.com/cardano-foundation/CIPs/pull/491) |
-| 0007? | [Voltaire era Governance](https://github.com/cardano-foundation/CIPs/pull/481) |
 
-<p align="right"><i>Last updated on 2023-06-09</i></p>
+<p align="right"><i>Last updated on 2023-07-02</i></p>
 
 ## Stalled / Waiting For Authors
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 0086 | [NFT Metadata Update Oracles](./CIP-0086) | Proposed |
 | 0094 | [SPO On-chain Polls](./CIP-0094) | Active |
 | 0381 | [Plutus Support for Pairings Over BLS12-381](./CIP-0381) | Proposed |
+| 1694 | [A proposal for entering the Voltaire phase](./CIP-1694) | Proposed |
 | 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/) | Active |
 | 1853 | [HD (Hierarchy for Deterministic) Stake Pool Cold Keys for Cardano](./CIP-1853/) | Active |
 | 1854 | [Multi-signatures HD Wallets](./CIP-1854/) | Draft |
 | 1855 | [Forging policy keys for HD Wallets](./CIP-1855/) | Active |
-| 1694 | [A proposal for entering the Voltaire phase](./CIP-1694) | Proposed |
 | 9999 | [Cardano Problem Statements](./CIP-9999/) | Active |
 
 <p align="right"><i>Last updated on 2023-07-02</i></p>


### PR DESCRIPTION
As previously arranged in https://github.com/cardano-foundation/CIPs/pull/456#issuecomment-1579110371, RSS proposals can all be given a status of `Proposed` and category of `Ledger` now that CIP-0084 is merged with a language clarification both extending & limiting the Ledger team's responsibility for these CIPs (quoted in https://github.com/cardano-foundation/CIPs/pull/456#issuecomment-1585558784).

More recent CIPs written according to the updated CIP-0001 (0075, 0082: cc @TobiasFancee) have their `Inactive` status removed and no longer have a strike-out on the CIP table.  (re: https://github.com/cardano-foundation/CIPs/pull/482)

Older CIPs also now have status `Proposed` in the top level table, and will soon be updated for compatibility with CIP-0001 with headers fixed to use the new status & other fields:
- https://github.com/cardano-foundation/CIPs/issues/532 @shawnim
- https://github.com/cardano-foundation/CIPs/issues/533 @shawnim
- https://github.com/cardano-foundation/CIPs/issues/534 @shawnim
- https://github.com/cardano-foundation/CIPs/issues/535 @ADARobinHood

Note CIP-0024 is mainly updated in name since it doesn't propose RSS changes or affect the Ledger but only recommends changes to Daedalus (and perhaps the Cardano white paper).

(CPS-0007 promotion on the top level page is only incidental here... irrelevant to the main subject but we don't want too many merge conflicts from concurrent updates to the top level README.)