### PR TITLE
CIP-0093 | Update cross-CIP links to anchored relative paths

### DIFF
--- a/CIP-0093/README.md
+++ b/CIP-0093/README.md
@@ -18,7 +18,7 @@ The proposed Cardano Improvement Proposal (CIP) outlines a conventional structur
 
 ## Motivation
 
-The cardano wallets have the ability to sign arbitrary piece of data as we can see in the [Message signing CIP-0008](/CIP-0008/README.md). All wallets implement the method ```api.signData(addr: Address, payload: Bytes): Promise<DataSignature>``` defined in [Cardano dApp-Wallet Web Bridge CIP-0030](/CIP-0030/README.md).
+The cardano wallets have the ability to sign arbitrary piece of data as we can see in the [Message signing CIP-0008](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0008/README.md). All wallets implement the method ```api.signData(addr: Address, payload: Bytes): Promise<DataSignature>``` defined in [Cardano dApp-Wallet Web Bridge CIP-0030](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0030/README.md).
 
 dApps generate arbritary payloads as byte arrays. These payloads are signed and included in the protected headers of the signatures. The wallets are responsible for showing the payload data to the user, who will proceed to sign or reject the payload. It's a common practice to encode a string or a JSON string but there isn't any standard for the way to construct and to show this data.
 

--- a/CIP-0093/README.md
+++ b/CIP-0093/README.md
@@ -18,7 +18,7 @@ The proposed Cardano Improvement Proposal (CIP) outlines a conventional structur
 
 ## Motivation
 
-The cardano wallets have the ability to sign arbitrary piece of data as we can see in the [Message signing CIP-0008](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0008/README.md). All wallets implement the method ```api.signData(addr: Address, payload: Bytes): Promise<DataSignature>``` defined in [Cardano dApp-Wallet Web Bridge CIP-0030](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0030/README.md).
+The cardano wallets have the ability to sign arbitrary piece of data as we can see in the [Message signing CIP-0008](./CIP-0008/README.md). All wallets implement the method ```api.signData(addr: Address, payload: Bytes): Promise<DataSignature>``` defined in [Cardano dApp-Wallet Web Bridge CIP-0030](./CIP-0030/README.md).
 
 dApps generate arbritary payloads as byte arrays. These payloads are signed and included in the protected headers of the signatures. The wallets are responsible for showing the payload data to the user, who will proceed to sign or reject the payload. It's a common practice to encode a string or a JSON string but there isn't any standard for the way to construct and to show this data.
 


### PR DESCRIPTION
The same old thing, generally to fix builds of derived sites especially the Cardano Developer Portal (warnings generated below).  Hard to spot these in GitHub review, where relative paths between CIPs are valid.  Someday our site builders might correct for this, but for newcomers to this issue we resolved in the meantime to make all the cross-CIP URLs absolute.  cc @jmagan @katomm

---

```
[WARNING] Docs markdown link couldn't be resolved: (/CIP-0008/README.md) in "/home/rphair/archive/build/developer-portal/docs/governance/cardano-improvement-proposals/CIP-0093.md" for version current
[WARNING] Docs markdown link couldn't be resolved: (/CIP-0030/README.md) in "/home/rphair/archive/build/developer-portal/docs/governance/cardano-improvement-proposals/CIP-0093.md" for version current

[WARNING] Docusaurus found broken links! ...
- On source page path = /docs/governance/cardano-improvement-proposals/CIP-0093:
   -> linking to /CIP-0008/README.md
   -> linking to /CIP-0030/README.md
```