### PR TITLE
CIP-0036 | Adjust preamble and structure w.r.t CIP-0001

### DIFF
--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -7,7 +7,8 @@ Authors:
   - Giacomo Pasini <giacomo.pasini@iohk.io>
   - Kevin Hammond <kevin.hammond@iohk.io>
   - Mark Stopka <mark.stopka@perlur.cloud>
-Implementors: []
+Implementors:
+  - cardano-signer <https://github.com/gitmachtl/cardano-signer>
 Discussions:
   - https://forum.cardano.org/t/cip-catalyst-registration-metadata-format/44038
   - https://github.com/cardano-foundation/CIPs/pull/188

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -288,7 +288,7 @@ Fund 11:
   - See the [schema file](./schema.cddl).
 - [x] Authors to provide CDDL schema file.
   - See [test vector file](./test-vector.md).
-- [ ] Authors to test this format for security and compatibility with existing Catalyst infrastructure.
+- [x] Authors to test this format for security and compatibility with existing Catalyst infrastructure.
 
 
 ## Copyright

--- a/CIP-0036/README.md
+++ b/CIP-0036/README.md
@@ -1,10 +1,18 @@
 ---
 CIP: 36
-Title: Catalyst/Voltaire Registration Transaction Metadata Format (Updated)
-Authors: Giacomo Pasini <giacomo.pasini@iohk.io>, Kevin Hammond <kevin.hammond@iohk.io>, Mark Stopka <mark.stopka@perlur.cloud>
-Comments-URI: https://forum.cardano.org/t/cip-catalyst-registration-metadata-format/44038
+Title: Catalyst Registration Transaction Metadata Format (Updated)
+Category: Tools
 Status: Proposed
-Type: Standards
+Authors:
+  - Giacomo Pasini <giacomo.pasini@iohk.io>
+  - Kevin Hammond <kevin.hammond@iohk.io>
+  - Mark Stopka <mark.stopka@perlur.cloud>
+Implementors: []
+Discussions:
+  - https://forum.cardano.org/t/cip-catalyst-registration-metadata-format/44038
+  - https://github.com/cardano-foundation/CIPs/pull/188
+  - https://github.com/cardano-foundation/CIPs/pull/349
+  - https://github.com/cardano-foundation/CIPs/pull/373
 Created: 2021-12-06
 License: CC-BY-4.0
 ---
@@ -12,9 +20,9 @@ License: CC-BY-4.0
 ## Abstract
 
 Cardano uses a sidechain for its treasury system. One needs to "register" to participate on this sidechain by submitting a registration transaction on the mainnet chain. This CIP details the registration transaction format.
-This is a revised version of the original CIP-15.
+This is a revised version of the original [CIP-15 | Registration Transaction Metadata Format](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0015).
 
-## Motivation
+## Motivation: why is this CIP necessary?
 
 Cardano uses a sidechain for its treasury system ("Catalyst") and for other voting purposes. One of the desirable properties of this sidechain is that even if its safety is compromised, it doesn't cause loss of funds on the main Cardano chain. To achieve this, instead of using your wallet's recovery phrase on the sidechain, we need to use a brand new "voting key".
 
@@ -28,8 +36,7 @@ We therefore need a registration transaction that serves three purposes:
 2. Associates mainnet ADA to this voting key(s)
 3. Declares a payment address to receive Catalyst rewards
 
-
-Note: This schema does not attempt to differentiate delegations from direct registrations, as the two options have exactly the same format.  It also does not distinguish between delegations that are made as "private" arrangements (proxy votes)
+**Note**: This schema does not attempt to differentiate delegations from direct registrations, as the two options have exactly the same format. It also does not distinguish between delegations that are made as "private" arrangements (proxy votes)
 from those that are made by delegating to representatives who promote themselves publicly.
 Distinguishing these possibilities is left to upper layers or future revisions of this standard, if required.
 In this document, we will use the term 'delegations' to refer to all these possibilities.
@@ -57,7 +64,7 @@ Each delegation therefore contains:
 
 ### Voting key 
 
