### PR TITLE
CIP-1694 correction | Fix ledger spec links

### DIFF
--- a/CIP-1694/README.md
+++ b/CIP-1694/README.md
@@ -1189,16 +1189,16 @@ Nothing prevents money being taken out of the treasury other than the proposed v
 
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
 
-[^1]: A formal description of the current rules for governance actions is given in the [Shelley ledger specification](https://hydra.iohk.io/job/Cardano/cardano-ledger/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec).
+[^1]: A formal description of the current rules for governance actions is given in the [Shelley ledger specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf).
 
     - For protocol parameter changes (including hard forks), the `PPUP` transition rule (Figure 13) describes how protocol parameter updates are processed, and the `NEWPP` transition rule (Figure 43) describes how changes to protocol parameters are enacted.
 
     - For funds transfers, the `DELEG` transition rule (Figure 24) describes how MIR certificates are processed, and the `MIR` transition rule (Figure 55) describes how treasury and reserve movements are enacted.
 
     > **Note**
-    > The capabilities of the `MIR` transition rule were expanded in the [Alonzo ledger specification](https://hydra.iohk.io/job/Cardano/cardano-ledger/specs.alonzo-ledger/latest/download-by-type/doc-pdf/alonzo-changes)
+    > The capabilities of the `MIR` transition rule were expanded in the [Alonzo ledger specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/alonzo-ledger.pdf)
 
 
 [^2]: There are many varying definitions of the term "hard fork" in the blockchain industry. Hard forks typically refer to non-backwards compatible updates of a network. In Cardano, we formalize the definition slightly more by calling any upgrade that would lead to _more blocks_ being validated a "hard fork" and force nodes to comply with the new protocol version, effectively obsoleting nodes that are unable to handle the upgrade.
 
-[^3]: This is the definition used in "active stake" for stake delegation to stake pools, see Section 17.1, Total stake calculation, of the [Shelley ledger specification](https://hydra.iohk.io/job/Cardano/cardano-ledger/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec).
+[^3]: This is the definition used in "active stake" for stake delegation to stake pools, see Section 17.1, Total stake calculation, of the [Shelley ledger specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf).


### PR DESCRIPTION
Ledger GitHub repo [cardano-ledger](https://github.com/input-output-hk/cardano-ledger) was released while CIP-1694 was evolving; this corrects obsolete hydra based URLs as we have for https://github.com/cardano-foundation/CIPs/pull/487.

Not submitted with contemporary PR https://github.com/cardano-foundation/CIPs/pull/547 because the other one might require some consideration, while this is definitely a straightforward change that can be done immediately.

cc @WhatisRT