### PR TITLE
CIP-0100 | Small clean up on example files

### DIFF
--- a/CIP-0100/README.md
+++ b/CIP-0100/README.md
@@ -273,7 +273,7 @@ An example document with an inline context is provided in [this](./example.json)
 
 Canonicalization should produce the following blak2b-256 hash:
 
-34cbb91e044cbd1dbda9e5aa542a74e712d23d0bf151c436c52920dcac03629c
+`6ea05c0e97b1b7316d48b5587a9e60d47c0c44993c8609c9544d88c111814819`
 
 ## Path to Active
 

--- a/CIP-0100/cip-0100.common.jsonld
+++ b/CIP-0100/cip-0100.common.jsonld
@@ -1,6 +1,5 @@
 {
     "@context": {
-        "Proposal": "https://cips.cardano.org/cip/CIP-0100#Proposal",
         "hashAlgorithm": "https://cips.cardano.org/cip/CIP-0100#hashAlgorithm",
         "body": {
             "@id": "https://cips.cardano.org/cip/CIP-0100#body",
@@ -9,8 +8,8 @@
                     "@id": "https://cips.cardano.org/cip/CIP-0100#references",
                     "@container": "@set",
                     "@context": {
-                        "GovernanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
-                        "Other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
+                        "governanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
+                        "other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
                         "label": "https://cips.cardano.org/cip/CIP-0100#reference-label",
                         "uri": "https://cips.cardano.org/cip/CIP-0100#reference-uri"
                     }

--- a/CIP-0100/cip-0100.common.jsonld
+++ b/CIP-0100/cip-0100.common.jsonld
@@ -1,41 +1,41 @@
 {
     "@context": {
-        "hashAlgorithm": "https://cips.cardano.org/cip/CIP-0100#hashAlgorithm",
+        "hashAlgorithm": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#hashAlgorithm",
         "body": {
-            "@id": "https://cips.cardano.org/cip/CIP-0100#body",
+            "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body",
             "@context": {
                 "references": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#references",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references",
                     "@container": "@set",
                     "@context": {
-                        "governanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
-                        "other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
-                        "label": "https://cips.cardano.org/cip/CIP-0100#reference-label",
-                        "uri": "https://cips.cardano.org/cip/CIP-0100#reference-uri"
+                        "governanceMetadata": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#GovernanceMetadataReference",
+                        "other": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#OtherReference",
+                        "label": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label",
+                        "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri"
                     }
                 },
-                "comment": "https://cips.cardano.org/cip/CIP-0100#comment",
+                "comment": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment",
                 "externalUpdates": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#externalUpdates",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates",
                     "@context": {
-                        "title": "https://cips.cardano.org/cip/CIP-0100#update-title",
-                        "uri": "https://cips.cardano.org/cip/CIP-0100#update-uri"
+                        "title": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-title",
+                        "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-uri"
                     }
                 }
             }
         },
         "authors": {
-            "@id": "https://cips.cardano.org/cip/CIP-0100#authors",
+            "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#authors",
             "@container": "@set",
             "@context": {
                 "did": "@id",
                 "name": "http://xmlns.com/foaf/0.1/name",
                 "witness": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#witness",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#witness",
                     "@context": {
-                        "witnessAlgorithm": "https://cips.cardano.org/cip/CIP-0100#witnessAlgorithm",
-                        "publicKey": "https://cips.cardano.org/cip/CIP-0100#publicKey",
-                        "signature": "https://cips.cardano.org/cip/CIP-0100#signature"
+                        "witnessAlgorithm": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#witnessAlgorithm",
+                        "publicKey": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#publicKey",
+                        "signature": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#signature"
                     }
                 }
             }

--- a/CIP-0100/cip-0100.common.schema.json
+++ b/CIP-0100/cip-0100.common.schema.json
@@ -29,7 +29,7 @@
             "description": "The hash algorithm used to authenticate this document externally",
             "type": "string",
             "enum": [
-                "blake2b-224"
+                "blake2b-256"
             ]
         },
         "Author": {

--- a/CIP-0100/example.body.canonical
+++ b/CIP-0100/example.body.canonical
@@ -1,9 +1,9 @@
-_:c14n0 <https://cips.cardano.org/cip/CIP-0100#update-title> "Blog"@en-us .
-_:c14n0 <https://cips.cardano.org/cip/CIP-0100#update-uri> "https://314pool.com"@en-us .
-_:c14n2 <https://cips.cardano.org/cip/CIP-0100#body> _:c14n5 .
-_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://cips.cardano.org/cip/CIP-0100#OtherReference> .
-_:c14n3 <https://cips.cardano.org/cip/CIP-0100#reference-label> "CIP-100"@en-us .
-_:c14n3 <https://cips.cardano.org/cip/CIP-0100#reference-uri> "https://cips.cardano.org/cip/CIP-0100"@en-us .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#comment> "This is a test vector for CIP-100"@en-us .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#externalUpdates> _:c14n0 .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#references> _:c14n3 .
+_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-title> "Blog"@en-us .
+_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-uri> "https://314pool.com"@en-us .
+_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body> _:c14n5 .
+_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#OtherReference> .
+_:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label> "CIP-100"@en-us .
+_:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri> "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md"@en-us .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment> "This is a test vector for CIP-100"@en-us .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates> _:c14n0 .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references> _:c14n3 .

--- a/CIP-0100/example.canonical
+++ b/CIP-0100/example.canonical
@@ -1,10 +1,10 @@
-_:c14n0 <https://cips.cardano.org/cip/CIP-0100#update-title> "Blog"@en-us .
-_:c14n0 <https://cips.cardano.org/cip/CIP-0100#update-uri> "https://314pool.com"@en-us .
-_:c14n2 <https://cips.cardano.org/cip/CIP-0100#body> _:c14n5 .
-_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://cips.cardano.org/cip/CIP-0100#OtherReference> .
-_:c14n3 <https://cips.cardano.org/cip/CIP-0100#reference-label> "CIP-100"@en-us .
-_:c14n3 <https://cips.cardano.org/cip/CIP-0100#reference-uri> "https://cips.cardano.org/cip/CIP-0100"@en-us .
+_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-title> "Blog"@en-us .
+_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-uri> "https://314pool.com"@en-us .
+_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body> _:c14n5 .
+_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#OtherReference> .
+_:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label> "CIP-100"@en-us .
+_:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri> "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md"@en-us .
 _:c14n4 <http://xmlns.com/foaf/0.1/name> "Pi Lanningham"@en-us .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#comment> "This is a test vector for CIP-100"@en-us .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#externalUpdates> _:c14n0 .
-_:c14n5 <https://cips.cardano.org/cip/CIP-0100#references> _:c14n3 .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment> "This is a test vector for CIP-100"@en-us .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates> _:c14n0 .
+_:c14n5 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references> _:c14n3 .

--- a/CIP-0100/example.json
+++ b/CIP-0100/example.json
@@ -1,42 +1,42 @@
 {
     "@context": {
         "@language": "en-us",
-        "hashAlgorithm": "https://cips.cardano.org/cip/CIP-0100#hashAlgorithm",
+        "hashAlgorithm": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#hashAlgorithm",
         "body": {
-            "@id": "https://cips.cardano.org/cip/CIP-0100#body",
+            "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body",
             "@context": {
                 "references": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#references",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references",
                     "@container": "@set",
                     "@context": {
-                        "governanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
-                        "other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
-                        "label": "https://cips.cardano.org/cip/CIP-0100#reference-label",
-                        "uri": "https://cips.cardano.org/cip/CIP-0100#reference-uri"
+                        "governanceMetadata": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#GovernanceMetadataReference",
+                        "other": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#OtherReference",
+                        "label": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label",
+                        "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri"
                     }
                 },
-                "comment": "https://cips.cardano.org/cip/CIP-0100#comment",
+                "comment": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment",
                 "externalUpdates": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#externalUpdates",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates",
                     "@context": {
-                        "title": "https://cips.cardano.org/cip/CIP-0100#update-title",
-                        "uri": "https://cips.cardano.org/cip/CIP-0100#update-uri"
+                        "title": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-title",
+                        "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-uri"
                     }
                 }
             }
         },
         "authors": {
-            "@id": "https://cips.cardano.org/cip/CIP-0100#authors",
+            "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#authors",
             "@container": "@set",
             "@context": {
                 "did": "@id",
                 "name": "http://xmlns.com/foaf/0.1/name",
                 "witness": {
-                    "@id": "https://cips.cardano.org/cip/CIP-0100#witness",
+                    "@id": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#witness",
                     "@context": {
-                        "witnessAlgorithm": "https://cips.cardano.org/cip/CIP-0100#witnessAlgorithm",
-                        "publicKey": "https://cips.cardano.org/cip/CIP-0100#publicKey",
-                        "signature": "https://cips.cardano.org/cip/CIP-0100#signature"
+                        "witnessAlgorithm": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#witnessAlgorithm",
+                        "publicKey": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#publicKey",
+                        "signature": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#signature"
                     }
                 }
             }
@@ -48,7 +48,7 @@
     ],
     "body": {
       "references": [
-        { "@type": "other", "label": "CIP-100", "uri": "https://cips.cardano.org/cip/CIP-0100" }
+        { "@type": "other", "label": "CIP-100", "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md" }
       ],
       "comment": "This is a test vector for CIP-100",
       "externalUpdates": [

--- a/CIP-0100/example.json
+++ b/CIP-0100/example.json
@@ -42,7 +42,7 @@
             }
         }
     },
-    "hashAlgorithm": "blake2b-224",
+    "hashAlgorithm": "blake2b-256",
     "authors": [
       { "name": "Pi Lanningham", "witness": { "witnessAlgorithm": "ed25519", "publicKey": "46e4db7f87497ba232977ccd591b3d040316b155e8c60e3ea49176c03fa269de", "signature": "abcd"}}
     ],

--- a/CIP-0100/example.json
+++ b/CIP-0100/example.json
@@ -1,7 +1,6 @@
 {
     "@context": {
         "@language": "en-us",
-        "Proposal": "https://cips.cardano.org/cip/CIP-0100#Proposal",
         "hashAlgorithm": "https://cips.cardano.org/cip/CIP-0100#hashAlgorithm",
         "body": {
             "@id": "https://cips.cardano.org/cip/CIP-0100#body",
@@ -10,8 +9,8 @@
                     "@id": "https://cips.cardano.org/cip/CIP-0100#references",
                     "@container": "@set",
                     "@context": {
-                        "GovernanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
-                        "Other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
+                        "governanceMetadata": "https://cips.cardano.org/cip/CIP-0100#GovernanceMetadataReference",
+                        "other": "https://cips.cardano.org/cip/CIP-0100#OtherReference",
                         "label": "https://cips.cardano.org/cip/CIP-0100#reference-label",
                         "uri": "https://cips.cardano.org/cip/CIP-0100#reference-uri"
                     }
@@ -49,7 +48,7 @@
     ],
     "body": {
       "references": [
-        { "@type": "Other", "label": "CIP-100", "uri": "https://cips.cardano.org/cip/CIP-0100" }
+        { "@type": "other", "label": "CIP-100", "uri": "https://cips.cardano.org/cip/CIP-0100" }
       ],
       "comment": "This is a test vector for CIP-100",
       "externalUpdates": [


### PR DESCRIPTION
### Motivation
Whilst making some[ more example files](https://github.com/Ryun1/metadata), I have found a couple inconsistencies with the provided examples.

### Changes
- Removed proposal property which does not exist in the standard
- Aligned capitalisation
- Changed hashing algorithm from blake2b-224 to blake2b-256 as only 256 [is the only supported](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md?plain=1#L108)
- Changed links to reference github rather than CIPs website

cc @Quantumplation 