### PR TITLE
CIP-0005 | Distinguish between key based and script based conway credentials

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -109,15 +109,18 @@ We define the following set of common prefixes with their corresponding semantic
 
 ### Miscellaneous
 
-| Prefix       | Meaning                                  | Contents                                                      |
-| ---          | ---                                      | ---                                                           |
-| `addr`       | Mainnet address                          | Network tag, payment credential and optional stake credential |
-| `addr_test`  | Testnet address                          | Network tag, payment credential and optional stake credential |
-| `cc_cold`    | Constitutional committee cold credential | committee cold credential                                     |
-| `cc_hot`     | Constitutional committee hot credential  | committee hot credential                                      |
-| `drep`       | DRep credential                          | DRep credential                                               |
-| `stake`      | Mainnet stake address                    | Network tag and stake credential                              |
-| `stake_test` | Testnet stake address                    | Network tag and stake credential                              |
+| Prefix           | Meaning                                               | Contents                                                      |
+| ---              | ---                                                   | ---                                                           |
+| `addr`           | Mainnet address                                       | Network tag, payment credential and optional stake credential |
+| `addr_test`      | Testnet address                                       | Network tag, payment credential and optional stake credential |
+| `cc_cold`        | Constitutional committee key based cold credential    | committee key based cold credential                           |
+| `cc_cold_script` | Constitutional committee script based cold credential | committee script based cold credential                        |
+| `cc_hot`         | Constitutional committee key based hot credential     | committee key based hot credential                            |
+| `cc_hot_script`  | Constitutional committee script based hot credential  | committee script based hot credential                         |
+| `drep`           | DRep key based credential                             | DRep key based credential                                     |
+| `drep_script`    | DRep script based credential                          | DRep script based credential                                  |
+| `stake`          | Mainnet stake address                                 | Network tag and stake credential                              |
+| `stake_test`     | Testnet stake address                                 | Network tag and stake credential                              |
 
 ## Rationale: how does this CIP achieve its goals?
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -92,20 +92,26 @@ We define the following set of common prefixes with their corresponding semantic
 
 ### Hashes
 
-| Prefix             | Meaning                                            | Contents                                                  |
-| ---                | ---                                                | ---                                                       |
-| `asset`            | Fingerprint of a native asset for human comparison | See [CIP-0014]                                            |
-| `pool`             | Pool operator verification key hash (pool ID)      | blake2b\_224 digest of an operator verification key       |
-| `script`           | Script hash                                        | blake2b\_224 digest of a serialized transaction script    |
-| `addr_vkh`         | Address verification key hash                      | blake2b\_224 digest of a payment verification key         |
-| `addr_shared_vkh`  | Shared address verification key hash               | blake2b\_224 digest of a payment verification key         |
-| `policy_vkh`       | Policy verification key hash                       | blake2b\_224 digest of a policy verification key          |
-| `stake_vkh`        | Stake address verification key hash                | blake2b\_224 digest of a delegation verification key      |
-| `stake_shared_vkh` | Shared stake address verification key hash         | blake2b\_224 digest of a delegation verification key      |
-| `req_signer_vkh`   | Required signer verification key hash              | blake2b\_224 digest of a required signer verification key |
-| `vrf_vkh`          | VRF verification key hash                          | blake2b\_256 digest of a VRF verification key             |
-| `datum`            | Output datum hash                                  | blake2b\_256 digest of output datum                       |
-| `script_data`      | Script data hash                                   | blake2b\_256 digest of script data                        |
+| Prefix             | Meaning                                                 | Contents                                                                 |
+| ---                | ---                                                     | ---                                                                      |
+| `asset`            | Fingerprint of a native asset for human comparison      | See [CIP-0014]                                                           |
+| `pool`             | Pool operator verification key hash (pool ID)           | blake2b\_224 digest of an operator verification key                      |
+| `script`           | Script hash                                             | blake2b\_224 digest of a serialized transaction script                   |
+| `addr_vkh`         | Address verification key hash                           | blake2b\_224 digest of a payment verification key                        |
+| `addr_shared_vkh`  | Shared address verification key hash                    | blake2b\_224 digest of a payment verification key                        |
+| `policy_vkh`       | Policy verification key hash                            | blake2b\_224 digest of a policy verification key                         |
+| `stake_vkh`        | Stake address verification key hash                     | blake2b\_224 digest of a delegation verification key                     |
+| `stake_shared_vkh` | Shared stake address verification key hash              | blake2b\_224 digest of a delegation verification key                     |
+| `req_signer_vkh`   | Required signer verification key hash                   | blake2b\_224 digest of a required signer verification key                |
+| `vrf_vkh`          | VRF verification key hash                               | blake2b\_256 digest of a VRF verification key                            |
+| `datum`            | Output datum hash                                       | blake2b\_256 digest of output datum                                      |
+| `script_data`      | Script data hash                                        | blake2b\_256 digest of script data                                       |
+| `drep`             | Delegate representative verification key hash (DRep ID) | blake2b\_224 digest of a delegate representative verification key        |
+| `drep_script`      | Delegate representative script hash (DRep ID)           | blake2b\_224 digest of a serialized delegate representative script       |
+| `cc_cold`          | Constitutional committee cold verification key hash     | blake2b\_224 digest of a consitutional committee cold verification key   |
+| `cc_cold_script`   | Constitutional committee cold script hash               | blake2b\_224 digest of a serialized constitutional committee cold script |
+| `cc_hot`           | Constitutional committee hot verification key hash      | blake2b\_224 digest of a consitutional committee hot verification key    |
+| `cc_hot_script`    | Constitutional committee hot script hash                | blake2b\_224 digest of a serialized constitutional committee hot script  |
 
 ### Miscellaneous
 
