### PR TITLE
CIP-0001 | Allow ISO date if translation source uncommitted

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -158,7 +158,7 @@ Field          | Description
 `CIP`          | The CIP number (without leading 0)
 `Source`       | The canonical GitHub link to the original CIP document
 `Title`        | A translation of the CIP's title
-`Revision`     | The commit hash (8-10 first hex-digits) of the source (e.g. `12ab34cd`)
+`Revision`     | Whenever possible, the commit hash (7 first hex-digits, e.g. `12ab34c`) of the source in the main repository. If the source was not committed to the main repo, use the best known translation date in ISO format (if unknown, use the date posted in the translation's PR branch).
 `Translators`  | A list of translators names and email addresses (e.g. `John Doe <john.doe@email.domain>`)
 `Language`     | An [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code of the target language (e.g. `fr`)
 


### PR DESCRIPTION
Motivation and method already discussed at CIP meeting with characteristic example still pending merge in https://github.com/cardano-foundation/CIPs/pull/582.

One side effect of this PR: original language said to use a 8-10 digit commit hash, while the GitHub histories contain only 7-digit commit hashes.  As already identified in https://github.com/cardano-foundation/CIPs/pull/539#pullrequestreview-1514656299, searches for longer hashes on the GitHub history page will fail if longer hashes are used, making the hashes more difficult in general to verify.