### PR TITLE
CIP-0010 | Add proof of origin metadata label

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -56,6 +56,10 @@
     "description": "amphitheatre by the ape society"
   },
   {
+    "transaction_metadatum_label": 1904,
+    "description": "Proof of origin and quality related verification data in supply chain"
+  },
+  {
     "transaction_metadatum_label": 1967,
     "description": "nut.link metadata oracles registry"
   },


### PR DESCRIPTION
We would like to register a new metadata label `1904` reserved for proof of origin and quality control in the supply chain space. The first use case is our [pilot project](https://cardanofoundation.org/en/news/cardano-foundation-partners-with-georgian-national-wine-agency/) at the Cardano Foundation with the National Wine Agency of Georgia.

We have prepared a specification which should hopefully become its own CIP but is still internally under final review. We would like to for now reserve this label and later update the description to point to the CIP.

The standard aims to cover proof of origin (see some initial documentation on the metadata [here](https://cardano-foundation.github.io/cf-georgian-wine-resolver/)) and quality control through Certificates of Conformity (documentation pending). The upcoming CIP intends to cover a broader set of use cases than just Georgian wine.