@@ -113,12 +119,6 @@ We define the following set of common prefixes with their corresponding semantic
 | ---              | ---                                                   | ---                                                           |
 | `addr`           | Mainnet address                                       | Network tag, payment credential and optional stake credential |
 | `addr_test`      | Testnet address                                       | Network tag, payment credential and optional stake credential |
-| `cc_cold`        | Constitutional committee key based cold credential    | committee key based cold credential                           |
-| `cc_cold_script` | Constitutional committee script based cold credential | committee script based cold credential                        |
-| `cc_hot`         | Constitutional committee key based hot credential     | committee key based hot credential                            |
-| `cc_hot_script`  | Constitutional committee script based hot credential  | committee script based hot credential                         |
-| `drep`           | DRep key based credential                             | DRep key based credential                                     |
-| `drep_script`    | DRep script based credential                          | DRep script based credential                                  |
 | `stake`          | Mainnet stake address                                 | Network tag and stake credential                              |
 | `stake_test`     | Testnet stake address                                 | Network tag and stake credential                              |
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -92,26 +92,26 @@ We define the following set of common prefixes with their corresponding semantic
 
 ### Hashes
 
-| Prefix             | Meaning                                                 | Contents                                                                 |
-| ---                | ---                                                     | ---                                                                      |
-| `asset`            | Fingerprint of a native asset for human comparison      | See [CIP-0014]                                                           |
-| `pool`             | Pool operator verification key hash (pool ID)           | blake2b\_224 digest of an operator verification key                      |
-| `script`           | Script hash                                             | blake2b\_224 digest of a serialized transaction script                   |
-| `addr_vkh`         | Address verification key hash                           | blake2b\_224 digest of a payment verification key                        |
-| `addr_shared_vkh`  | Shared address verification key hash                    | blake2b\_224 digest of a payment verification key                        |
-| `policy_vkh`       | Policy verification key hash                            | blake2b\_224 digest of a policy verification key                         |
-| `stake_vkh`        | Stake address verification key hash                     | blake2b\_224 digest of a delegation verification key                     |
-| `stake_shared_vkh` | Shared stake address verification key hash              | blake2b\_224 digest of a delegation verification key                     |
-| `req_signer_vkh`   | Required signer verification key hash                   | blake2b\_224 digest of a required signer verification key                |
-| `vrf_vkh`          | VRF verification key hash                               | blake2b\_256 digest of a VRF verification key                            |
-| `datum`            | Output datum hash                                       | blake2b\_256 digest of output datum                                      |
-| `script_data`      | Script data hash                                        | blake2b\_256 digest of script data                                       |
-| `drep`             | Delegate representative verification key hash (DRep ID) | blake2b\_224 digest of a delegate representative verification key        |
-| `drep_script`      | Delegate representative script hash (DRep ID)           | blake2b\_224 digest of a serialized delegate representative script       |
-| `cc_cold`          | Constitutional committee cold verification key hash     | blake2b\_224 digest of a consitutional committee cold verification key   |
-| `cc_cold_script`   | Constitutional committee cold script hash               | blake2b\_224 digest of a serialized constitutional committee cold script |
-| `cc_hot`           | Constitutional committee hot verification key hash      | blake2b\_224 digest of a consitutional committee hot verification key    |
-| `cc_hot_script`    | Constitutional committee hot script hash                | blake2b\_224 digest of a serialized constitutional committee hot script  |
+| Prefix             | Meaning                                                               | Contents                                                                 |
+| ---                | ---                                                                   | ---                                                                      |
+| `asset`            | Fingerprint of a native asset for human comparison                    | See [CIP-0014]                                                           |
+| `pool`             | Pool operator verification key hash (pool ID)                         | blake2b\_224 digest of an operator verification key                      |
+| `script`           | Script hash                                                           | blake2b\_224 digest of a serialized transaction script                   |
+| `addr_vkh`         | Address verification key hash                                         | blake2b\_224 digest of a payment verification key                        |
+| `addr_shared_vkh`  | Shared address verification key hash                                  | blake2b\_224 digest of a payment verification key                        |
+| `policy_vkh`       | Policy verification key hash                                          | blake2b\_224 digest of a policy verification key                         |
+| `stake_vkh`        | Stake address verification key hash                                   | blake2b\_224 digest of a delegation verification key                     |
+| `stake_shared_vkh` | Shared stake address verification key hash                            | blake2b\_224 digest of a delegation verification key                     |
+| `req_signer_vkh`   | Required signer verification key hash                                 | blake2b\_224 digest of a required signer verification key                |
+| `vrf_vkh`          | VRF verification key hash                                             | blake2b\_256 digest of a VRF verification key                            |
+| `datum`            | Output datum hash                                                     | blake2b\_256 digest of output datum                                      |
+| `script_data`      | Script data hash                                                      | blake2b\_256 digest of script data                                       |
+| `drep`             | Delegate representative verification key hash (DRep ID)               | blake2b\_224 digest of a delegate representative verification key        |
+| `drep_script`      | Delegate representative script hash (DRep ID)                         | blake2b\_224 digest of a serialized delegate representative script       |
+| `cc_cold`          | Constitutional committee cold verification key hash (cold credential) | blake2b\_224 digest of a consitutional committee cold verification key   |
+| `cc_cold_script`   | Constitutional committee cold script hash (cold credential)           | blake2b\_224 digest of a serialized constitutional committee cold script |
+| `cc_hot`           | Constitutional committee hot verification key hash (hot credential)   | blake2b\_224 digest of a consitutional committee hot verification key    |
+| `cc_hot_script`    | Constitutional committee hot script hash (hot credential)             | blake2b\_224 digest of a serialized constitutional committee hot script  |
 
 ### Miscellaneous
 

