### PR TITLE
CIP-0027 | Adjust preamble and structure w.r.t CIP-0001

### DIFF
--- a/CIP-0027/README.md
+++ b/CIP-0027/README.md
@@ -6,7 +6,7 @@ Category: Tokens
 Authors:
   - Huth S0lo <john@digitalsyndicate.io>
   - TheRealAdamDean <adam@crypto2099.io>
-Implementors: NA
+Implementors: N/A
 Discussions:
   - https://forum.cardano.org/t/cip-royalties/68599
   - https://github.com/cardano-foundation/CIPs/pull/116

--- a/CIP-0027/README.md
+++ b/CIP-0027/README.md
@@ -1,25 +1,28 @@
 ---
 CIP: 27
 Title: CNFT Community Royalties Standard
-Authors: Huth S0lo <john@digitalsyndicate.io>, TheRealAdamDean <adam@crypto2099.io>
-Comments-URI: https://forum.cardano.org/t/cip-royalties/68599
 Status: Active
-Type: Informational
+Category: Tokens
+Authors:
+  - Huth S0lo <john@digitalsyndicate.io>
+  - TheRealAdamDean <adam@crypto2099.io>
+Implementors: NA
+Discussions:
+  - https://forum.cardano.org/t/cip-royalties/68599
+  - https://github.com/cardano-foundation/CIPs/pull/116
 Created: 2021-08-29
 License: Apache-2.0
 ---
 
-## Simple Summary
-
-A community standard for royalties&#39; functionality, that does not require smart contracts to implement.
-
 ## Abstract
 
-This proposed standard will allow for uniform royalties&#39; distributions across the secondary market space. It is easy to implement using metadata only, and does not require a smart contract.  However, it is scalable to allow for the usage of a downstream smart contract, as needed by the asset creator. It has been developed with input from Artano, BuffyBot, CNFT.io, Digital Syndicate, Fencemaker, MADinArt, NFT-Maker.io, Hydrun, Tokhun, and many more.
+This proposed standard will allow for uniform royalties' distributions across the secondary market space. It is easy to implement using metadata only, and does not require a smart contract.  However, it is scalable to allow for the usage of a downstream smart contract, as needed by the asset creator.
 
-## Motivation
+## Motivation: why is this CIP necessary?
 
-There is a significant interest within the Cardano Community for an implementation of royalties distribution when a Cardano Asset is resold on the secondary market. It has become a common theme to see and hear statements that the only thing stopping artists from adopting Cardano, is that they are waiting for an implementation of royalties.  At the present time, smart contracts do not create a simple mechanism to implement royalties.  By developing a community standard, we can resolve the immediate need for royalties, and create a path forward for a potential future iteration of smart contracts.
+There is a significant interest within the Cardano Community for an implementation of royalties distribution when a Cardano Asset is resold on the secondary market. It has become a common theme to see and hear statements that the only thing stopping artists from adopting Cardano, is that they are waiting for an implementation of royalties.
+
+At the present time, smart contracts do not create a simple mechanism to implement royalties.  By developing a community standard, we can resolve the immediate need for royalties, and create a path forward for a potential future iteration of smart contracts.
 
 ## Specification
 
@@ -32,7 +35,7 @@ A new tag of 777 is proposed for this implementation.  The community guidelines 
 6) The "addr" key tag can be a string value, or an array.  It is to include a single payment address.  By allowing for an array, the payment address can exceed the per line 64 character limitation.  This payment address could be part of a smart contract, which should allow for greater flexibility of royalties distributions, controlled by the asset creator.
 7) The royalty token must be minted prior to creating any assets off the policy.  All markets will be instructed to look only for the first minted asset on a policy, which would need to be the unnamed 777 token.
 
-## Example JSON with string
+### Example JSON with string
 
 {
 	"777": {
@@ -41,7 +44,7 @@ A new tag of 777 is proposed for this implementation.  The community guidelines 
 	}
 }
 
-## Example JSON with array
+### Example JSON with array
 
 {
 	"777": {
@@ -53,27 +56,44 @@ A new tag of 777 is proposed for this implementation.  The community guidelines 
 	}
 }
 
-## Process Flow
+### Process Flow
+
 1) Create policy for planned assets.
 2) Mint no name token with community standard royalties metadata.
 3) Burn no name token to free up UTxO (recommended, but not required).
 4) Mint planned assets using this same policy.
 