-The terms "(CIP-36) voting keys" and "(CIP-36) vote keys" should be used interchangeably to indicate the keys described in this specification. But it should be made clear that implementations should favour the term "(CIP-36) vote" and that the association of both terms aims to reduce the possibility of confusion.
+The terms "(CIP-36) voting keys" and "(CIP-36) vote keys" should be used interchangeably to indicate the keys described in this specification. But it should be made clear that implementations should favour the term "(CIP-36) vote key" and that the association of both terms aims to reduce the possibility of confusion.
 
 The term governance should not be associated with these keys nor should these keys be associated with other vote or voting keys used in the ecosystem. When discussing these keys in a wider context they should be specified by such terminology as "CIP-36 vote keys" or "CIP-36 style vote keys".
 
@@ -67,11 +74,11 @@ To avoid linking voting keys directly with Cardano spending keys, the voting key
 
 `m / 1694' / 1815' / account' / chain / address_index`
 
-We recommend that implementors only use `address_index`=0 to avoid the need for voting key discovery.
+We recommend that implementors only use `address_index=0` to avoid the need for voting key discovery.
 
 #### Tooling
 
-Supporting tooling should clearly define and differentiate this as a unique key type, describing such keys as "CIP-36 vote keys". When utilizing Bech32 encoding the appropriate `cvote_sk` and `cvote_vk` prefixes should be used as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)
+Supporting tooling should clearly define and differentiate this as a unique key type, describing such keys as "CIP-36 vote keys". When utilizing Bech32 encoding the appropriate `cvote_sk` and `cvote_vk` prefixes should be used as described in [CIP-05](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005).
 
 Examples of acceptable `keyType`s for supporting tools:
 
@@ -90,31 +97,9 @@ For hardware implementations:
 
 The intention with this design is that if projects beyond Catalyst implement this specification they are able to add to themselves `keyType` **Description**s.
 
-### Associating voting power with a voting key
-
-This method has been used since Fund 2.
-For future fund iterations, a new method making use of time-lock scripts may
-be introduced as described [below][future-development].
-
-Recall: Cardano uses the UTXO model so to completely associate a wallet's balance with a voting key (i.e. including enterprise addresses), we would need to associate every payment key to a voting key individually. Although there are attempts at this (see [CIP-0008]), the resulting data structure is a little excessive for on-chain metadata (which we want to keep small)
-
-Given the above, we choose to associate staking credentials with voting keys. At the moment, the only supported staking credential is a staking key. Since most Cardano wallets only use base addresses for Shelley wallet types, in most cases this should perfectly match the user's wallet.
-
-The voting power that is associated with each delegated voting key is derived from the user's total voting power
-as follows.
-
-1. The total weight is calculated as a sum of all the weights;
-2. The user's total voting power is calculated as a whole number of ADA (rounded down);
-3. The voting power associated with each voting key in the delegation array is calculated as the weighted fraction of the
-   total voting power (rounded down);
-4. Any remaining voting power is assigned to the last voting key in the delegation array.
-
-This ensures that the voter's total voting power is never accidentally reduced through poor choices of weights,
-and that all voting powers are exact ADA.
-
 ### Example - Registration
 
