### PR TITLE
CIP-0035 | Adjust preamble and structure w.r.t CIP-0001

### DIFF
--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -1,9 +1,16 @@
 ---
 CIP: 35
 Title: Changes to Plutus Core
-Authors: Michael Peyton Jones <michael.peyton-jones@iohk.io>
 Status: Active
 Category: Meta
+Authors:
+  - Michael Peyton Jones <michael.peyton-jones@iohk.io>
+Implementors: NA
+Discussions:
+  - https://github.com/cardano-foundation/CIPs/pull/215
+  - https://github.com/cardano-foundation/CIPs/pull/428
+  - https://github.com/cardano-foundation/CIPs/pull/437
+  - https://github.com/cardano-foundation/CIPs/pull/484
 Created: 2022-02-09
 License: CC-BY-4.0
 ---

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -5,7 +5,7 @@ Status: Active
 Category: Meta
 Authors:
   - Michael Peyton Jones <michael.peyton-jones@iohk.io>
-Implementors: NA
+Implementors: N/A
 Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/215
   - https://github.com/cardano-foundation/CIPs/pull/428


### PR DESCRIPTION
Fixes #691.

@michaelpj this was mostly done in https://github.com/cardano-foundation/CIPs/pull/437: I just added the history and set `Implementors: NA` in imitation of CIP-0084.  If there's a better choice for `Implementors` please say so.

([updated proposal](https://github.com/rphair/CIPs/blob/remediate-0035/CIP-0035/README.md))