### PR TITLE
CIP-1694 | Correctly characterise delegated active stake

### DIFF
--- a/CIP-1694/README.md
+++ b/CIP-1694/README.md
@@ -1251,7 +1251,7 @@ Depending on the type of governance action, an action will thus be ratified when
 
 * the constitutional committee approves of the action (the number of members who vote `Yes` meets the threshold of the constitutional committee)
 * the DReps approve of the action (the stake controlled by the DReps who vote `Yes` meets a certain threshold of the total active voting stake)
-* the SPOs approve of the action (the stake controlled by the SPOs who vote `Yes` meets a certain threshold over the total registered voting stake)
+* the SPOs approve of the action (the stake controlled by the SPOs who vote `Yes` meets a certain threshold over the total delegated active stake for the epoch)
 
 > **Warning**
 > As explained above, different stake distributions apply to DReps and SPOs.


### PR DESCRIPTION
The stake distribution used for talllying spo votes is not the _registered voting stake_ (delegated to DReps), but instead the _active stake_: the stake delegated and active on the epoch for block production.