### PR TITLE
CIP-0030 | Encourage namespaced extension endpoints

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -210,6 +210,8 @@ api.cip123.endpoint2()
 
 Authors should be careful when omitting namespacing. Omission should only be considered when creating endpoints to override those defined in this specification or other extensions. Even so when overriding; the new functionality should not prevent dApps from accessing past functionality thus overriding must ensure backwards compatibility.
 
+Any namespace omission needs to be fully justified via the proposal's Rationale section, with explanation to why it is necessary. Any potential backwards compatibility considerations should be noted to give wallets and dApps a clear unambiguous direction.
+
 ##### Can extensions depend on other extensions?
 
 Yes. Extensions may have other extensions as pre-requisite. Some newer extensions may also invalidate functionality introduced by earlier extensions. There's no particular rule or constraints in that regards. Extensions are specified as CIP, and will define what it entails to enable them.
@@ -220,7 +222,7 @@ Yes. They all are CIPs.
 
 ##### Can extensions add their own endpoints and/or error codes?
 
-Yes. Extensions may introduce new endpoints or error codes, and modify existing ones. Extensions may even change the rules outlined in this very proposal. The idea being that wallet providers should start off implementing this CIP, and then walk their way to implementing their chosen extensions.
+Yes. Extensions may introduce new endpoints or error codes, and modify existing ones. Although, it is recommended that endpoints are namespaced. Extensions may even change the rules outlined in this very proposal. The idea being that wallet providers should start off implementing this CIP, and then walk their way to implementing their chosen extensions.
 
 ##### Are wallet expected to implement all extensions?
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -200,6 +200,12 @@ Upon start, dApp can explicitly request a list of additional functionalities the
 
 DApps are expected to use this endpoint to perform an initial handshake and ensure that the wallet supports all their required functionalities. Note that it's possible for two extensions to be mutually incompatible (because they provide two conflicting features). While we may try to avoid this as much as possible while designing CIPs, it is also the responsability of wallet providers to assess whether they can support a given combination of extensions, or not. Hence wallets aren't expected to fail should they not recognize or not support a particular combination of extensions. Instead, they should decide what they enable and reflect their choice in the `cardano.{walletName}.extensions` field of the Full API. As a result, dApps may fail and inform their users or may use a different, less-efficient, strategy to cope with a lack of functionality.
 
+Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object. For example; CIP-300's endpoints should be accessed by:
+
+```ts
+api.cip300.endpoint()
+```
+
 ##### Can extensions depend on other extensions?
 
 Yes. Extensions may have other extensions as pre-requisite. Some newer extensions may also invalidate functionality introduced by earlier extensions. There's no particular rule or constraints in that regards. Extensions are specified as CIP, and will define what it entails to enable them.
@@ -367,6 +373,10 @@ Extensions can be seen as a smart versioning scheme. Except that, instead of bei
 1. There are multiple concurrent standardization efforts on different fronts to accomodate a rapidly evolving ecosystem;
 2. Not everyone agrees and has desired to support every existing standard;
 3. There's a need from an API consumer standpoint to clearly identify what features are supported by providers.
+
+#### Namespacing Extension
+
+By explicitly namespacing each enabled extension we aim to improve the usability of extensions for dApps. This prevents possible polymorphism of extension endpoints, which should also improve complexity of wallet implementations.
 
 ## Path to Active
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -214,20 +214,7 @@ Any namespace omission needs to be fully justified via the proposal's Rationale 
 
 ##### Draft or Experimental Extensions
 
