### PR TITLE
CIP-0052 | Adjust preamble and structure w.r.t CIP-0001

### DIFF
--- a/CIP-0052/README.md
+++ b/CIP-0052/README.md
@@ -1,11 +1,16 @@
 ---
 CIP: 52
 Title: Cardano audit best practice guidelines
-Authors: Simon Thompson <simon.thompson@iohk.io>
-Comments-Summary: No comments yet.
-Comments-URI: https://github.com/cardano-foundation/CIPs/wiki/Comments:CIP-0052
 Status: Proposed
-Type: Process
+Category: Meta
+Authors:
+  - Simon Thompson <simon.thompson@iohk.io>
+Implementors: []
+Discussions: 
+  - https://github.com/cardano-foundation/CIPs/pull/252
+  - https://github.com/cardano-foundation/CIPs/pull/344
+  - https://github.com/cardano-foundation/CIPs/pull/406
+  - https://github.com/cardano-foundation/CIPs/pull/560
 Created: 2022-04-25
 License: CC-BY-4.0
 ---
@@ -14,7 +19,7 @@ License: CC-BY-4.0
 
 These guidelines describe the audit process in general before setting out for DApp developers what information they will need to supply to auditors as part of the process. These are guidelines rather than requirements, and different auditors may engage differently, providing complementary services. The guidelines aim to establish a common baseline, including alternative ways of satisfying high-level requirements. Appendices provide (1) a glossary, (2) an audit FAQ, (3) a list of auditors for Cardano, and (4) a sample audit report.
 
-## Motivation
+## Motivation: why is this CIP necessary?
 
 This CIP aims to promote the process of audit for DApps on Cardano, to improve the overall standard of assurance of DApps built for Cardano, and thus to contribute the improvement of the wider Cardano ecosystem.  
 
@@ -30,9 +35,85 @@ DApp developers seek to drive adoption through their DApps being certified. Wall
 
 These are guidelines rather than requirements, and different auditors may engage differently, providing complementary services. The guidelines aim to establish a common baseline, including alternative ways of satisfying high-level requirements. Appendices provide (1) a glossary, (2) an audit FAQ, (3) a list of auditors for Cardano, and (4) a sample audit report.
 
+### Prerequisites
 
+#### Key terms
 
