### PR TITLE
CIP-0030 | Fix API headers for markdown portability

### DIFF
--- a/CIP-0030/README.md
+++ b/CIP-0030/README.md
@@ -54,7 +54,7 @@ A string representing an address in either bech32 format, or hex-encoded bytes. 
 
 A hex-encoded string of the corresponding bytes.
 
-#### cbor\<T>
+#### `cbor<T>`
 
 A hex-encoded string representing [CBOR](https://tools.ietf.org/html/rfc7049) corresponding to `T` defined via [CDDL](https://tools.ietf.org/html/rfc8610) either inside of the [Shelley Multi-asset binary spec](https://github.com/input-output-hk/cardano-ledger-specs/blob/0738804155245062f05e2f355fadd1d16f04cd56/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl) or, if not present there, from the [CIP-0008 signing spec](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0008/README.md).
 This representation was chosen when possible as it is consistent across the Cardano ecosystem and widely used by other tools, such as [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib), which has support to encode every type in the binary spec as CBOR bytes.
@@ -63,8 +63,8 @@ This representation was chosen when possible as it is consistent across the Card
 
 ```ts
 type DataSignature = {|
-  signature: cbor\<COSE_Sign1>,
-  key: cbor\<COSE_Key>,
+  signature: cbor<COSE_Sign1>,
+  key: cbor<COSE_Key>,
 |};
 ```
 
@@ -190,7 +190,7 @@ type TxSignError = {
 
 In order to initiate communication from webpages to a user's Cardano wallet, the wallet must provide the following javascript API to the webpage. A shared, namespaced `cardano` object must be injected into the page if it did not exist already. Each wallet implementing this standard must then create a field in this object with a name unique to each wallet containing a `wallet` object with the following methods. The API is split into two stages to maintain the user's privacy, as the user will have to consent to `cardano.{walletName}.enable()` in order for the dApp to read any information pertaining to the user's wallet with `{walletName}` corresponding to the wallet's namespaced name of its choice.
 
-#### cardano.{walletName}.enable({ extensions: Extension[] } = {}): Promise\<API>
+#### `cardano.{walletName}.enable({ extensions: Extension[] } = {}): Promise<API>`
 
 Errors: `APIError`
 
@@ -233,25 +233,25 @@ Yes. Extensions may introduce new endpoints or error codes, and modify existing 
 No. It's up to wallet providers to decide which extensions they ought to support.
 
 
-#### cardano.{walletName}.isEnabled(): Promise\<bool>
+#### `cardano.{walletName}.isEnabled(): Promise<bool>`
 
 Errors: `APIError`
 
 Returns true if the dApp is already connected to the user's wallet, or if requesting access would return true without user confirmation (e.g. the dApp is whitelisted), and false otherwise. If this function returns true, then any subsequent calls to `wallet.enable()` during the current session should succeed and return the `API` object.
 
-#### cardano.{walletName}.apiVersion: String
+#### `cardano.{walletName}.apiVersion: String`
 
 The version number of the API that the wallet supports. Set to `1`.
 
-#### cardano.{walletName}.supportedExtensions: Extension[]
+#### `cardano.{walletName}.supportedExtensions: Extension[]`
 
 A list of extensions supported by the wallet. Extensions may be requested by dApps on initialization. Some extensions may be mutually conflicting and this list does not thereby reflect what extensions will be enabled by the wallet. Yet it informs on what extensions are known and can be requested by dApps if needed.
 
-#### cardano.{walletName}.name: String
+#### `cardano.{walletName}.name: String`
 
 A name for the wallet which can be used inside of the dApp for the purpose of asking the user which wallet they would like to connect with.
 
-#### cardano.{walletName}.icon: String
+#### `cardano.{walletName}.icon: String`
 
 A URI image (e.g. data URI base64 or other) for img src for the wallet which can be used inside of the dApp for the purpose of asking the user which wallet they would like to connect with.
 
@@ -261,25 +261,25 @@ Upon successful connection via `cardano.{walletName}.enable()`, a javascript obj
 
 The API chosen here is for the minimum API necessary for dApp <-> Wallet interactions without convenience functions that don't strictly need the wallet's state to work. The API here is for now also only designed for Shelley's Mary hardfork and thus has NFT support. When Alonzo is released with Plutus support this API will have to be extended.
 
-#### api.getExtensions(): Promise\<Extension[]>
+#### `api.getExtensions(): Promise<Extension[]>`
 
 Errors: `APIError`
 
 Retrieves the list of extensions enabled by the wallet. This may be influenced by the set of extensions requested in the initial `enable` request.
 
-#### api.getNetworkId(): Promise\<number>
+#### `api.getNetworkId(): Promise<number>`
 
 Errors: `APIError`
 
 Returns the network id of the currently connected account. 0 is testnet and 1 is mainnet but other networks can possibly be returned by wallets. Those other network ID values are not governed by this document. This result will stay the same unless the connected account has changed.
 
-#### api.getUtxos(amount: cbor\<value> = undefined, paginate: Paginate = undefined): Promise\<TransactionUnspentOutput[] | null>
+#### `api.getUtxos(amount: cbor<value> = undefined, paginate: Paginate = undefined): Promise<TransactionUnspentOutput[] | null>`
 
 Errors: `APIError`, `PaginateError`
 
 If `amount` is `undefined`, this shall return a list of all UTXOs (unspent transaction outputs) controlled by the wallet. If `amount` is not `undefined`, this request shall be limited to just the UTXOs that are required to reach the combined ADA/multiasset value target specified in `amount`, and if this cannot be attained, `null` shall be returned. The results can be further paginated by `paginate` if it is not `undefined`.
 
-#### api.getCollateral(params: { amount: cbor\<Coin> }): Promise\<TransactionUnspentOutput[] | null>
+#### `api.getCollateral(params: { amount: cbor<Coin> }): Promise<TransactionUnspentOutput[] | null>`
 
 Errors: `APIError`
 
@@ -296,43 +296,43 @@ The main point is to allow the wallet to encapsulate all the logic required to h
 
 The `amount` parameter is required, specified as a `string` (BigNumber) or a `number`, and the maximum allowed value must be agreed to be something like 5 ADA. Not limiting the maximum possible value might force the wallet to attempt to purify an unreasonable amount of ADA just because the dapp is doing something weird. Since by protocol the required collateral amount is always a percentage of the transaction fee, it seems that the 5 ADA limit should be enough for the foreseeable future.
 
-#### api.getBalance(): Promise\<cbor\<value>>
+#### `api.getBalance(): Promise<cbor<value>>`
 
 Errors: `APIError`
 
 Returns the total balance available of the wallet. This is the same as summing the results of `api.getUtxos()`, but it is both useful to dApps and likely already maintained by the implementing wallet in a more efficient manner so it has been included in the API as well.
 
-#### api.getUsedAddresses(paginate: Paginate = undefined): Promise\<Address[]>
+#### `api.getUsedAddresses(paginate: Paginate = undefined): Promise<Address[]>`
 
 Errors: `APIError`
 
 Returns a list of all used (included in some on-chain transaction) addresses controlled by the wallet. The results can be further paginated by `paginate` if it is not `undefined`.
 
-#### api.getUnusedAddresses(): Promise\<Address[]>
+#### `api.getUnusedAddresses(): Promise<Address[]>`
 
 Errors: `APIError`
 
 Returns a list of unused addresses controlled by the wallet.
 
-#### api.getChangeAddress(): Promise\<Address>
+#### `api.getChangeAddress(): Promise<Address>`
 
 Errors: `APIError`
 
 Returns an address owned by the wallet that should be used as a change address to return leftover assets during transaction creation back to the connected wallet. This can be used as a generic receive address as well.
 
-#### api.getRewardAddresses(): Promise\<Address[]>
+#### `api.getRewardAddresses(): Promise<Address[]>`
 
 Errors: `APIError`
 
 Returns the reward addresses owned by the wallet. This can return multiple addresses e.g. CIP-0018.
 
-#### api.signTx(tx: cbor\<transaction>, partialSign: bool = false): Promise\<cbor\<transaction_witness_set>>
+#### `api.signTx(tx: cbor<transaction>, partialSign: bool = false): Promise<cbor<transaction_witness_set>>`
 
 Errors: `APIError`, `TxSignError`
 
 Requests that a user sign the unsigned portions of the supplied transaction. The wallet should ask the user for permission, and if given, try to sign the supplied body and return a signed transaction. If `partialSign` is true, the wallet only tries to sign what it can. If `partialSign` is false and the wallet could not sign the entire transaction, `TxSignError` shall be returned with the `ProofGeneration` code. Likewise if the user declined in either case it shall return the `UserDeclined` code. Only the portions of the witness set that were signed as a result of this call are returned to encourage dApps to verify the contents returned by this endpoint while building the final transaction.
 
-#### api.signData(addr: Address, payload: Bytes): Promise\<DataSignature>
+#### `api.signData(addr: Address, payload: Bytes): Promise<DataSignature>`
 
 Errors: `APIError`, `DataSignError`
 
@@ -352,7 +352,7 @@ If the payment key for `addr` is not a P2Pk address then `DataSignError` will be
 * `crv` (-1) - must be set to `Ed25519` (6)
 * `x` (-2) - must be set to the public key bytes of the key used to sign the `Sig_structure`
 
-#### api.submitTx(tx: cbor\<transaction>): Promise\<hash32>
+#### `api.submitTx(tx: cbor<transaction>): Promise<hash32>`
 
 Errors: `APIError`, `TxSendError`
 


### PR DESCRIPTION
Recognised in https://github.com/cardano-foundation/CIPs/pull/591#issuecomment-1712917686 (cc @SmaugPool) and cleaned up here since running this code through Showdown in site builders causes text inside angle brackets beginning `\<` to be dropped unless quoted literally in Markdown (as code would be).

To avoid too many unnecessary changes, I've only applied this change to the [API section](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030#initial-api) and not the preceding error types or data types.  Perhaps for functional & aesthetic considerations other reviewers might think these literals should also be quoted as code. 🤔 cc @rooooooooob

 - NOTE data type `cbor<T>` suffers the same problem I've also quoted it as code.
 - @Ryun1 @Crypto2099 @SebastienGllmt please look at the code segment in that section where I've also removed the quote back-slashes, which also truncate the code in Showdown and don't look right to me as code in the first place (?).  If the back-slashes _are_ necessary in the code, maybe we can find a portable way of putting them back in. 😵‍💫

What we're mainly trying to achieve is the correct appearance of this page on the Dev Portal (cc @katomm), which currently has sections of code in many of the API section headers truncated (cc @KtorZ): https://developers.cardano.org/docs/governance/cardano-improvement-proposals/CIP-0030

---

([how it renders with the changes in this branch](https://github.com/rphair/CIPs/blob/cip-0030-quote-code-in-headings/CIP-0030/README.md))