### PR TITLE
CIP-0025 | Change "NFT" to "token"

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -25,7 +25,7 @@
   },
   {
     "transaction_metadatum_label": 721,
-    "description": "CIP-0025 - NFT Metadata Standard"
+    "description": "CIP-0025 - NFT Token Standard"
   },
   {
     "transaction_metadatum_label": 777,

--- a/CIP-0025/README.md
+++ b/CIP-0025/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 25
-Title: Media NFT Metadata Standard
+Title: Media Token Metadata Standard
 Authors: Alessandro Konrad <alessandro.konrad@live.de>, Smaug <smaug@pool.pm>
 Comments-URI:
 Status: Active
@@ -12,7 +12,7 @@ License: CC-BY-4.0
 
 ## Abstract
 
-This proposal defines an Media NFT Metadata Standard for Native Tokens.
+This proposal defines an Media Token Metadata Standard for Native Tokens.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ This is the registered `transaction_metadatum_label` value
 
 | transaction_metadatum_label | description  |
 | --------------------------- | ------------ |
-| 721                         | NFT Metadata |
+| 721                         | Token Metadata |
 
 ### General structure
 
@@ -79,8 +79,8 @@ The structure allows for multiple token mints, also with different policies, in 
 - In version `1` the **`policy_id`** must be in text format for the key in the metadata map. In version `2` the the raw bytes of the **`policy_id`** are used.
 
 - The  **`name`** property is marked as required.
-- The **`image`** property is required and must be a valid [Uniform Resource Identifier (URI)](https://www.rfc-editor.org/rfc/rfc3986) pointing to a resource with mime type `image/*`.  Note that this resource is used as thumbnail or the actual link if the NFT is an image (ideally <= 1MB). If the string representing the resource location is >64 characters, an array may be used in place of a simple JSON string type, which viewers will automatically concatenate to create a single URI.
-	- Please note that if distributed storage systems like IPFS or Arweave are used it is required to use a URI containing the respective scheme (e.g., `ipfs://` or `ar://`) and not merely the content identifier (CID) as NFT viewers may not be able to locate the file.
+- The **`image`** property is required and must be a valid [Uniform Resource Identifier (URI)](https://www.rfc-editor.org/rfc/rfc3986) pointing to a resource with mime type `image/*`.  Note that this resource is used as thumbnail or the actual link if the token is an image (ideally <= 1MB). If the string representing the resource location is >64 characters, an array may be used in place of a simple JSON string type, which viewers will automatically concatenate to create a single URI.
+	- Please note that if distributed storage systems like IPFS or Arweave are used it is required to use a URI containing the respective scheme (e.g., `ipfs://` or `ar://`) and not merely the content identifier (CID) as token viewers may not be able to locate the file.
 		- Valid identifiers would include:
 			- `"https://cardano.org/favicon-32x32.png"`
 			- `"ipfs://QmbQDvKJeo2NgGcGdnUiUFibTzuKNK5Uij7jzmK8ZccmWp"`
@@ -153,7 +153,7 @@ Since modern token policies or ledger rules should generally make burning of tok
 
 ## Backward Compatibility
 
-To keep NFT metadata compatible with changes coming up in the future, we use the **`version`** property.
+To keep token metadata compatible with changes coming up in the future, we use the **`version`** property.
 A future version will introduce [schema.org](https://schema.org).
 
 ## References

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 0022 | [Pool operator verification](./CIP-0022/) | Active |
 | 0023 | [Fair Min Fees](./CIP-0023/) | Proposed |
 | 0024 | [Non-Centralizing Rankings](./CIP-0024/) | Proposed |
-| 0025 | [Media NFT Metadata Standard](./CIP-0025/) | Active |
+| 0025 | [Media Token Metadata Standard](./CIP-0025/) | Active |
 | 0026 | [Cardano Off-Chain Metadata](./CIP-0026/) | Draft |
 | 0027 | [CNFT Community Royalties Standard](./CIP-0027/) | Draft |
 | 0028 | [Protocol Parameters (Alonzo Era)](./CIP-0028/) | Active |


### PR DESCRIPTION
As we have standardized the use of fungible tokens for media/collectible tokens (ie: art editions & book copies), we need to avoid using "NFT" as a blanket term in CIP documentation as it can create confusion around whether a CIP includes these other token variants.