--- a/CIP-0105/README.md
+++ b/CIP-0105/README.md
@@ -108,7 +108,7 @@ DRep keys and DRep IDs should be encoded in Bech32 with the following prefixes:
 | `drep_vk`  | CIP-1852’s DRep verification key          | Ed25519 public key                 |
 | `drep_xsk` | CIP-1852’s DRep extended signing key      | Ed25519-bip32 extended private key |
 | `drep_xvk` | CIP-1852’s DRep extended verification key | Ed25519 public key with chain code |
-| `drep`     | DRep credential                           | DRep credential                    |
+| `drep`     | DRep key based credential                 | DRep key based credential          |
 
 #### Constitutional Committee Cold Keys
 

--- a/CIP-0105/README.md
+++ b/CIP-0105/README.md
@@ -99,41 +99,46 @@ As this is key-based credential it should be marked as entry `0` in a credential
 
 These are also described in [CIP-0005 | Common Bech32 Prefixes](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005/README.md), but we include them here for completeness.
 
+> **Note** we also include the prefixes for script-based credentials in the following subsections, for completeness.
+
 #### DRep Keys
 
 DRep keys and DRep IDs should be encoded in Bech32 with the following prefixes:
 
-| Prefix     | Meaning                                                 | Contents                                                          |
-| ---------- | --------------------------------------------------------| ----------------------------------------------------------------- |
-| `drep_sk`  | CIP-1852’s DRep signing key                             | Ed25519 private key                                               |
-| `drep_vk`  | CIP-1852’s DRep verification key                        | Ed25519 public key                                                |
-| `drep_xsk` | CIP-1852’s DRep extended signing key                    | Ed25519-bip32 extended private key                                |
-| `drep_xvk` | CIP-1852’s DRep extended verification key               | Ed25519 public key with chain code                                |
-| `drep`     | Delegate representative verification key hash (DRep ID) | blake2b\_224 digest of a delegate representative verification key |
+| Prefix        | Meaning                                                 | Contents                                                          |
+| ------------- | --------------------------------------------------------| ----------------------------------------------------------------- |
+| `drep_sk`     | CIP-1852’s DRep signing key                             | Ed25519 private key                                               |
+| `drep_vk`     | CIP-1852’s DRep verification key                        | Ed25519 public key                                                |
+| `drep_xsk`    | CIP-1852’s DRep extended signing key                    | Ed25519-bip32 extended private key                                |
+| `drep_xvk`    | CIP-1852’s DRep extended verification key               | Ed25519 public key with chain code                                |
+| `drep`        | Delegate representative verification key hash (DRep ID) | blake2b\_224 digest of a delegate representative verification key |
+| `drep_script` | Delegate representative script hash (DRep ID)        | blake2b\_224 digest of a serialized delegate representative script |
 
 #### Constitutional Committee Cold Keys
 
 Constitutional cold keys and credential should be encoded in Bech32 with the following prefixes:
 