-## Rationale
+## Rationale: how does this CIP achieve its goals?
 
-By creating a new tag for the distinct purpose of royalties distributions, Cardano Asset makers, and Marketplaces can uniformly apply royalties to assets with predictable results.  By creating the instructions on a single, no name token, all marketplaces will know the correct location of the royalties asset, without having to further locate it.  By enforcing the requirement of honoring only the first mint, cardano asset buyers and owners can predict the future resale value of the assets in their possession.  The solution is scalable to any desired royalty percentage.  It is easy to work with this new standard, and does not require an in depth understanding of smart contracts.
+By creating a new tag for the distinct purpose of royalties distributions, Cardano Asset makers, and Marketplaces can uniformly apply royalties to assets with predictable results.
 
-## Change Log
+By creating the instructions on a single, no name token, all marketplaces will know the correct location of the royalties asset, without having to further locate it.
 
-## Initial proposal - August 14th, 2021
-## Revised proposal - August 28th, 2021
-## Minor Revision - August 31st, 2011
-## Minor Revision - September 27th, 2021
-## Minor Revision - November 8th, 2021
-## Minor Revision - December 30th, 2021
-- Change CIP Type from Standards to Informational
-- Change CIP Status from Draft to Active
+By enforcing the requirement of honoring only the first mint, cardano asset buyers and owners can predict the future resale value of the assets in their possession.
 
-Copyright
+The solution is scalable to any desired royalty percentage.  It is easy to work with this new standard, and does not require an in depth understanding of smart contracts.
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+## Path to Active
+
+### Acceptance Criteria
+
+- [x] Support of this standard by multiple significant NFT related platforms.
+- [x] Implementation in libraries supporting NFT minting, including:
+  - [x] Mesh [Minting Royalty Token](https://meshjs.dev/apis/transaction/minting#mintingRoyaltyToken)
+
+### Implementation Plan
+
+- [x] Incorporate input from many Cardano NFT related entiries, including:
+  - [x] Artano
+  - [x] BuffyBot
+  - [x] CNFT.io
+  - [x] Digital Syndicate
+  - [x] Fencemaker
+  - [x] MADinArt
+  - [x] NFT-Maker.io
+  - [x] Hydrun
+  - [x] Tokhun
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CIP-0027/README.md
+++ b/CIP-0027/README.md
@@ -77,13 +77,13 @@ The solution is scalable to any desired royalty percentage.  It is easy to work 
 
 ### Acceptance Criteria
 
-- [x] Support of this standard by multiple significant NFT related platforms.
+- [x] Support of royalty distribution according to this standard by multiple significant NFT related platforms.
 - [x] Implementation in libraries supporting NFT minting, including:
   - [x] Mesh ([Minting Royalty Token](https://meshjs.dev/apis/transaction/minting#mintingRoyaltyToken))
 
 ### Implementation Plan
 
-- [x] Incorporate input from many Cardano NFT related entiries, including:
+- [x] Incorporate input from many Cardano NFT related entities, including:
   - [x] Artano
   - [x] BuffyBot
   - [x] CNFT.io

--- a/CIP-0027/README.md
+++ b/CIP-0027/README.md
@@ -79,7 +79,7 @@ The solution is scalable to any desired royalty percentage.  It is easy to work 
 
 - [x] Support of this standard by multiple significant NFT related platforms.
 - [x] Implementation in libraries supporting NFT minting, including:
-  - [x] Mesh [Minting Royalty Token](https://meshjs.dev/apis/transaction/minting#mintingRoyaltyToken)
+  - [x] Mesh ([Minting Royalty Token](https://meshjs.dev/apis/transaction/minting#mintingRoyaltyToken))
 
 ### Implementation Plan
 


### PR DESCRIPTION
Fixes #673.

@Crypto2099 as with other "remediations" of ubiquitously implemented proposals for #389 I've set `Implementors` (at least initially) to `NA` since there's no complete list that would not overrun the header.  If you can think of a subset of implementors that makes sense in this context & conveys something useful, please feel free to suggest it here.

([updated proposal](https://github.com/rphair/CIPs/blob/remediate-0027/CIP-0027/README.md))