### PR TITLE
CIP-0028 | Adjust preamble and structure w.r.t CIP-0001

### DIFF
--- a/CIP-0028/README.md
+++ b/CIP-0028/README.md
@@ -292,4 +292,4 @@ script failure if the collateral was not available).
 
 ## Copyright
 
-This CIP is licensed under [Apache-2.0][https://www.apache.org/licenses/LICENSE-2.0].
+This CIP is licensed under [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/CIP-0028/README.md
+++ b/CIP-0028/README.md
@@ -1,24 +1,27 @@
 ---
 CIP: 28
 Title: Protocol Parameters (Alonzo Era)
-Authors: Kevin Hammond <kevin.hammond@iohk.io>
 Status: Active
-Type: Informational
+Category: Ledger
+Authors:
+  - Kevin Hammond <kevin.hammond@iohk.io>
+Implementors:
+  - IOG
+Discussions:
+  - https://github.com/cardano-foundation/CIPs/pull/140
 Created: 2021-10-14
-License: CC-BY-4.0
-Requires: CIP-0009
+License: Apache-2.0
 ---
 
 ## Abstract
 
 This CIP extends CIP-0009 to include the new protocol parameters that have been introduced for Alonzo, specifically those relating to the costing of Plutus scripts.  It describes the initial settings for those parameters.
 
-## Motivation
+## Motivation: why is this CIP necessary?
 
 We need to document the chain of changes to the protocol parameters.  This document describes precisely the changes that have been made from CIP-0009, allowing the differences to be determined.  It thus supplements rather than replaces CIP-0009.
 
 ## Specification
-
 
 ### New Updatable Protocol Parameters
 
@@ -251,7 +254,7 @@ For simplicity, the details of the parameter settings is omitted here.
 
 There are no changes to the non-updatable protocol parameters.
 
-## Rationale
+## Rationale: how does this CIP achieve its goals?
 
 The majority of the parameters are needed to enable the use of Plutus scripts on-chain.  They relate to the fees calculations for
 transactions that include Plutus scripts.
@@ -278,12 +281,15 @@ script failure if the collateral was not available).
 
 ## Path to Active
 
-- [x] The Cardano Alonzo era is activated.
+### Acceptance Criteria
 
-### Change Log
+- [x] The Alonzo ledger era is activated.
+- [x] Documented parameters have been in operational use by Cardano Node and Ledger as of the Alonzo ledger era.
 
-See [CIP-0055: Protocol Parameters (Babbage Era)](../CIP-0055).
+### Implementation Plan
+
+- [x] Alonzo ledger era parameters are deemed correct by working groups at IOG.
 
 ## Copyright
 
-This CIP is licensed under Apache-2.0
+This CIP is licensed under [Apache-2.0][https://www.apache.org/licenses/LICENSE-2.0].


### PR DESCRIPTION
Fixes #675.

@kevinhammond as with https://github.com/cardano-foundation/CIPs/pull/650 I've resolved the discrepancy in licensing agreements in favour of Apache (CC was indicated in the YAML header).

Editors: we need to keep an eye on how these Protocol Parameter CIPs are stacking on top of each other.  The last solid resolution I remember (before @Ryun1 @Crypto2099 arrived) was that protocol parameter CIPs would describe differences with the previous ledger era, rather than a complete re-enumeration of parameters... but a lot of this material feels already stated in CIP-0009.

So although solving any issues of reference & redundancy is beyond the scope of the #389 "Remediation" (and therefore doesn't have to be attended to in this PR) I still think we should keep an eye on this issue (with help from @kevinhammond and @WhatisRT I hope) because otherwise this mangled history of protocol parameters is going to end up fossilised.

In this light I've **removed** a forward reference to CIP-0055 which was shoe-horned in here with #370 apparently after debate at at CIP meeting, since this would therefore be in direct conflict with the decision that parameter updates should be cumulative (and therefore containing only backward references):
```
### Change Log

See [CIP-0055: Protocol Parameters (Babbage Era)](../CIP-0055).
```
([updated proposal](https://github.com/rphair/CIPs/blob/remediate-0028/CIP-0028/README.md))