-| Prefix        | Meaning                                                               | Contents                                                               |
-| ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------  |
-| `cc_cold_sk`  | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                                                    |
-| `cc_cold_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                    |
-| `cc_cold_xsk` | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key                                     |
-| `cc_cold_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                     |
-| `cc_cold`     | Constitutional committee cold verification key hash (cold credential) | blake2b\_224 digest of a consitutional committee cold verification key |
+| Prefix           | Meaning                                                               | Contents                                                               |
+| ---------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------  |
+| `cc_cold_sk`     | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                                                    |
+| `cc_cold_vk`     | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                    |
+| `cc_cold_xsk`    | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key                                     |
+| `cc_cold_xvk`    | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                     |
+| `cc_cold`        | Constitutional committee cold verification key hash (cold credential) | blake2b\_224 digest of a consitutional committee cold verification key |
+| `cc_cold_script` | Constitutional committee cold script hash (cold credential)           | blake2b\_224 digest of a serialized constitutional committee cold script |
 
 #### Constitutional Committee Hot Keys
 
 Constitutional hot keys and credential should be encoded in Bech32 with the following prefixes:
 
-| Prefix       | Meaning                                                               | Contents                                                              |
-| ------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `cc_hot_sk`  | CIP-1852’s constitutional committee hot signing key                   | Ed25519 private key                                                   |
-| `cc_hot_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                   |
-| `cc_hot_xsk` | CIP-1852’s constitutional committee hot extended signing key          | Ed25519-bip32 extended private key                                    |
-| `cc_hot_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                    |
-| `cc_hot`     | Constitutional committee hot verification key hash (hot credential)   | blake2b\_224 digest of a consitutional committee hot verification key |
+| Prefix          | Meaning                                                               | Contents                                                              |
+| --------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `cc_hot_sk`     | CIP-1852’s constitutional committee hot signing key                   | Ed25519 private key                                                   |
+| `cc_hot_vk`     | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                   |
+| `cc_hot_xsk`    | CIP-1852’s constitutional committee hot extended signing key          | Ed25519-bip32 extended private key                                    |
+| `cc_hot_xvk`    | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                    |
+| `cc_hot`        | Constitutional committee hot verification key hash (hot credential)   | blake2b\_224 digest of a consitutional committee hot verification key |
+| `cc_hot_script` | Constitutional committee hot script hash (hot credential)             | blake2b\_224 digest of a serialized constitutional committee hot script |
 
 ### Tooling Definitions
 