-###  Tendering
+***(Smart) contract***: a program that runs on blockchain. In the case of Cardano, this will be a Plutus program that will contain Plutus Core components that run on blockchain as well as other code that runs off chain. All auditors will scrutinise on-chain code, some will examine off-chain code too.Some auditors might also provide orthogonal services eg. auditing a zero-knowledge protocol or an economic model.
+
+***DApp***: a complete “distributed” application that runs on blockchain. This will include off-chain code written in other languages, e.g. running in a browser, and will integrate or link with other services such as wallets and oracles.
+
+***Assurance***: the process of establishing various properties of systems, both positive (it does this) and negative (it doesn’t do this), with different degrees of certainty.
+
+***Audit***: the process of establishing assurance by means of manual examination of artefacts, systems, processes etc. Can involve some tooling, but it is a human-led process.
+
+***Tooling***: using automated processes to establish degrees of assurance of systems. Tools may be run on target DApps by parties providing such a service.
+
+***Evidence***: artefacts coming out of tooling and audit that can support assertions of assurance of systems. Examples include formal proofs, test suites, prior counterexamples and so on, as well as audit reports.
+
+***Certification***: the process and technology of giving to DApp end-users and developers secure evidence of forms of assurance about DApps and their component smart contracts. In the case of Cardano our approach is to provide information on  chain as transaction metadata. 
+
+*Note*: “certification” has also been used informally to cover the combined process of testing, audit, verification and providing evidence of these, as in “level 1 certification”. If it is felt that it is too confusing to use the term in both senses, then another term should be found, e.g. *evidencing* or *witnessing*. 
+
+***Component***: a discrete part of the complete system supplied by a third party, such as a wallet, (part of) which will be run on the user’s system.
+
+***Service***: a part of the system, such as Blockfrost, that is provided by an online server accessed through a well-defined protocol.
+
+***Scope***: the parts of the DApp that are subject to audit. A repository may contain much more than Plutus code. Some audits will look at the complete app, some will just concentrate on on-chain transactions, others on the web interface around it. The possible scopes are divided in three main categories:
+* On-chain
+* Off-chain
+* Context: the business and economic models for the DApp  
+
+***Deployment***: once a DApp is developed it is deployed by submitting the relevant on-chain scripts onto the Cardano blockchain as transaction validator scripts. The scripts being deployed  might be the scripts that have been audited, or be instances of them in the case that the audited scripts are *parametric*.
+
+#### Audit FAQ
+
+##### *What is an audit?*
+
+An audit is a comprehensive investigation of a DApp that provides an in-depth analysis on bugs, vulnerabilities, code quality and correctness of implementation. An audit does not necessarily analyse completed DApps and often will instead analyse a fragment of a DApp. For example many auditors will only analyse the on-chain code of a DApp.  
+
+##### *Who provides an audit?*
+
+Audits are provided by companies that specialise in the area of the developed DApp. In this case it will be experts on the Cardano blockchain and Plutus smart contracts.
+
+##### *How does audit work? What is the process?*
+
+This first part of the process is tendering, where developers will need to provide preliminary information about their DApp to candidate auditors, as described below.
+
+Once a contract is agreed, the next step in the process is to provide the auditors with the necessary information to perform the audit as set out in the guidelines below. Auditors may work with developers to ensure that the documentation and other materials for audit are prepared to the standard that is required for the audit to take place. Different auditors will have different requirements, but the guidelines below establish the minimum requirements.
+
+Auditors will typically produce a first version of a report, which the developer can use as a guide to improving their DApp, before submitting changes to produce the final version of the code on which the final, published report is based. Once a DApp is audited, it will be deployed on the Cardano blockchain.
+
+##### *When should a developer contact an auditor?*
+
+A developer should contact an auditor when they have a final working version of a DApp or fragment of a DApp that they want to have audited. Once the contract is agreed, the developer will need to provide the auditor with a final version of the DApp for audit. 
+
+However, it is recommended to contact a potential auditor as early as possible because many auditors also provide consultation services for the design and development of the DApps. A developer is encouraged to contact the auditor as early as possible so as to mitigate any design issues which may be very hard if not impossible to fix. Early contact is also encouraged because securing a time slot with an auditor in advance shortens the DApp’s overall time to market, finally, early contact allows for scheduling and potentially avoids long delays between starting and completing an audit.
+
+##### *What is audited when an audit takes place?*
+
+All audits will examine the on-chain code that is used to validate transactions submitted to advance the smart contracts that constitute part of a DApp. Audit may also cover more of the code in a DApp, including on- and off-chain code written in Plutus, as well as other languages, e.g. JavaScript running in a browser. 
+
+##### *What guarantees can and cannot be given by an audit?*
+
+An audit ***is not*** a guarantee of unbreakable security nor a way to offset trust or responsibility. An audit will provide an in-depth review of the source code of a DApp. The audit will provide a comprehensive code review detailing any found vulnerabilities, comments on the quality of code as well as an analysis of the implementation in regards to the supplied specification. An audit cannot guarantee that all possible vulnerabilities will be found or that the deployed DApp will perform as intended. This is especially true in the cases where an audit only looks at a fragment of a DApp or when a DApp has been updated.
+
+##### *Who are the stakeholders involved in the audit process?*
+
+DApps are used by *DApp users*, and built by *DApp developers*. Audit is performed by *audit companies*, using tools developed by themselves and other *tool developers*. Tooling can be run by *tool service providers*, and evidence of those and other results produced by *certification providers*. Audit is also impacted by components (e.g. light wallets) and services (e.g. blockfrost) provided by *ecosystem members*. Standards can be developed by *industry consortia* or *governance organisations* (e.g. the Cardano Foundation). In the widest sense, all *holders of Ada* stand to benefit from Cardano building an expectation that DApps are certified.
+
+### Cardano auditors
+
+| Audit company   | URL                                     | Contact email      | Public key      |
+| -----------     | -----------                             | -----------        | -----------        |
+| FYEO Inc.       | https://gofyeo.com/blockchain-security  | sales@gofyeo.com  | |
+| Hachi           | https://hachi.one                       | team@hachi.one        | |
+| MLabs           | https://mlabs.city                      | info@mlabs.city      | 64BC640B5454215D12165EEAEEFF303D2643ABA2 (PGP, ed25519) |
+| Runtime Verification           | https://www.runtimeverification.com | contact@runtimeverification.com  | |
+| Tweag                | https://www.tweag.io                  | sales@tweag.io                  | |
+| Vacuumlabs      | https://vacuumlabs.com/smart-contract-auditing/   | audit@vacuumlabs.com  | 16541FD112978F3C6D49E79881E6B1F9C0BC6BF9 (PGP, ed25519) |
+
+### Tendering
 In order to provide a quote for audit, developers will need to supply
 * A specification of the DApp to be audited (more details below).
 * The scope of the audit.
@@ -73,7 +154,6 @@ Ideally, submitters should submit a description of how the DApp has been tested,
 * The identity, configuration and version of all test components involved shall be documented.
 * The checksum and version of the DApp submitted for certification shall correspond to the same version making the subject of the test report. 
 * An evaluation of the test coverage and test completion should be provided. 
