### PR TITLE
CIP-0013 | Generalise for further protocols

### DIFF
--- a/CIP-0013/README.md
+++ b/CIP-0013/README.md
@@ -4,9 +4,9 @@ Title: Cardano URI Scheme
 Status: Proposed
 Category: Wallets
 Authors:
+    - Robert Phair <rphair@cosd.com>
     - Sebastien Guillemot <sebastien@emurgo.io>
     - Vicente Almonacid <vicente@emurgo.io>
-    - Robert Phair <rphair@cosd.com>
 Implementors: N/A
 Discussions:
     - https://github.com/Emurgo/EmIPs/pull/2
@@ -15,15 +15,23 @@ Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/61
     - https://github.com/cardano-foundation/CIPs/pull/86
     - https://forum.cardano.org/t/cip-stake-uri-scheme-for-pools-delegation-portfolios/40594
+    - https://forum.cardano.org/t/cip-generalized-cardano-urls/57464
+    - https://github.com/cardano-foundation/CIPs/pull/546
 Created: 2020-09-22
 License: CC-BY-4.0
 ---
 
 ## Abstract
 
-This proposal describes a basic URI scheme to handle Ada transfers and links to single stake pools or weighted lists of multiple pools.
+This proposal describes a basic URI scheme with two specific protocols to handle Ada transfers and links to weighted lists of stake pools.
 
 ## Motivation: why is this CIP necessary?
+
+### In general:
+
+Developers of protocols that use URI schemes should be able to choose unique protcol keywords for how these links are handled by applications.
+
+Beyond the two earliest defined protocols below, protocols using distinct keywords (e.g. `//stake`) can be defined in other standards and CIPs and implemented without ambiguity by applications which interpret those particular URI protocols.
 
 ### For payment URIs:
 
@@ -49,54 +57,50 @@ URIs for weighted stake pool lists provide alternatives to using a JSON file to 
 
 The core implementation should follow the [BIP-21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) standard (with `bitcoin:` replaced with `web+cardano:`)
 
-Rationale:
-- Use `cardano:` over `ada:` as other projects that implement this standard tend to take the project name over the currency name (this makes sense if we consider this protocol as a generic way for interacting with the blockchain through wallets - as opposed to a simple payment system)
-- Many wallets support multiple currencies. Following the same standard will ensure higher adoption of our protocol.
-
 Examples:
 ```
 <a href="web+cardano:Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Donate</a>
 <a href="web+cardano://stake?c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
 <a href="web+cardano://stake?POOL1=3.14159&POOL2=2.71828">Split between our 2 related pools</a>
 <a href="web+cardano://stake?COSD">Choose our least saturated pool</a>
+<a href="web+cardano://stake?COSD">Choose our least saturated pool</a>
+<a href="web+cardano://claim/v1?faucet_url=https%3A%2F%2Fclaim.hosky.io&code=consensus2023">Claim $HOSKY</a>
 ```
 
-### Considerations
+The protocol term (e.g. `//stake`) is called the _authority_ as defined in [Wikipedia > Uniform Resource Identifier > Syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax).
 
