### PR TITLE
CIP-1694 correction | Fix Rationale TOC for undefined Catalyst item

### DIFF
--- a/CIP-1694/README.md
+++ b/CIP-1694/README.md
@@ -815,7 +815,6 @@ We define a number of new terms related to voting stake:
 + [Reducing the power of entities with large amounts of Ada](#reducing-the-power-of-entities-with-large-amounts-of-ada)
 + [Piggybacking on stake pool stake distribution](#piggybacking-on-stake-pool-stake-distribution)
 + [Separation of hard-fork initiation from standard protocol parameter changes](#separation-of-hard-fork-initiation-from-standard-protocol-parameter-changes)
-+ [Treasury withdrawals vs Project Catalyst](#treasury-withdrawals-vs-project-catalyst)
 + [The purpose of the DReps](#the-purpose-of-the-dreps)
 + [Ratification requirements table](#ratification-requirements-table)
 + [Motion of no-confidence](#motion-of-no-confidence)


### PR DESCRIPTION
Found when reviewing translation in https://github.com/cardano-foundation/CIPs/pull/539.  Removes dead link in document since this subsection no longer exists.

Suggesting this item be simply be removed due to out-of-scoping as per://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md#off-chain-standards-for-governance-actions ... the alternative would be to reintroduce this subsection with a rationale affirming why it's out of scope.

cc @WhatisRT