--- a/CIP-0105/README.md
+++ b/CIP-0105/README.md
@@ -102,37 +102,37 @@ These are also described in [CIP-0005 | Common Bech32 Prefixes](https://github.c
 
 DRep keys and DRep IDs should be encoded in Bech32 with the following prefixes:
 
-| Prefix     | Meaning                                   | Contents                           |
-| ---------- | ----------------------------------------- | ---------------------------------- |
-| `drep_sk`  | CIP-1852’s DRep signing key               | Ed25519 private key                |
-| `drep_vk`  | CIP-1852’s DRep verification key          | Ed25519 public key                 |
-| `drep_xsk` | CIP-1852’s DRep extended signing key      | Ed25519-bip32 extended private key |
-| `drep_xvk` | CIP-1852’s DRep extended verification key | Ed25519 public key with chain code |
-| `drep`     | DRep key based credential                 | DRep key based credential          |
+| Prefix     | Meaning                                                 | Contents                                                          |
+| ---------- | --------------------------------------------------------| ----------------------------------------------------------------- |
+| `drep_sk`  | CIP-1852’s DRep signing key                             | Ed25519 private key                                               |
+| `drep_vk`  | CIP-1852’s DRep verification key                        | Ed25519 public key                                                |
+| `drep_xsk` | CIP-1852’s DRep extended signing key                    | Ed25519-bip32 extended private key                                |
+| `drep_xvk` | CIP-1852’s DRep extended verification key               | Ed25519 public key with chain code                                |
+| `drep`     | Delegate representative verification key hash (DRep ID) | blake2b\_224 digest of a delegate representative verification key |
 
 #### Constitutional Committee Cold Keys
 
 Constitutional cold keys and credential should be encoded in Bech32 with the following prefixes:
 
-| Prefix        | Meaning                                                               | Contents                            |
-| ------------- | --------------------------------------------------------------------- | ----------------------------------  |
-| `cc_cold_sk`  | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                 |
-| `cc_cold_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                 |
-| `cc_cold_xsk` | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key  |
-| `cc_cold_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code  |
-| `cc_cold`     | Constitutional committee key based cold credential                    | committee key based cold credential |
+| Prefix        | Meaning                                                               | Contents                                                               |
+| ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------  |
+| `cc_cold_sk`  | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                                                    |
+| `cc_cold_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                    |
+| `cc_cold_xsk` | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key                                     |
+| `cc_cold_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                     |
+| `cc_cold`     | Constitutional committee cold verification key hash (cold credential) | blake2b\_224 digest of a consitutional committee cold verification key |
 
 #### Constitutional Committee Hot Keys
 
 Constitutional hot keys and credential should be encoded in Bech32 with the following prefixes:
 
-| Prefix       | Meaning                                                               | Contents                           |
-| ------------ | --------------------------------------------------------------------- | ---------------------------------- |
-| `cc_hot_sk`  | CIP-1852’s constitutional committee hot signing key                   | Ed25519 private key                |
-| `cc_hot_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                |
-| `cc_hot_xsk` | CIP-1852’s constitutional committee hot extended signing key          | Ed25519-bip32 extended private key |
-| `cc_hot_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code |
-| `cc_hot`     | Constitutional committee key based hot credential                     | committee key based hot credential |
+| Prefix       | Meaning                                                               | Contents                                                              |
+| ------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `cc_hot_sk`  | CIP-1852’s constitutional committee hot signing key                   | Ed25519 private key                                                   |
+| `cc_hot_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                                                   |
+| `cc_hot_xsk` | CIP-1852’s constitutional committee hot extended signing key          | Ed25519-bip32 extended private key                                    |
+| `cc_hot_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code                                    |
+| `cc_hot`     | Constitutional committee hot verification key hash (hot credential)   | blake2b\_224 digest of a consitutional committee hot verification key |
 
 ### Tooling Definitions
 

--- a/CIP-0105/README.md
+++ b/CIP-0105/README.md
@@ -114,13 +114,13 @@ DRep keys and DRep IDs should be encoded in Bech32 with the following prefixes:
 
 Constitutional cold keys and credential should be encoded in Bech32 with the following prefixes:
 
-| Prefix        | Meaning                                                               | Contents                           |
-| ------------- | --------------------------------------------------------------------- | ---------------------------------- |
-| `cc_cold_sk`  | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                |
-| `cc_cold_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                |
-| `cc_cold_xsk` | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key |
-| `cc_cold_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code |
-| `cc_cold`     | Constitutional committee cold credential                              | committee cold credential          |
+| Prefix        | Meaning                                                               | Contents                            |
+| ------------- | --------------------------------------------------------------------- | ----------------------------------  |
+| `cc_cold_sk`  | CIP-1852’s constitutional committee cold signing key                  | Ed25519 private key                 |
+| `cc_cold_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                 |
+| `cc_cold_xsk` | CIP-1852’s constitutional committee cold extended signing key         | Ed25519-bip32 extended private key  |
+| `cc_cold_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code  |
+| `cc_cold`     | Constitutional committee key based cold credential                    | committee key based cold credential |
 
 #### Constitutional Committee Hot Keys
 
@@ -132,7 +132,7 @@ Constitutional hot keys and credential should be encoded in Bech32 with the foll
 | `cc_hot_vk`  | CIP-1852’s constitutional committee verification signing key          | Ed25519 private key                |
 | `cc_hot_xsk` | CIP-1852’s constitutional committee hot extended signing key          | Ed25519-bip32 extended private key |
 | `cc_hot_xvk` | CIP-1852’s constitutional committee extended verification signing key | Ed25519 public key with chain code |
-| `cc_hot`     | Constitutional committee hot credential                               | committee hot credential           |
+| `cc_hot`     | Constitutional committee key based hot credential                     | committee key based hot credential |
 
 ### Tooling Definitions
 

--- a/CIP-0105/README.md
+++ b/CIP-0105/README.md
@@ -1,7 +1,8 @@
 ---
 CIP: 105
-Title: Conway Era Key Chains for HD Wallets
+Title: Conway era Key Chains for HD Wallets
 Status: Proposed
+Category: Wallets
 Authors:
   - Ryan Williams <ryan.williams@iohk.io>
 Implementors: []
@@ -21,7 +22,7 @@ Such keys are to be known as DRep keys, constitutional committee cold keys and c
 Here we define some accompanying tooling standards.
 
 > **Note** this proposal assumes knowledge of the Conway ledger design (see
-> [draft ledger specification](https://github.com/input-output-hk/cardano-ledger/blob/d2d37f706b93ae9c63bff0ff3825d349d0bd15df/eras/conway/impl/cddl-files/conway.cddl))
+> [draft ledger specification](https://github.com/IntersectMBO/cardano-ledger/blob/d2d37f706b93ae9c63bff0ff3825d349d0bd15df/eras/conway/impl/cddl-files/conway.cddl))
 > and
 > [CIP-1694](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md).
 
@@ -229,15 +230,18 @@ If required, another CIP could, of course, introduce a multi-DRep/CC method.
 For simplicity, we have omitted network tags within the encoding.
 This is because we have modeled DRep IDs and CC credentials on stake pool operator IDs, which similarly do not include a network tag.
 
-
 The advantage of including a network tag would be to reduce the likelihood of mislabelling a DRep’s network of operation (eg Preview v Cardano mainnet).
 
 ## Path to Active
 
 ### Acceptance Criteria
 
-- [ ] The derivation path is used by three wallet implementers (software and/or hardware).
-- [ ] The tooling definitions are used across at least two tools.
+- [x] The DRep derivation path is used by three wallet/tooling implementations.
+  - [Nufi](https://assets.nu.fi/extension/sanchonet/nufi-cwe-sanchonet-latest.zip)
+  - [Lace](https://chromewebstore.google.com/detail/lace-sanchonet/djcdfchkaijggdjokfomholkalbffgil?hl=en)
+  - [Yoroi](https://chrome.google.com/webstore/detail/yoroi-nightly/poonlenmfdfbjfeeballhiibknlknepo/related)
+  - [demos wallet](https://github.com/Ryun1/cip95-demos-wallet)
+- [ ] The consitutional committee derivation paths are used by two implementations.
 
 ### Implementation Plan
 


### PR DESCRIPTION
…and CC members

Committee members and DReps can be identified by a credential that can be either an Ed25519 verification key OR  a Script. The current prefixes do not make any distinction between these. It is good for clarity and transparency to make a clear distinction between the two types.