-1. BIP-21 is limited to only features Bitcoin supports. A similar feature for Ethereum would, for example, also support gas as an extra parameter. BIP-21 is easily extensible but we have to take precaution to avoid different wallets having different implementations of these features as they become available on Cardano. To get an idea of some extra features that could be added, consider this (still under discussion) proposal for Ethereum: [EIP-681](https://eips.ethereum.org/EIPS/eip-681)
+### Considerations for URI scheme name
 
-2. Depending on the protocol registration method (see next section), browsers generally enforce a `web+` or `ext+` prefix for non-whitelisted protocols (note: `bitcoin:` was whitelisted; see [registerProtocolHandler > Permitted schemes](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler#permitted_schemes)). The prefix `ext+` is recommended for extensions, but not mandatory (see [protocol_handlers](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers)).
+`cardano:` is chosen over `ada:` because other projects that implement this standard tend to take the project name over the currency name (this makes sense if we consider this protocol as a generic way for interacting with the blockchain through wallets and dApps - as opposed to a simple payment system).
 
-### ABNF Grammar (Proposal)
+Depending on the protocol registration method (see next section), browsers generally enforce a `web+` or `ext+` prefix for non-whitelisted protocols (note: `bitcoin:` was whitelisted; see [registerProtocolHandler > Permitted schemes](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler#permitted_schemes)). The prefix `ext+` is recommended for extensions, but not mandatory (see [protocol_handlers](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers)).
 
-This is an initial, simplified protocol definition for fast implementation; it only requires:
+### Considerations for payment link query string
 
-* for a payment URI (authority unspecified), an address and an optional amount parameter;
-* for a stake pool URI (authority = `stake`), a weighted list of one or more stake pools.
+BIP-21 is limited to only features Bitcoin supports. A similar feature for Ethereum would, for example, also support gas as an extra parameter. BIP-21 is easily extensible but we have to take precaution to avoid different wallets having different implementations of these features as they become available on Cardano. To get an idea of some extra features that could be added, consider this (still under discussion) proposal for Ethereum: [EIP-681](https://eips.ethereum.org/EIPS/eip-681)
 
-As discussed above, these rules are likely to evolve in order to support other capabilities of the Cardano blockchain.
+### ABNF Grammar
+
+This protocol definition is mainly to allow switching to the particular protocol for each separately defined `authority, with a payment link being the "default":
+
+* When `authority` is unspecified, it is a payment URI (with an address and an optional amount parameter;
+* When `authority` is explicit (containing `//` followed by the authority keyword), it is defined in the `//stake` case below or in a separate CIP for that protocol.
 
 ```
-cardanourn = "web+cardano:" (paymentref | stakepoolref)
+cardanouri = "web+cardano:" (paymentref | authorityref)
 
 paymentref = cardanoaddress [ "?" amountparam ]
 cardanoaddress = *(base58 | bech32)
 amountparam = "amount=" *digit [ "." *digit ]
 
-stakepoolref = "//stake" stakequery
-stakequery = ( "?" stakepoolpair) *( "&" stakepoolpair)
-stakepoolpair = stakepool [ "=" proportion]
-
-stakepool = poolhexid | poolticker
-poolhexid = 56HEXDIG
-poolticker = 3*5UNICODE
-
-proportion = *digit [ "." *digit ]
+authorityref = (stakepoolref | otherref)
+otherref = "//" authority query
 ```
 
 For grammar reference, see:
 
   - [Wikipedia > Augmented Backus–Naur form](https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form)
+  - [RFC 2234: Augmented BNF for Syntax Specifications: ABNF](https://datatracker.ietf.org/doc/html/rfc2234)
   - [Unicode in ABNF](https://tools.ietf.org/html/draft-seantek-unicode-in-abnf-00)
 
 #### Payment URI queries
@@ -105,9 +109,17 @@ The amount parameter must follow the [same rules](https://github.com/bitcoin/bip
 
 #### Stake pool URI queries
 
-For brevity, essential in many Internet contexts, `poolticker`  must be supported here in addition to the unambiguous `poolhexid`.
+stakepoolref = "//stake" query
+query = ( "?" stakepoolpair) *( "&" stakepoolpair)
+stakepoolpair = stakepool [ "=" proportion]
 
-When there is more than one pool registered with any of the specified `poolticker` parameters (whether for pool groups which have the same ticker for all pools, or for separate pools using the same ticker), the choice to which pool(s) to finally delegate is left to the user through the wallet UI.
+stakepool = poolhexid | poolticker
+poolhexid = 56HEXDIG
+poolticker = 3*5UNICODE
+
+proportion = *digit [ "." *digit ]
+
+For brevity, essential in many Internet contexts, `poolticker`  must be supported here in addition to the unambiguous `poolhexid`.
 
 ##### Interpretation of `proportion`:
 
@@ -116,7 +128,13 @@ When there is more than one pool registered with any of the specified `poolticke
 * Any missing `proportion` is assigned a precise value of `1`.
 * If a stake pool is listed multiple times, the URI is rejected as invalid.
 
+### Other URI queries
+
+An ABNF grammar should be specified and explained similarly for each CIP that defines a new Cardano URI authority by explicitly defining the terms `authority` and `query` as for the "Stake pool" case above.
+
 ### Handling stake pool links
+
+When there is more than one pool registered with any of the specified `poolticker` parameters (whether for pool groups which have the same ticker for all pools, or for separate pools using the same ticker), the choice to which pool(s) to finally delegate is left to the user through the wallet UI.
 
 The wallet UI should always confirm the exact delegation choice even when it is unambiguous from the URI.  When the user has multiple wallets, the wallet UI must select which wallet(s) the user will be delegating from.
 
@@ -133,7 +151,7 @@ If, during a wallet or other application's development process, it is still only
 
 ## Rationale: how does this CIP achieve its goals?
 
-### Why not use Universal links, deep links or other non-protocol-based Solution?
+### For general URI scheme: Why not use Universal links, deep links or other non-protocol-based Solution?
 
 An alternative solution to the original problem described above is to use standard URL links in combination with a routing backend system. The routing system is used to redirect to the app's URI. The advantage of this scheme is that it allows to provide a fallback mechanism to handle the case when no application implementing the protocol is installed (for instance, by redirecting to the App Store or Google Play). This is the approach behind iOS Universal Links and Android App Links. In general, it provides a better user experience but requires a centralized system which makes it unsuitable for as a multi-app standard.
 
@@ -143,7 +161,7 @@ For background, see
   - [Apple Developer Docs > Defining a custom URL scheme for your app](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)
   - [React Native > Linking](https://reactnative.dev/docs/linking.html)
 
-### How URI delegation portfolio links supplement use of JSON files for the same purpose?
+### For stake pool links: How do URI delegation portfolio links supplement use of JSON files for the same purpose?
 
 URIs facilitate the "social element" of delegated staking and pool promotion through a socially familiar, easily accessible, and less centralised convention for sharing stake pool references and potential delegation portfolios without having to construct or host a JSON file.
 
@@ -159,18 +177,24 @@ For a CIP based on this principle, see [CIP-0017](https://github.com/cardano-fou
   - [x] Yoroi
 - [x] There exist one or more wallets supporting Stake Pool URIs.
   - [ ] TBD
+- [x] There exist other CIPs or drafts defining additional URI protocols.
+- [x] There exist one or more wallets supporting additional URI protocols.
+  - [ ] TBD
 
 ### Implementation Plan
 
-Survey contemporary wallet developers to suggest adoption of both feature sets, since they are likely to be considered separately:
+Encourage wallet and dApp developers to support initial protocols for all currently defined URI protocols, keeping in mind these are each likely to be considered separately:
 
 - Payment URIs
 - Stake Pool URIs
+- all other URI schemes defined in separate CIPs
 
-This survey can be conducted and/or advocated by either (ideally both):
+Education and advocacy about these standards should be done by:
 
+- Developers of applications and standards requiring new URI schemes
 - Cardano sponsoring companies
 - Community advocates
+- CIP editors
 
 ## Copyright
 

--- a/CIP-0013/README.md
+++ b/CIP-0013/README.md
@@ -63,7 +63,6 @@ Examples:
 <a href="web+cardano://stake?c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
 <a href="web+cardano://stake?POOL1=3.14159&POOL2=2.71828">Split between our 2 related pools</a>
 <a href="web+cardano://stake?COSD">Choose our least saturated pool</a>
-<a href="web+cardano://stake?COSD">Choose our least saturated pool</a>
 <a href="web+cardano://claim/v1?faucet_url=https%3A%2F%2Fclaim.hosky.io&code=consensus2023">Claim $HOSKY</a>
 ```
 


### PR DESCRIPTION
This change was considered in this forum thread (now added into `Discussions:` history) and deemed necessary for https://github.com/cardano-foundation/CIPs/pull/546.

It's a substantial rewrite but preserves the formatting & language for the Payment links and the additions for Stake Pool links which I added afterwards.

Notably it indicates that further extensions to the protocol (`//keyword` where the keyword is called an "authority" by URI convention) should be defined in further CIPs.  Although that may not be strictly adhered to by developers, I think that is a reasonable thing to require in _this_ CIP and for other CIPs which depend in any way on a URI scheme.

([formatted new version in branch](https://github.com/rphair/CIPs/blob/cip-0013-generalise-protocol/CIP-0013/README.md))