-
 
 In the case that off-chain code is included in the scope of the audit, testing should be able to assess the performance and robustness of the DApp against significant throughput, under substantial workload, and in the scenario of a DoS attack.
 
@@ -134,98 +214,21 @@ Auditors shall provide credentials for the following competencies:
 Disclosure
 It is common – but not universal – practice for disclosure/publication of audit report, for example as a part of a responsible disclosure policy. A typical policy would be to publish a report after a certain period (e.g. 30-90 day) or at the point that a DApp goes live, whichever is earlier.
 
-
-## Rationale
+## Rationale: how does this CIP achieve its goals?
 
 These guidelines are the result of a process of discussion between IOG staff and members of the audit and academic communities over a series of online meetings in February and March 2022. Audit organisations involved include Tweag, WellTyped, Certik, Runtime Verification, BT Block, MLabs, Quviq and Hachi/Meld, all of which supported the guidelines outlined here.
 
 ## Path to active
 
-This CIP is ready to be made active; since it is a process standard, it requires no implementation.
+### Acceptance Criteria
+
+- [ ] Evidence that Cardano audits are being performed according to this proposed standard, by reference to specific audit(s) citing CIP-0052 and containing these audit elements.
+
+### Implementation Plan
+
+- [x] Initial set of Cardano auditors provided with CIP, with others added afterward along with contact information and verification keys.
 
 ## Copyright
 
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
-
-## Appendices
-
-### 1. Glossary
-
-***(Smart) contract***: a program that runs on blockchain. In the case of Cardano, this will be a Plutus program that will contain Plutus Core components that run on blockchain as well as other code that runs off chain. All auditors will scrutinise on-chain code, some will examine off-chain code too.Some auditors might also provide orthogonal services eg. auditing a zero-knowledge protocol or an economic model.
-
-***DApp***: a complete “distributed” application that runs on blockchain. This will include off-chain code written in other languages, e.g. running in a browser, and will integrate or link with other services such as wallets and oracles.
-
-***Assurance***: the process of establishing various properties of systems, both positive (it does this) and negative (it doesn’t do this), with different degrees of certainty.
-
-***Audit***: the process of establishing assurance by means of manual examination of artefacts, systems, processes etc. Can involve some tooling, but it is a human-led process.
-
-***Tooling***: using automated processes to establish degrees of assurance of systems. Tools may be run on target DApps by parties providing such a service.
-
-***Evidence***: artefacts coming out of tooling and audit that can support assertions of assurance of systems. Examples include formal proofs, test suites, prior counterexamples and so on, as well as audit reports.
-
-***Certification***: the process and technology of giving to DApp end-users and developers secure evidence of forms of assurance about DApps and their component smart contracts. In the case of Cardano our approach is to provide information on  chain as transaction metadata. 
-
-*Note*: “certification” has also been used informally to cover the combined process of testing, audit, verification and providing evidence of these, as in “level 1 certification”. If it is felt that it is too confusing to use the term in both senses, then another term should be found, e.g. *evidencing* or *witnessing*. 
-
-***Component***: a discrete part of the complete system supplied by a third party, such as a wallet, (part of) which will be run on the user’s system.
-
-***Service***: a part of the system, such as Blockfrost, that is provided by an online server accessed through a well-defined protocol.
-
-***Scope***: the parts of the DApp that are subject to audit. A repository may contain much more than Plutus code. Some audits will look at the complete app, some will just concentrate on on-chain transactions, others on the web interface around it. The possible scopes are divided in three main categories:
-* On-chain
-* Off-chain
-* Context: the business and economic models for the DApp  
-
-***Deployment***: once a DApp is developed it is deployed by submitting the relevant on-chain scripts onto the Cardano blockchain as transaction validator scripts. The scripts being deployed  might be the scripts that have been audited, or be instances of them in the case that the audited scripts are *parametric*.
-
-### 2. An audit FAQ
-
-#### *What is an audit?*
-
-An audit is a comprehensive investigation of a DApp that provides an in-depth analysis on bugs, vulnerabilities, code quality and correctness of implementation. An audit does not necessarily analyse completed DApps and often will instead analyse a fragment of a DApp. For example many auditors will only analyse the on-chain code of a DApp.  
-
-#### *Who provides an audit?*
-
-Audits are provided by companies that specialise in the area of the developed DApp. In this case it will be experts on the Cardano blockchain and Plutus smart contracts.
-
-#### *How does audit work? What is the process?*
-
-This first part of the process is tendering, where developers will need to provide preliminary information about their DApp to candidate auditors, as described below.
-
-Once a contract is agreed, the next step in the process is to provide the auditors with the necessary information to perform the audit as set out in the guidelines below. Auditors may work with developers to ensure that the documentation and other materials for audit are prepared to the standard that is required for the audit to take place. Different auditors will have different requirements, but the guidelines below establish the minimum requirements.
-
-Auditors will typically produce a first version of a report, which the developer can use as a guide to improving their DApp, before submitting changes to produce the final version of the code on which the final, published report is based. Once a DApp is audited, it will be deployed on the Cardano blockchain.
-
-#### *When should a developer contact an auditor?*
-
-A developer should contact an auditor when they have a final working version of a DApp or fragment of a DApp that they want to have audited. Once the contract is agreed, the developer will need to provide the auditor with a final version of the DApp for audit. 
-
-However, it is recommended to contact a potential auditor as early as possible because many auditors also provide consultation services for the design and development of the DApps. A developer is encouraged to contact the auditor as early as possible so as to mitigate any design issues which may be very hard if not impossible to fix. Early contact is also encouraged because securing a time slot with an auditor in advance shortens the DApp’s overall time to market, finally, early contact allows for scheduling and potentially avoids long delays between starting and completing an audit.
-
-#### *What is audited when an audit takes place?*
-
-All audits will examine the on-chain code that is used to validate transactions submitted to advance the smart contracts that constitute part of a DApp. Audit may also cover more of the code in a DApp, including on- and off-chain code written in Plutus, as well as other languages, e.g. JavaScript running in a browser. 
-
-#### *What guarantees can and cannot be given by an audit?*
-
-An audit ***is not*** a guarantee of unbreakable security nor a way to offset trust or responsibility. An audit will provide an in-depth review of the source code of a DApp. The audit will provide a comprehensive code review detailing any found vulnerabilities, comments on the quality of code as well as an analysis of the implementation in regards to the supplied specification. An audit cannot guarantee that all possible vulnerabilities will be found or that the deployed DApp will perform as intended. This is especially true in the cases where an audit only looks at a fragment of a DApp or when a DApp has been updated.
-
-#### *Who are the stakeholders involved in the audit process?*
-
-DApps are used by *DApp users*, and built by *DApp developers*. Audit is performed by *audit companies*, using tools developed by themselves and other *tool developers*. Tooling can be run by *tool service providers*, and evidence of those and other results produced by *certification providers*. Audit is also impacted by components (e.g. light wallets) and services (e.g. blockfrost) provided by *ecosystem members*. Standards can be developed by *industry consortia* or *governance organisations* (e.g. the Cardano Foundation). In the widest sense, all *holders of Ada* stand to benefit from Cardano building an expectation that DApps are certified.
-
-### 3. Cardano auditors
-
-| Audit company   | URL                                     | Contact email      | Public key      |
-| -----------     | -----------                             | -----------        | -----------        |
-| FYEO Inc.       | https://gofyeo.com/blockchain-security  | sales@gofyeo.com  | |
-| Hachi           | https://hachi.one                       | team@hachi.one        | |
-| MLabs           | https://mlabs.city                      | info@mlabs.city      | 64BC640B5454215D12165EEAEEFF303D2643ABA2 (PGP, ed25519) |
-| Runtime Verification           | https://www.runtimeverification.com | contact@runtimeverification.com  | |
-| Tweag                | https://www.tweag.io                  | sales@tweag.io                  | |
-| Vacuumlabs      | https://vacuumlabs.com/smart-contract-auditing/   | audit@vacuumlabs.com  | 16541FD112978F3C6D49E79881E6B1F9C0BC6BF9 (PGP, ed25519) |
-
-### 4. A sample audit report
-
-Tha audit report compiled by FYEO (formerly BT Block) is available from this link: https://www.gofyeo.com/post/btblock-completes-cardano-smart-contract-review-for-adax  
 


### PR DESCRIPTION
Fixes #701.

@simonjohnthompson I've had to make some adjustments due to more rigorous formatting requirements and stricter requirements in anticipation of becoming `Active` since this was originally merged.

The main text shuffle was to move your _Appendix_ into the "Prerequisites" for your _Specification_.  This assumes these terms are essential to implementing the audit process exactly as envisioned in your Specification.
* If that assumption isn't true, or if the background material is cumbersome in that position, especially if common knowledge to auditors, this might be offloaded to a document like "Handbook for audits" that exists outside the CIP.

I had to delete the "example audit" since its web page is defunct and the Wayback Machine version doesn't run the right code to download the PDF.  If you have that document in the raw perhaps it can be linked into the CIP somehow.

Finally I do believe this should have a proper _Path to Active_ since neither auditors nor those who use audit services have provided the CIP repository with examples of CIP-0052 in audits which would qualify this CIP as `Active`.
* Hopefully with the qualification of usage that I have added, any auditors following CIP-0052 would be encouraged to submit their audits as evidence of `Active` status for this CIP.

([updated proposal](https://github.com/rphair/CIPs/blob/remediate-0052/CIP-0052/README.md))