### PR TITLE
CIP-0110? | Plutus v1 compatible script references

### DIFF
--- a/CIP-0110/README.md
+++ b/CIP-0110/README.md
@@ -1,11 +1,11 @@
 ---
 CIP: 110
 Title: Plutus v1 Script References
-Status: Active
+Status: Proposed
 Category: Plutus
 Authors:
     - Pi Lanningham <pi@sundaeswap.finance>
-Implementors: N/A
+Implementors: []
 Discussions:
  - https://twitter.com/SmaugPool/status/1737454984147390905
  - https://twitter.com/Quantumplation/status/1737704936089985339
@@ -14,8 +14,6 @@ Discussions:
 Created: 2023-12-20
 License: CC-BY-4.0
 ---
-
-# CIP-?: Plutus v1
 
 ## Abstract
 

--- a/CIP-0110/README.md
+++ b/CIP-0110/README.md
@@ -18,17 +18,21 @@ License: CC-BY-4.0
 
 ## Abstract
 
-Despite making up less than half the transactions on Cardano, Plutus v1 scripts make up 90% of the space dedicated to scripts (around 60% of the total block space). Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
+Despite making up less than half the transactions on Cardano, Plutus v1 scripts occupy around 40% of the total block space since chain inception, and sometimes higher during periods of peak activity. Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
 
 ## Motivation: why is this CIP necessary?
 
 Plutus v2 introduced a way to publish scripts on-chain, and *reference* those scripts to satisfy the witness requirement. However, because this was done via a new field on the transaction (i.e. "Reference Inputs"), which shows up in the script context, this feature is not backwards compatible with Plutus v1.
 
