### PR TITLE
CIP-0088 | Introducing Policy Intent Classification

### DIFF
--- a/CIP-0088/CIPs/0025/CIP25_v1.json
+++ b/CIP-0088/CIPs/0025/CIP25_v1.json
@@ -34,7 +34,8 @@
           ]
         ]
       ],
-      "6": "SpaceBudz"
+      "6": "SpaceBudz",
+      "7": "Collectible"
     }
   }
 }

--- a/CIP-0088/CIPs/0025/CIP25_v1.json
+++ b/CIP-0088/CIPs/0025/CIP25_v1.json
@@ -35,7 +35,7 @@
         ]
       ],
       "6": "SpaceBudz",
-      "7": "Collectible"
+      "7": 2
     }
   }
 }

--- a/CIP-0088/CIPs/0025/README.md
+++ b/CIP-0088/CIPs/0025/README.md
@@ -31,7 +31,7 @@ relevant information under index #6, prefixed by the number of the CIP (25 or 68
 | 4     | NSFW Flag           | 0 or 1   | No       |
 | 5     | Social Media        | Array    | No       |
 | 6     | Project/Artist Name | String   | No       |
-| 7     | Policy Intent Class | String   | No       |
+| 7     | Policy Intent Class | Integer  | No       |
 
 For details on what these fields represent and how they should be structured in the metadata, please refer to
 [Token Project Details](../common/Token-Project-Details_v1.md)

--- a/CIP-0088/CIPs/0025/README.md
+++ b/CIP-0088/CIPs/0025/README.md
@@ -31,6 +31,7 @@ relevant information under index #6, prefixed by the number of the CIP (25 or 68
 | 4     | NSFW Flag           | 0 or 1   | No       |
 | 5     | Social Media        | Array    | No       |
 | 6     | Project/Artist Name | String   | No       |
+| 7     | Policy Intent Class | String   | No       |
 
 For details on what these fields represent and how they should be structured in the metadata, please refer to
 [Token Project Details](../common/Token-Project-Details_v1.md)
@@ -74,7 +75,8 @@ For details on what these fields represent and how they should be structured in 
           ]
         ]
       ],
-      6: "Virtua Metaverse"
+      6: "Virtua Metaverse",
+      7: "Collectible"
     }
   }
 }

--- a/CIP-0088/CIPs/0068/CIP68_v1.json
+++ b/CIP-0088/CIPs/0068/CIP68_v1.json
@@ -34,7 +34,8 @@
           ]
         ]
       ],
-      "6": "SpaceBudz"
+      "6": "SpaceBudz",
+      "7": "Collectible"
     }
   }
 }

--- a/CIP-0088/CIPs/0068/CIP68_v1.json
+++ b/CIP-0088/CIPs/0068/CIP68_v1.json
@@ -35,7 +35,7 @@
         ]
       ],
       "6": "SpaceBudz",
-      "7": "Collectible"
+      "7": 2
     }
   }
 }

--- a/CIP-0088/CIPs/0068/README.md
+++ b/CIP-0088/CIPs/0068/README.md
@@ -31,7 +31,7 @@ relevant information under index #6, prefixed by the number of the CIP (25 or 68
 | 4     | NSFW Flag           | 0 or 1   | No       |
 | 5     | Social Media        | Array    | No       |
 | 6     | Project/Artist Name | String   | No       |
-| 7     | Policy Intent Class | String   | No       |
+| 7     | Policy Intent Class | Integer  | No       |
 
 For details on what these fields represent and how they should be structured in the metadata, please refer to
 [Token Project Details](../common/Token-Project-Details_v1.md)

--- a/CIP-0088/CIPs/0068/README.md
+++ b/CIP-0088/CIPs/0068/README.md
@@ -31,6 +31,7 @@ relevant information under index #6, prefixed by the number of the CIP (25 or 68
 | 4     | NSFW Flag           | 0 or 1   | No       |
 | 5     | Social Media        | Array    | No       |
 | 6     | Project/Artist Name | String   | No       |
+| 7     | Policy Intent Class | String   | No       |
 
 For details on what these fields represent and how they should be structured in the metadata, please refer to
 [Token Project Details](../common/Token-Project-Details_v1.md)
@@ -74,7 +75,8 @@ For details on what these fields represent and how they should be structured in 
           ]
         ]
       ],
-      6: "SpaceBudz"
+      6: "SpaceBudz",
+      7: "Collectible"
     }
   }
 }

--- a/CIP-0088/Policy-Intent-Class-Index
+++ b/CIP-0088/Policy-Intent-Class-Index
@@ -1,0 +1,14 @@
+{
+  "1": {
+    "name": "Utility Pass",
+    "description: "A token that grants the holder access or rights to something."
+    },
+  "2": {
+    "name": "Collectible",
+    "description: "A collectible asset, meant to be traded on collectible marketplaces."
+    },
+  "3": {
+    "name": "Exchange Token",
+    "description: "A token of varying functionality, meant to be traded on token exchanges."
+    }
+}


### PR DESCRIPTION
Frontends can use intent classifications to filter which assets they allow on their platform. For example, "NFT" marketplaces can choose to allow only "collectible" classification. DEXs can allow "trading" and "governance" classifications. Bond marketplaces can focus on a "Bond" classification. These are just examples of course, and the classification strings themselves can be community-created (options mainly set by minting platforms who build the initial CIP-88 registration for new minting policies) so that a list of allowed classification strings doesn't have to be maintained by CIP editors. DEXs will require legacy support for the Cardano Token Registry, however for future token listings they can rely on the policy intent classification in the policy's CIP-88 registration.

Proposed for both CIP-25 and CIP-68 as referenced under CIP-88. Can be added to other CIPs that have different genres of assets.