### PR TITLE
CIP-0054 | Fix API headers for markdown portability

### DIFF
--- a/CIP-0054/README.md
+++ b/CIP-0054/README.md
@@ -160,11 +160,11 @@ It is recommended that the Smart NFT API not be injected for every NFT – only 
 Although an asynchronous API is specified – so the data could be retrieved at the time when the NFT actually requests it – it is expected that in most instances the site which renders the NFT would gather the relevant transaction logs in advance, and inject them into the `<iframe>` sandbox at the point where the sandbox is created, so that the data is immediately available to the NFT without having to
 perform an HTTP request. 
 
-### cardano.nft.fingerprint: String
+### `cardano.nft.fingerprint: String`
 
 The fingerprint of the current token - in the case where we're rendering a child token, this will be the fingerprint of the child token. 
 
-### cardano.nft.metadata : Array
+### `cardano.nft.metadata : Array`
  
 The content of the 721 key from the metadata json from the mint transaction of the current NFT - if we are rendering on behalf of a child NFT, this will be the metadata from the child NFT.
 

--- a/CIP-0054/README.md
+++ b/CIP-0054/README.md
@@ -215,7 +215,7 @@ This function will return a list of the tokens held by the address specified in 
 }
 ```
 
-### cardano.nft.getFileURL( string id = null, string fingerprint = null ) : Promise&lt;String>
+### `cardano.nft.getFileURL( string id = null, string fingerprint = null ) : Promise<String>`
 
 Errors: `APIError`
 

--- a/CIP-0054/README.md
+++ b/CIP-0054/README.md
@@ -191,7 +191,7 @@ This function will return a list of transaction hashes and metadata relating to 
 ```
 For simplicity, we do not include anything other than the txHash and the metadata – since any other relevant details about the transaction can always be encoded into the metadata, there is no need to over-complicate by including other transaction data like inputs, outputs or the date of the transaction etc. That is left for a potential future extension of the API to include more full GraphQL support.
 
-### cardano.nft.getTokens( string address, paginate: Paginate = undefined ) : Promise&lt;Object>
+### `cardano.nft.getTokens( string address, paginate: Paginate = undefined ) : Promise<Object>`
 
 Errors: `APIError`, `PaginateError`
 

--- a/CIP-0054/README.md
+++ b/CIP-0054/README.md
@@ -168,7 +168,7 @@ The fingerprint of the current token - in the case where we're rendering a child
  
 The content of the 721 key from the metadata json from the mint transaction of the current NFT - if we are rendering on behalf of a child NFT, this will be the metadata from the child NFT.
 
-### cardano.nft.getTransactions( string which,  paginate: Paginate = undefined ) : Promise\<Object>
+### cardano.nft.getTransactions( string which,  paginate: Paginate = undefined ) : Promise&lt;Object>
 
 Errors: `APIError`, `PaginateError`
 
@@ -191,7 +191,7 @@ This function will return a list of transaction hashes and metadata relating to 
 ```
 For simplicity, we do not include anything other than the txHash and the metadata – since any other relevant details about the transaction can always be encoded into the metadata, there is no need to over-complicate by including other transaction data like inputs, outputs or the date of the transaction etc. That is left for a potential future extension of the API to include more full GraphQL support.
 
-### cardano.nft.getTokens( string address, paginate: Paginate = undefined ) : Promise\<Object>
+### cardano.nft.getTokens( string address, paginate: Paginate = undefined ) : Promise&lt;Object>
 
 Errors: `APIError`, `PaginateError`
 
@@ -215,7 +215,7 @@ This function will return a list of the tokens held by the address specified in 
 }
 ```
 
-### cardano.nft.getFileURL( string id = null, string fingerprint = null ) : Promise\<String>
+### cardano.nft.getFileURL( string id = null, string fingerprint = null ) : Promise&lt;String>
 
 Errors: `APIError`
 

--- a/CIP-0054/README.md
+++ b/CIP-0054/README.md
@@ -168,7 +168,7 @@ The fingerprint of the current token - in the case where we're rendering a child
  
 The content of the 721 key from the metadata json from the mint transaction of the current NFT - if we are rendering on behalf of a child NFT, this will be the metadata from the child NFT.
 
-### cardano.nft.getTransactions( string which,  paginate: Paginate = undefined ) : Promise&lt;Object>
+### `cardano.nft.getTransactions( string which,  paginate: Paginate = undefined ) : Promise<Object>`
 
 Errors: `APIError`, `PaginateError`
 


### PR DESCRIPTION
`\<` is supported by GitHub to escape HTML but not part of Markdown spec and not supported by showdown, breaking CIP-0054 rendering on https://cips.cardano.org/:
![image](https://github.com/cardano-foundation/CIPs/assets/66848001/7f4b1a65-fd25-47d1-9596-ff8a59c62a04)

By escaping instead the opening angle bracket with `&lt;`, both GitHub and showdown rendering work correctly:
![image](https://github.com/cardano-foundation/CIPs/assets/66848001/75bd041b-325d-49e5-b87e-4677d530eb0c)

GitHub rendering:
https://github.com/SmaugPool/CIPs/tree/cip54-fix-rendering/CIP-0054

FYI: @kieransimkin