-Extensions that are draft, in development, or prototyped should not use extension naming nor should they use official namspacing.
-
-Draft [Extension](#extension)s should instead be referred to as `"x-cip"`, and their number can be arbitrary and should not be expected to be unique. `"x-cip"` numbers should NOT be used with overlap official CIP or draft CIP assignments unless they are the draft extension for the respective CIP. Extensions without an officially assigned CIP number *MUST* use negative numbers until their proposal is officially assigned a number by the CIP process. Namespacing should use the associated `.x-cip`.
-
-For example a extension author (without an assigned number) could use:
-```ts
-{ "x-cip": -123 }
-```
-with namespaced endpoints accessed by:
-```ts
-api.x-cip-123.endpoint1()
-api.x-cip-123.endpoint2()
-``` 
-When a CIP is ratified, the wallet may continue to recognize the `"x-cip"` extension. In this example, the finalized extension CIP that replaces the draft would be `{ "cip": 123 }`. This will allow for a graceful transition from draft to official status of extensions. How long a wallet or dApp will recognize the draft or experimental extension object is up to the individual wallet and dApp.
+Extensions that are draft, in development, or prototyped should not use extension naming nor should they use official namspacing until assigned a CIP number. Draft extension authors are free to test their implementation endpoints by using the [Experimental API](#experimental-api).
 
 ##### Can extensions depend on other extensions?
 
@@ -396,13 +383,6 @@ Extensions can be seen as a smart versioning scheme. Except that, instead of bei
 1. There are multiple concurrent standardization efforts on different fronts to accomodate a rapidly evolving ecosystem;
 2. Not everyone agrees and has desired to support every existing standard;
 3. There's a need from an API consumer standpoint to clearly identify what features are supported by providers.
-
-#### Draft Extensions
-
-The reason for using `"x-cip"` for drafts with an official number is to clearly distinguish between draft implementations and the official version. The official CIP can have differences from the final draft that both the dApp and wallet may need to accommodate. Avoiding using the official CIP extension until ratified disambiguates the draft process at the time of ratification.
-This clearly distinguishing between them prevents avoidable compatibility errors should the final draft and ratified CIP differ.
-
-If a wallet is requested to enable both the draft and ratified CIP, it should **ALWAYS** prefer the ratified CIP. For example, a wallet that supported both CIP-62 final and draft would only enable the final CIP-62 extension if the request was to enable `(extensions: {[{"x-cip":62}, {"cip":62}]})`.
 
 #### Namespacing Extensions
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -214,7 +214,7 @@ Any namespace omission needs to be fully justified via the proposal's Rationale 
 
 ##### Draft or Experimental Extensions
 
-Extensions that are draft, in development, or prototyped should not use extension naming nor should they use official namspacing until assigned a CIP number. Draft extension authors are free to test their implementation endpoints by using the [Experimental API](#experimental-api).
+Extensions that are draft, in development, or prototyped should not use extension naming nor should they use official namspacing until assigned a CIP number. Draft extension authors are free to test their implementation endpoints by using the [Experimental API](#experimental-api). Once a CIP number is assigned implementors should move functionality out of the experimental API.
 
 ##### Can extensions depend on other extensions?
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -200,10 +200,11 @@ Upon start, dApp can explicitly request a list of additional functionalities the
 
 DApps are expected to use this endpoint to perform an initial handshake and ensure that the wallet supports all their required functionalities. Note that it's possible for two extensions to be mutually incompatible (because they provide two conflicting features). While we may try to avoid this as much as possible while designing CIPs, it is also the responsability of wallet providers to assess whether they can support a given combination of extensions, or not. Hence wallets aren't expected to fail should they not recognize or not support a particular combination of extensions. Instead, they should decide what they enable and reflect their choice in the `cardano.{walletName}.extensions` field of the Full API. As a result, dApps may fail and inform their users or may use a different, less-efficient, strategy to cope with a lack of functionality.
 
-Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object. For example; CIP-300's endpoints should be accessed by:
+Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object. For example; CIP-1234's endpoints should be accessed by:
 
 ```ts
-api.cip300.endpoint()
+api.cip1234.endpoint1()
+api.cip1234.endpoint2()
 ```
 
 ##### Can extensions depend on other extensions?

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -212,6 +212,23 @@ Authors should be careful when omitting namespacing. Omission should only be con
 
 Any namespace omission needs to be fully justified via the proposal's Rationale section, with explanation to why it is necessary. Any potential backwards compatibility considerations should be noted to give wallets and dApps a clear unambiguous direction.
 
+##### Draft or Experimental Extensions
+
+Extensions that are draft, in development, or prototyped should not use extension naming nor should they use official namspacing.
+
+Draft [Extension](#extension)s should instead be referred to as `"x-cip"`, and their number can be arbitrary and should not be expected to be unique. `"x-cip"` numbers should NOT be used with overlap official CIP or draft CIP assignments unless they are the draft extension for the respective CIP. Extensions without an officially assigned CIP number *MUST* use negative numbers until their proposal is officially assigned a number by the CIP process. Namespacing should use the associated `.x-cip`.
+
+For example a extension author (without an assigned number) could use:
+```ts
+{ "x-cip": -123 }
+```
+with namespaced endpoints accessed by:
+```ts
+api.x-cip-123.endpoint1()
+api.x-cip-123.endpoint2()
+``` 
+When a CIP is ratified, the wallet may continue to recognize the `"x-cip"` extension. In this example, the finalized extension CIP that replaces the draft would be `{ "cip": 123 }`. This will allow for a graceful transition from draft to official status of extensions. How long a wallet or dApp will recognize the draft or experimental extension object is up to the individual wallet and dApp.
+
 ##### Can extensions depend on other extensions?
 
 Yes. Extensions may have other extensions as pre-requisite. Some newer extensions may also invalidate functionality introduced by earlier extensions. There's no particular rule or constraints in that regards. Extensions are specified as CIP, and will define what it entails to enable them.
@@ -380,7 +397,14 @@ Extensions can be seen as a smart versioning scheme. Except that, instead of bei
 2. Not everyone agrees and has desired to support every existing standard;
 3. There's a need from an API consumer standpoint to clearly identify what features are supported by providers.
 
-#### Namespacing Extension
+#### Draft Extensions
+
+The reason for using `"x-cip"` for drafts with an official number is to clearly distinguish between draft implementations and the official version. The official CIP can have differences from the final draft that both the dApp and wallet may need to accommodate. Avoiding using the official CIP extension until ratified disambiguates the draft process at the time of ratification.
+This clearly distinguishing between them prevents avoidable compatibility errors should the final draft and ratified CIP differ.
+
+If a wallet is requested to enable both the draft and ratified CIP, it should **ALWAYS** prefer the ratified CIP. For example, a wallet that supported both CIP-62 final and draft would only enable the final CIP-62 extension if the request was to enable `(extensions: {[{"x-cip":62}, {"cip":62}]})`.
+
+#### Namespacing Extensions
 
 By encouraging the explicit namespacing of each extension we aim to improve the usability of extensions for dApps. By allowing special cases where namespacing can be dropped we maintain good flexibility in extension design.
 

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -200,12 +200,15 @@ Upon start, dApp can explicitly request a list of additional functionalities the
 
 DApps are expected to use this endpoint to perform an initial handshake and ensure that the wallet supports all their required functionalities. Note that it's possible for two extensions to be mutually incompatible (because they provide two conflicting features). While we may try to avoid this as much as possible while designing CIPs, it is also the responsability of wallet providers to assess whether they can support a given combination of extensions, or not. Hence wallets aren't expected to fail should they not recognize or not support a particular combination of extensions. Instead, they should decide what they enable and reflect their choice in the `cardano.{walletName}.extensions` field of the Full API. As a result, dApps may fail and inform their users or may use a different, less-efficient, strategy to cope with a lack of functionality.
 
-Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object, without any leading zeros. For example; CIP-0123's endpoints should be accessed by:
+It is at the extension author's discretion if they wish to separate their endpoints from the base API via namespacing. Although, it is highly recommend that authors do namespace all of their extensions. If namespaced, endpoints must be preceded by `.cipXXXX.` from the `API` object, without any leading zeros.
 
+For example; CIP-0123's endpoints should be accessed by:
 ```ts
 api.cip123.endpoint1()
 api.cip123.endpoint2()
 ```
+
+Authors should be careful when omitting namespacing. Omission should only be considered when creating endpoints to override those defined in this specification or other extensions. Even so when overriding; the new functionality should not prevent dApps from accessing past functionality thus overriding must ensure backwards compatibility.
 
 ##### Can extensions depend on other extensions?
 
@@ -377,7 +380,7 @@ Extensions can be seen as a smart versioning scheme. Except that, instead of bei
 
 #### Namespacing Extension
 
-By explicitly namespacing each enabled extension we aim to improve the usability of extensions for dApps. This prevents possible polymorphism of extension endpoints, which should also improve complexity of wallet implementations.
+By encouraging the explicit namespacing of each extension we aim to improve the usability of extensions for dApps. By allowing special cases where namespacing can be dropped we maintain good flexibility in extension design.
 
 ## Path to Active
 
@@ -394,8 +397,8 @@ By explicitly namespacing each enabled extension we aim to improve the usability
 ### Implementation Plan
 
 - [x] Provide some reference implementation of wallet providers
-  - [Berry-Pool/nami-wallet](https://github.com/Berry-Pool/nami-wallet/blob/master/src/pages/Content/injected.js)
-  - [Emurgo/yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-ergo-connector/src/inject.js)
+  - [Berry-Pool/nami-wallet](https://github.com/berry-pool/nami/blob/4d7539b2768464480a9cff53a2d66af9879f8534/src/pages/Content/injected.js)
+  - [Emurgo/yoroi-wallet](https://github.com/Emurgo/yoroi-frontend/blob/f4eabb25eedd564821514059479835601f8073ab/packages/yoroi-connector/example-cardano/index.js)
 
 - [x] Provide some reference implementation of the dapp connector
   - [cardano-foundation/connect-with-wallet](https://github.com/cardano-foundation/cardano-connect-with-wallet)

--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -200,11 +200,11 @@ Upon start, dApp can explicitly request a list of additional functionalities the
 
 DApps are expected to use this endpoint to perform an initial handshake and ensure that the wallet supports all their required functionalities. Note that it's possible for two extensions to be mutually incompatible (because they provide two conflicting features). While we may try to avoid this as much as possible while designing CIPs, it is also the responsability of wallet providers to assess whether they can support a given combination of extensions, or not. Hence wallets aren't expected to fail should they not recognize or not support a particular combination of extensions. Instead, they should decide what they enable and reflect their choice in the `cardano.{walletName}.extensions` field of the Full API. As a result, dApps may fail and inform their users or may use a different, less-efficient, strategy to cope with a lack of functionality.
 
-Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object. For example; CIP-1234's endpoints should be accessed by:
+Extension's endpoints should be namespaced by `.cipXXXX.` with the returned `API` object, without any leading zeros. For example; CIP-0123's endpoints should be accessed by:
 
 ```ts
-api.cip1234.endpoint1()
-api.cip1234.endpoint2()
+api.cip123.endpoint1()
+api.cip123.endpoint2()
 ```
 
 ##### Can extensions depend on other extensions?


### PR DESCRIPTION
### Change
- Encourage that extension endpoints are explicitly namespaced by their cip/extension name.
example: `api.cip95.getPubDRepKey()`

### Motivation
I believe this is a sensible change to make ahead of the emergence of CIP-30 extensions, such as https://github.com/cardano-foundation/CIPs/pull/509.

- This prevents extensions from creating conflicting endpoints with the same naming.
- This should help simplify wallet implementations, by allowing easier routing of requests.
- This should simplify extension management for dApps.

---

Thanks @stevenj and @refi93 for the suggestion.