-Voting registration example:
+#### Voting registration example:
 ```
 61284: {
   // delegations - CBOR byte array 
@@ -144,7 +129,6 @@ considered valid if the following conditions hold:
 - The delegation array is not empty
 - The weights in the delegation array are not all zero
 
-
 Delegation to the voting key `0xa6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663` will have relative weight 1 and delegation to the voting key `0x00588e8e1d18cba576a4d35758069fe94e53f638b6faf7c07b8abd2bc5c5cdee` relative weight 3 (for a total weight of 4).
 Such a registration will assign 1/4 and 3/4 of the value in ADA to those keys respectively, with any remainder assigned to the second key.
 
@@ -158,7 +142,7 @@ using the Ed25519 signature algorithm. The witness metadata entry is
 added to the transaction under key 61285 as a CBOR map with a single entry
 that consists of the integer key 1 and signature as obtained above as the byte array value.
 
-Witness example:
+#### Witness example:
 ```
 61285: {
   // witness - ED25119 signature CBOR byte array
@@ -183,7 +167,7 @@ Notably, there should be three entries inside the metadata map (key 61286):
 
 Be aware, the deregistration metadata key is 61286, and not 61284 like it is used for a registration! The registraton metadata format and specification is independent from the deregistration one, and may not be supported by all wallets/tools.
  
-### Example - Deregistration (Catalyst)
+#### Example - Deregistration (Catalyst)
 
 ```
 {
@@ -224,14 +208,37 @@ using the Ed25519 signature algorithm. The witness metadata entry is
 added to the transaction under key 61285 as a CBOR map with a single entry
 that consists of the integer key 1 and signature as obtained above as the byte array value.
 
-
 ### Metadata schema
 
-See the [schema file](./schema.cddl)
+See the [schema file](./schema.cddl).
 
-# Test vector
+### Test vector
 
-See [test vector file](./test-vector.md)
+See [test vector file](./test-vector.md).
+
+## Rationale: how does this CIP achieve its goals?
+
+### Associating voting power with a voting key
+
+This method has been used since Fund 2.
+For future fund iterations, a new method making use of time-lock scripts may
+be introduced as described [below][future-development].
+
+Recall: Cardano uses the UTXO model so to completely associate a wallet's balance with a voting key (i.e. including enterprise addresses), we would need to associate every payment key to a voting key individually. Although there are attempts at this (see [CIP-0008]), the resulting data structure is a little excessive for on-chain metadata (which we want to keep small)
+
+Given the above, we choose to associate staking credentials with voting keys. At the moment, the only supported staking credential is a staking key. Since most Cardano wallets only use base addresses for Shelley wallet types, in most cases this should perfectly match the user's wallet.
+
+The voting power that is associated with each delegated voting key is derived from the user's total voting power
+as follows.
+
+1. The total weight is calculated as a sum of all the weights;
+2. The user's total voting power is calculated as a whole number of ADA (rounded down);
+3. The voting power associated with each voting key in the delegation array is calculated as the weighted fraction of the
+   total voting power (rounded down);
+4. Any remaining voting power is assigned to the last voting key in the delegation array.
+
+This ensures that the voter's total voting power is never accidentally reduced through poor choices of weights,
+and that all voting powers are exact ADA.
 
 ### Future development
 
@@ -242,7 +249,7 @@ with a staking credential. Therefore, the `staking_credential` map entry
 and the `registration_witness` payload with key 61285 will no longer
 be required.
 
-## Changelog
+### Changelog
 
 Fund 3 added the `reward_address` inside the `key_registration` field.
 
@@ -266,8 +273,23 @@ Fund 10:
 Fund 11:
  - added the `deregistration` metadata format.
 
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] Have this registration format supported in Catalyst infrastructure for two Catalyst funds.
+- [ ] Have this registration format supported by three wallets/tools.
+  - [cardano-signer](https://github.com/gitmachtl/cardano-signer)
+
+### Implementation Plan
+
+- [x] Authors to provide test vector file.
+  - See the [schema file](./schema.cddl).
+- [x] Authors to provide CDDL schema file.
+  - See [test vector file](./test-vector.md).
+- [ ] Authors to test this format for security and compatibility with existing Catalyst infrastructure.
+
+
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
-
-[CIP-0008]: https://github.com/cardano-foundation/CIPs/tree/master/CIP-0008
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 | 0033 | [Reference Scripts](./CIP-0033/) | Active |
 | 0034 | [Chain ID Registry](./CIP-0034/) | Draft |
 | 0035 | [Plutus Core Evolution](./CIP-0035) | Active |
-| 0036 | [Catalyst/Voltaire Registration Transaction Metadata Format](./CIP-0036) | Proposed |
+| 0036 | [Catalyst Registration Transaction Metadata Format](./CIP-0036) | Proposed |
 | 0037 | [Dynamic Saturation Based on Pledge](./CIP-0037) | Proposed |
 | 0040 | [Collateral Output](./CIP-0040) | Active |
 | 0042 | [New Plutus Builtin: serialiseBuiltinData](./CIP-0042) | Active |


### PR DESCRIPTION
Fixes #604.

#### Changes
- Removed `Voltaire` from the title as it is now clear that this will not be used for Voltaire.
- Moved rationale to `Rationale` section.
- Moved `Changelog` subsection to `Rationale` section.
- Added `Path to Active` section.
- Added links/missing words/missing grammar.
- Removed extra spaces and unused reference.

------

[Rendered Updated Proposal](https://github.com/Ryun1/CIPs/blob/remediate-36/CIP-0036/README.md)