-However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 60% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 60 gb of that (nearly 40%) can be attributed to the wasted space from repeating the same scripts in the last 2 years. This analysis was further confirmed by IOG in [this](https://github.com/IntersectMBO/cardano-ledger/issues/3965) issue.
+However, of the 151gb it takes to represent the 6 year history of the chain, roughly 60 gb of that (nearly 40%) can be attributed to the wasted space from repeating the same scripts in the last 2 years. This analysis was further confirmed by IOG in [this](https://github.com/IntersectMBO/cardano-ledger/issues/3965) issue.
+
+It would be one thing if this was an issue mostly felt before or shortly after the Babbage hard-fork. It was assumed at the time that Plutus v2 would become a dominant player, and that usage of Plutus v1 contracts would die off. However, looking at recent trends in late 2023, it's clear this isn't happening.
+
+Looking at recent trends [through late 2023](https://twitter.com/SmaugPool/status/1737454984147390905/photo/1), considering all scripts included in transactions, Plutus v1 hovered at or slightly below 50% of all scripts in transactions. However, comparing the size of transactions which execute scripts scripts, [Plutus v1 scripts make up 90% of that space](https://twitter.com/SmaugPool/status/1737454984147390905/photo/2).
+
+Looking at periods of saturation can also help us understand where the limits of the chain are. Periods where activity is low and the chain is underutilized can skew our view of the problem: it largely doesn't matter to end users what percentage of space is occupied by different script versions, because the user experience is largely unimpacted and transactions are able to fit into the next block regardless. However, in periods of high activity, when blocks are nearly full, we get a better picture of where user activity is allocating that space, and where the cost savings would be most beneficial. For example, [epoch 455](https://twitter.com/SmaugPool/status/1737814898648691195) saw nearly 100% block usage for a full epoch, of which an average of 48% (and sometimes as high as 75%) of the space was occupied by scripts, presumably much of that Plutus v1 scripts.
 
 This problem isn't going away: while protocols may migrate to new Plutus v2 or v3 scripts, these old protocols will exist forever. Liquidity locked in these scripts, sometimes permanently, will mean that there is always an arbitrage opportunity that incentivizes a large portion of the block to be occupied by continually republishing these v1 scripts.
-
-> Historical Note: At the time that the babbage hardfork happened, the belief was that Plutus v2 would be attractive enough to encourage migration of that traffic. In practice, this simply isn't true, and circumstances like locked liquidity were unforseen.
 
 Additionally, raising the block size is considered incredibly sensitive, as it impacts block propagation times.
 

--- a/CIP-0110/README.md
+++ b/CIP-0110/README.md
@@ -5,7 +5,8 @@ Status: Proposed
 Category: Plutus
 Authors:
     - Pi Lanningham <pi@sundaeswap.finance>
-Implementors: []
+Implementors:
+    - Alexey Kuleshevich <alexey.kuleshevich@iohk.io>
 Discussions:
  - https://twitter.com/SmaugPool/status/1737454984147390905
  - https://twitter.com/Quantumplation/status/1737704936089985339

--- a/CIP-script-ref-plutus-v1/README.md
+++ b/CIP-script-ref-plutus-v1/README.md
@@ -18,7 +18,7 @@ License: CC-BY-4.0
 
 ## Abstract
 
-Despite making up less than half the transactions on Cardano, Plutus v1 scripts occupy around 60% of the block space. Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
+Despite making up less than half the transactions on Cardano, Plutus v1 scripts make up 90% of the space dedicated to scripts (around 60% of the total block space). Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
 
 ## Motivation: why is this CIP necessary?
 

--- a/CIP-script-ref-plutus-v1/README.md
+++ b/CIP-script-ref-plutus-v1/README.md
@@ -1,0 +1,117 @@
+---
+CIP: ?
+Title: Plutus v1 Script References
+Status: Active
+Category: Plutus
+Authors:
+    - Pi Lanningham <pi@sundaeswap.finance>
+Implementors: N/A
+Discussions:
+ - https://twitter.com/SmaugPool/status/1737454984147390905
+ - https://twitter.com/Quantumplation/status/1737704936089985339
+Created: 2023-12-20
+License: CC-BY-4.0
+---
+
+# CIP-?: Plutus v1
+
+## Abstract
+
+Despite making up less than half the transactions on Cardano, Plutus v1 scripts occupy over 90% of the block space. Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
+
+## Motivation: why is this CIP necessary?
+
+Plutus v2 introduced a way to publish scripts on-chain, and *reference* those scripts to satisfy the witness requirement. However, because this was done via a new field on the transaction (i.e. "Reference Inputs"), which shows up in the script context, this feature is not backwards compatible with Plutus v1.
+
+However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 90% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 93 gb of that (nearly 61%) can be attributed to the wasted space from repeating the same scripts in the last 2 years.
+
+This problem isn't going away: while protocols may migrate to new Plutus v2 or v3 scripts, these old protocols will exist forever. Liquidity locked in these scripts, sometimes permanently, will mean that there is always an arbitrage opportunity that incentivizes a large portion of the block to be occupied by continually republishing these v1 scripts.
+
+Additionally, raising the block size is considered incredibly sensitive, as it impacts block propagation times.
+
+A simple, backwards compatible mechanism for plutus v1 protocols to satisfy the script witness requirement, without changing the script context and causing breaking changes for Plutus v1 scripts, would alleviate quite literally millions of dollars worth of storage requirements, user pain, and developer frustration.
+
+## Specification
+
+Currently, the relevant parts of the transaction body CDDL are produced below:
+
+```
+transaction =
+  [ transaction_body
+  , transaction_witness_set
+  ...
+  ]
+
+transaction_body =
+  { 0 : set<transaction_input>             ; inputs
+  ...
+  , ? 7 : auxiliary_data_hash
+  ...
+  , ? 11 : script_data_hash
+  ...
+  , ? 13 : nonempty_set<transaction_input> ; collateral inputs
+  ...
+  , ? 18 : nonempty_set<transaction_input> ; reference inputs
+  }
+
+post_alonzo_transaction_output =
+  {
+  ...
+  , ? 3 : script_ref   ; script reference
+  }
+
+transaction_witness_set =
+  {
+  , ? 3: [* plutus_v1_script ]
+  ...
+  , ? 6: [* plutus_v2_script ]
+  , ? 7: [* plutus_v3_script ]
+  }
+```
+
+In order to satisfy the script witness requirement for some input locked by script hash H, you must either:
+ - Include a script that hashes to H in the `transaction_witness_set`, in fields 3, 6, or 7
+ - Include an input in field 18 of the transaction body (reference inputs), which refers to an input with `script_ref` set to a script that hashes to H
+
+Because of the use of the reference inputs, this will cause the construction of the plutus v1 script context to fail, as it has no backwards compatible way to expose these reference inputs to the script context.
+
+However, the `transaction_witness_set` is not exposed directly to the script context.
+
+So, we propose adding a new field for script references, as follows:
+
+```
+transaction_witness_set =
+  {
+  , ? 3: [* plutus_v1_script ]
+  ...
+  , ? 6: [* plutus_v2_script ]
+  , ? 7: [* plutus_v3_script ]
+  , ? 8: [* transaction_input ]
+  }
+```
+
+These inputs are not visible as reference inputs to the script context, and are *only* used to satisfy the script witness criteria. The node will look up each input referenced in `transaction_input`, and use any scripts found in the `script_ref` field, hash them, and use those scripts when it comes to evaluating whether each input can be spent.
+
+## Rationale: how does this CIP achieve its goals?
+
+This approach would immediately allow all major plutus v1 dApps to reduce their transaction sizes dramatically. Some napkin math for both Sundae and Minswap shows that this would cut around 85% of the transaction size for each transaction; Considering 90% of the space taken by by blocks is taken up by Plutus v1 scripts, this would have a massive impact on chain load.
+
+This may initially receive push-back because it admittedly has a "hacky" aesthetic; It feels like introducing multiple ways to accomplish the same thing, and adds a wrinkle to the specification of the transaction body.
+
+However, it is hard to overstate the long-term positive impact that this change could have for real users of the Cardano blockchain. Unless there is a very material drawback or attack vector for this change, I believe that many would agree that the aesthetic awkwardness is vastly outweighed by this real world impact.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] Review of this proposal by the relevant subject matter experts
+- [ ] Implement the change in the cardano-ledger and cardano-node repositories
+- [ ] Include this change in a relevant hard fork
+
+### Implementation Plan
+
+- [ ] 
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CIP-script-ref-plutus-v1/README.md
+++ b/CIP-script-ref-plutus-v1/README.md
@@ -10,6 +10,7 @@ Discussions:
  - https://twitter.com/SmaugPool/status/1737454984147390905
  - https://twitter.com/Quantumplation/status/1737704936089985339
  - https://twitter.com/SmaugPool/status/1737814894710231161
+ - https://github.com/IntersectMBO/cardano-ledger/issues/3965
 Created: 2023-12-20
 License: CC-BY-4.0
 ---
@@ -24,7 +25,7 @@ Despite making up less than half the transactions on Cardano, Plutus v1 scripts 
 
 Plutus v2 introduced a way to publish scripts on-chain, and *reference* those scripts to satisfy the witness requirement. However, because this was done via a new field on the transaction (i.e. "Reference Inputs"), which shows up in the script context, this feature is not backwards compatible with Plutus v1.
 
-However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 60% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 60 gb of that (nearly 40%) can be attributed to the wasted space from repeating the same scripts in the last 2 years.
+However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 60% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 60 gb of that (nearly 40%) can be attributed to the wasted space from repeating the same scripts in the last 2 years. This analysis was further confirmed by IOG in [this](https://github.com/IntersectMBO/cardano-ledger/issues/3965) issue.
 
 This problem isn't going away: while protocols may migrate to new Plutus v2 or v3 scripts, these old protocols will exist forever. Liquidity locked in these scripts, sometimes permanently, will mean that there is always an arbitrage opportunity that incentivizes a large portion of the block to be occupied by continually republishing these v1 scripts.
 
@@ -66,6 +67,8 @@ In terms of the risks, there are four main risks to consider:
 
    In this case, the cost would only go down, and it is again hard to imagine a scenario where this is at material risk of violating some protocols integrity in a way that is not already compromised.
 
+Given the parallel plans to include reference scripts in the cost of the transaction, outlined [here](https://github.com/IntersectMBO/cardano-ledger/issues/3952), further mitigates these concerns.
+
 ## Path to Active
 
 ### Acceptance Criteria
@@ -76,7 +79,10 @@ In terms of the risks, there are four main risks to consider:
 
 ### Implementation Plan
 
-- [ ] 
+- [ ] Update the formal Agda specification
+- [ ] Implement [minFeeRefScriptCoinsPerByte] or similar approach, as described [here](https://github.com/IntersectMBO/cardano-ledger/issues/3952)
+- [ ] Update the implementation [here](https://github.com/IntersectMBO/cardano-ledger/blob/fdc366df654fc02b1668012342732d41eaa099fe/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs#L94-L97)
+ - [ ] Update property based tests to cover these scenarios
 
 ## Copyright
 

--- a/CIP-script-ref-plutus-v1/README.md
+++ b/CIP-script-ref-plutus-v1/README.md
@@ -9,6 +9,7 @@ Implementors: N/A
 Discussions:
  - https://twitter.com/SmaugPool/status/1737454984147390905
  - https://twitter.com/Quantumplation/status/1737704936089985339
+ - https://twitter.com/SmaugPool/status/1737814894710231161
 Created: 2023-12-20
 License: CC-BY-4.0
 ---
@@ -17,13 +18,13 @@ License: CC-BY-4.0
 
 ## Abstract
 
-Despite making up less than half the transactions on Cardano, Plutus v1 scripts occupy over 90% of the block space. Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
+Despite making up less than half the transactions on Cardano, Plutus v1 scripts occupy around 60% of the block space. Increasing the space available to blocks is risky, as it impacts the block propagation time. This proposal puts forth a simple way to reduce this strain.
 
 ## Motivation: why is this CIP necessary?
 
 Plutus v2 introduced a way to publish scripts on-chain, and *reference* those scripts to satisfy the witness requirement. However, because this was done via a new field on the transaction (i.e. "Reference Inputs"), which shows up in the script context, this feature is not backwards compatible with Plutus v1.
 
-However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 90% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 93 gb of that (nearly 61%) can be attributed to the wasted space from repeating the same scripts in the last 2 years.
+However, despite consisting of less than half of the transactions being posted to the blockchain in late 2023, the bytes taken up by constantly re-publishing the same Plutus v1 scripts is nearly 60% of each block. Put another way, of the 151gb it takes to represent the 6 year history of the chain, roughly 60 gb of that (nearly 40%) can be attributed to the wasted space from repeating the same scripts in the last 2 years.
 
 This problem isn't going away: while protocols may migrate to new Plutus v2 or v3 scripts, these old protocols will exist forever. Liquidity locked in these scripts, sometimes permanently, will mean that there is always an arbitrage opportunity that incentivizes a large portion of the block to be occupied by continually republishing these v1 scripts.
 

--- a/CIP-script-ref-plutus-v1/README.md
+++ b/CIP-script-ref-plutus-v1/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: ?
+CIP: 110
 Title: Plutus v1 Script References
 Status: Active
 Category: Plutus


### PR DESCRIPTION
Plutus v1 scripts are unable to use the CIP-0031 / CIP-0033 reference inputs / script references to reduce transaction size. As a result, between 80% and 90% of every block is occupied by repeating the same script bytes over and over.

This problem will not go away even as new protocols that do support Plutus v2 are released: these protocols exist forever, and in many cases, will hold hundreds of thousands in liquidity practically forever.  As long as that is the case, they will represent an arbitrage opportunity that someone somewhere will want to take advantage of.

This proposal suggests a very simple (albeit perhaps aesthetically uncouth), backwards compatible way to support script references for Plutus v1 scripts.

[Rendered](https://github.com/Quantumplation/CIPs/blob/pi/plutusv1-script-refs/CIP-0110/README.md)