### PR TITLE
CIP-0112? | Observe script type

### DIFF
--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -1,0 +1,125 @@
+---
+CIP: ?
+Title: Observe Script Type
+Status: Proposed
+Category: Plutus
+Authors:
+    - Philip DiSarro <info@anastasialabs.com>
+Implementors: []
+Discussions: []
+Created: 2024-1-8
+License: CC-BY-4.0
+---
+
+
+<!-- Existing categories:
+
+- Meta     | For meta-CIPs which typically serves another category or group of categories.
+- Wallets  | For standardisation across wallets (hardware, full-node or light).
+- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata | For proposals around metadata (on-chain or off-chain).
+- Tools    | A broad category for ecosystem tools not falling into any other category.
+- Plutus   | Changes or additions to Plutus
+- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
+
+-->
+
+## Abstract
+<!-- A short (\~200 word) description of the proposed solution and the technical issue being addressed. -->
+We propose to introduce a new Plutus scripts type `Observe` in addition to those currently available e (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. 
+Since observe validators are decoupled from actions, you can run them in a transaction without needing to perform any associated action (ie you don't need to consume a script input, or mint a token, or withdraw from a staking script just to execute this validator). 
+
+## Motivation: why is this CIP necessary?
+<!-- A clear explanation that introduces the reason for a proposal, its use cases and stakeholders. If the CIP changes an established design then it must outline design issues that motivate a rework. For complex proposals, authors must write a Cardano Problem Statement (CPS) as defined in CIP-9999 and link to it as the `Motivation`. -->
+Often in a plutus validator you want to check "a particular Plutus script checked this transaction", but it's annoying (and wasteful) to have to have to lock an output in a script and then check if that output is consumed, or mint a token, or whatever else just to trigger script validation. 
+
+Currently the main design pattern used to achieve this is a very obscure trick involving staking validators and the fact that you can withdraw 0 from a staking validator to trigger the script validation. A summary of the trick is:
+Implement all the intended validation logic in a Plutus staking validator, we will call this validator `s_v`. To check that this validator was executed in the transaction you check if the credential of `s_v` (`StakingCredential`) is present in `txInfoWdrl`, this guarantees that `s_v` was checked in validation. 
+This relies on the fact that unlike in `txInfoMint` the ledger does not filter out 0 amount entries in `txInfoWdrl`. This means that you are allowed to build transactions that withdraw zero from a staking credential which in-turn triggers the staking script associated with that credential to execute in the transaction,
+which makes it available in `txInfoWdrl`. This is a enables a very efficient design pattern for checking logic that is shared across multiple scripts.
+
+For instance, a common design pattern is a token based forwarding validator in which the validator defers its logic to another validator by checking that a state token is present in one of the transaction inputs:
+```haskell
+forwardNFTValidator :: AssetClass -> BuiltinData -> BuiltinData -> ScriptContext -> () 
+forwardNFTValidator stateToken _ _ ctx = assetClassValueOf stateToken (valueSpent (txInfo ctx)) == 1
+```
+This pattern is common in protocols that use the batcher architecture. Some protocols improve on the pattern by including the index of the input with the state token in the redeemer:
+```haskell
+forwardNFTValidator :: AssetClass -> BuiltinData -> Integer -> ScriptContext -> () 
+forwardNFTValidator stateToken _ tkIdx ctx =  assetClassValueOf stateToken (txInInfoResolved (elemAt tkIdx (txInfoInputs (txInfo ctx)))) == 1 
+
+forwardMintPolicy:: AssetClass -> Integer -> ScriptContext -> () 
+forwardMintPolicy stateToken tkIdx ctx =  assetClassValueOf stateToken (txInInfoResolved (elemAt tkIdx (txInfoInputs (txInfo ctx)))) == 1 
+```
+With this pattern DApps are able to process roughly 12-30 forwardNFTValidator UTxO's  per transaction without exceeding script budget limitations.
+The time complexity of this validator is **O(n)** where n is the number of tx inputs. This logic is executed once per input being unlocked  / currency symbol being minted. 
+The redundant execution of searching the inputs for a token is the largest throughput bottleneck for these DApps; it is **O(n*m)** where n is the number of inputs and m is the number of `forwardValidator` inputs + `forwardValidator` minting policies.
+Using the stake validator trick, the time complexity of the forwarding logic is improved to **O(1)**. The forwardValidator logic becomes:
+```haskell
+forwardWithStakeTrick:: StakingCredential -> BuiltinData -> BuiltinData -> ScriptContext -> ()
+forwardWithStakeTrick obsScriptCred tkIdx ctx = fst (head stakeCertPairs) == obsScriptCred 
+  where 
+    info = txInfo ctx 
+    stakeCertPairs = AssocMap.toList (txInfoWdrl info)
+```
+IE check that the StakingCredential is in the first pair in the `txInfoWdrl`.  This script is **O(1)** in the case where you limit it to one Observe script, or if you don't want to break composability with other Observe scripts, then it becomes** O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction.
+
+This proposal just makes this design pattern indepedent from implementation details of stake validators and withdrawals, and improves efficiency and readability for validators that implement it. 
+
+## Specification
+<!-- The technical specification should describe the proposed improvement in sufficient technical detail. In particular, it should provide enough information that an implementation can be performed solely on the basis of the design in the CIP. This is necessary to facilitate multiple, interoperable implementations. This must include how the CIP should be versioned. If a proposal defines structure of on-chain data it must include a CDDL schema in it's specification.-->
+The type signature of this script type will be consistent with the type signature of minting and staking validators, namely:
+```haskell
+Redeemer -> ScriptContext -> () 
+```
+
+The type signature of the newly introduced `Purpose` will be:
+```haskell
+Observe Integer -- ^ where integer is the index into the observations 
+```
+
+A new field will be introduced into the script context:
+
+```haskell
+-- | TxInfo for PlutusV3
+data TxInfo = TxInfo
+  { txInfoInputs                :: [V2.TxInInfo]
+  , txInfoReferenceInputs       :: [V2.TxInInfo]
+  , txInfoOutputs               :: [V2.TxOut]
+  , txInfoFee                   :: V2.Value
+  , txInfoMint                  :: V2.Value
+  , txInfoTxCerts               :: [TxCert]
+  , txInfoWdrl                  :: Map V2.Credential Haskell.Integer
+  , txInfoValidRange            :: V2.POSIXTimeRange
+  , txInfoSignatories           :: [V2.PubKeyHash]
+  , txInfoRedeemers             :: Map ScriptPurpose V2.Redeemer
+  , txInfoData                  :: Map V2.DatumHash V2.Datum
+  , txInfoId                    :: V2.TxId
+  , txInfoVotingProcedures      :: Map Voter (Map GovernanceActionId VotingProcedure)
+  , txInfoProposalProcedures    :: [ProposalProcedure]
+  , txInfoCurrentTreasuryAmount :: Haskell.Maybe V2.Value
+  , txInfoTreasuryDonation      :: Haskell.Maybe V2.Value
+  , txInfoObservations          :: [ScriptHash] -- ^ newly introduced list of observation scripts that executed in this tx. 
+  }
+```
+
+## Rationale: how does this CIP achieve its goals?
+<!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.
+
+It must also explain how the proposal affects the backward compatibility of existing solutions when applicable. If the proposal responds to a CPS, the 'Rationale' section should explain how it addresses the CPS, and answer any questions that the CPS poses for potential solutions.
+-->
+
+## Path to Active
+
+### Acceptance Criteria
+<!-- Describes what are the acceptance criteria whereby a proposal becomes 'Active' -->
+
+### Implementation Plan
+<!-- A plan to meet those criteria. Or `N/A` if not applicable. -->
+
+## Copyright
+<!-- The CIP must be explicitly licensed under acceptable copyright terms. -->
+
+[CC-BY-4.0]: https://creativecommons.org/licenses/by/4.0/legalcode
+[Apache-2.0]: http://www.apache.org/licenses/LICENSE-2.0

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -148,7 +148,7 @@ transaction_body =
 required_observations = set<scripthash>
 ```
 
-The required observations (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set, the transaction will fail in phase 1 validation. This way, Plutus validation scripts can know which observation scripts were executed in the transaction.
+The required observations (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
 
 ## Rationale: how does this CIP achieve its goals?
 <!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -33,7 +33,7 @@ Since observe validators are decoupled from actions, you can run them in a trans
 
 ## Motivation: why is this CIP necessary?
 <!-- A clear explanation that introduces the reason for a proposal, its use cases and stakeholders. If the CIP changes an established design then it must outline design issues that motivate a rework. For complex proposals, authors must write a Cardano Problem Statement (CPS) as defined in CIP-9999 and link to it as the `Motivation`. -->
-Often in a plutus validator you want to check "a particular Plutus script checked this transaction", but it's annoying (and wasteful) to have to have to lock an output in a script and then check if that output is consumed, or mint a token, or whatever else just to trigger script validation. 
+Often in a plutus validator you want to check "a particular (different) Plutus script checked this transaction", but it's annoying (and wasteful) to have to have to lock an output in a script and then check if that output is consumed, or mint a token, or whatever else just to trigger script validation. 
 
 Currently the main design pattern used to achieve this is a very obscure trick involving staking validators and the fact that you can withdraw 0 from a staking validator to trigger the script validation. A summary of the trick is:
 Implement all the intended validation logic in a Plutus staking validator, we will call this validator `s_v`. To check that this validator was executed in the transaction you check if the credential of `s_v` (`StakingCredential`) is present in `txInfoWdrl`, this guarantees that `s_v` was checked in validation. 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -189,7 +189,7 @@ This change is not backwards-compatible and will need to go into a new Plutus la
 ## Path to Active
 
 ### Acceptance Criteria
-- [] Fully implemented in Cardano.
+- [ ] These rules included within a official Plutus version, and released via a major hard fork.
       
 ### Implementation Plan
 - [ ] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -8,7 +8,7 @@ Authors:
 Implementors: []
 Discussions: 
     - https://github.com/cardano-foundation/CIPs/pull/418/
-Created: 2024-1-8
+Created: 2024-01-08
 License: CC-BY-4.0
 ---
 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -12,20 +12,6 @@ Created: 2024-01-08
 License: CC-BY-4.0
 ---
 
-
-<!-- Existing categories:
-
-- Meta     | For meta-CIPs which typically serves another category or group of categories.
-- Wallets  | For standardisation across wallets (hardware, full-node or light).
-- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata | For proposals around metadata (on-chain or off-chain).
-- Tools    | A broad category for ecosystem tools not falling into any other category.
-- Plutus   | Changes or additions to Plutus
-- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
-
--->
-
 ## Abstract
 <!-- A short (\~200 word) description of the proposed solution and the technical issue being addressed. -->
 We propose to introduce a new Plutus scripts type `Observe` in addition to those currently available (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -68,7 +68,7 @@ stakeValidatorWithSharedLogic :: AssetClass -> BuiltinData -> ScriptContext -> (
 stakeValidatorWithSharedLogic stateToken _rdmr ctx = assetClassValueOf stateToken (valueSpent (txInfo ctx)) == 1
 ```
 For the staking validator trick (demonstrated above), we are simply checking that the StakingCredential of the the staking validator containing the shared validation logic is in the first pair in `txInfoWdrl`. If the StakingCredential is present in `txInfoWdrl`, that means the staking validator (with our shared validation logic) successfully executed in the transaction. This script is **O(1)** in the case where you limit it to one shared logic validator (staking validator), or if you don't want to break composability with other staking validator, 
-then it becomes** O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction as you have to verify that the StakingCredential is present in `txInfoWdrl`.
+then it becomes **O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction as you have to verify that the StakingCredential is present in `txInfoWdrl`.
 
 
 This proposal makes this design pattern indepedent from implementation details of stake validators and withdrawals, and improves efficiency and readability for validators that implement it. 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -173,6 +173,7 @@ It must also explain how the proposal affects the backward compatibility of exis
       
 ## Copyright
 <!-- The CIP must be explicitly licensed under acceptable copyright terms. -->
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 [CC-BY-4.0]: https://creativecommons.org/licenses/by/4.0/legalcode
 [Apache-2.0]: http://www.apache.org/licenses/LICENSE-2.0

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -148,7 +148,7 @@ transaction_body =
 required_scripts = set<scripthash>
 ```
 
-The required scripts (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set or present in a reference script, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
+The required scripts (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set or as a reference script and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set or present in a reference script, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
 
 ## Rationale: how does this CIP achieve its goals?
 <!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -147,19 +147,28 @@ transaction_body =
   , ? 20 : proposal_procedures             ; Proposal procedures
   , ? 21 : coin                            ; current treasury value
   , ? 22 : positive_coin                   ; donation
-  , ? 23 : required_scripts                ; New; observation scripts that must execute in phase 2 validation
+  , ? 23 : required_observers              ; New; observation scripts that must execute in phase 2 validation
   }
 
-required_scripts = set<scripthash>
+required_observers = set<scripthash>
 ```
 
-The required scripts (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set or as a reference script and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set or present in a reference script, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
+The `required_observers` (field 23) is a set of script hashes that can be used to require the associated Plutus script to be present in the witness set or as a reference script and executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set or present in a reference script, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
 
 ## Rationale: how does this CIP achieve its goals?
 <!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.
 
 It must also explain how the proposal affects the backward compatibility of existing solutions when applicable. If the proposal responds to a CPS, the 'Rationale' section should explain how it addresses the CPS, and answer any questions that the CPS poses for potential solutions.
 -->
+Currently Plutus scripts in a transaction will only execute when the transaction performs the associated ledger action (ie. a Plutus minting policy will only execute if the transaction mints or burns tokens with matching currency symbol). The only exception is the withdraw zero trick which relies on an obscure mechanic where zero amount withdrawals are not filtered by the ledger. Now using `required_observers` we can specify a list of Plutus scripts to be executed in the transaction independent of any ledger actions. The newly introduced `txInfoObservations` field in the script context provides a straightforward way for Plutus scripts to check that "a particular script validated this transaction".
+
+This change is not backwards-compatible and will need to go into a new Plutus language version.
+
+### Alternatives 
+
+- We could decide to accept the withdraw-zero staking script trick as an adequate solution, and just preserve the nonsensical withdraw zero case in future language versions. 
+- The staking script trick could be abstracted away from the developer by smart contract languages that compile to UPLC. 
+    - This can be dangerous since by distancing the developer from what is actually happening you open up the door for the developer to act on misguided assumptions. 
 
 ## Path to Active
 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -28,7 +28,7 @@ License: CC-BY-4.0
 
 ## Abstract
 <!-- A short (\~200 word) description of the proposed solution and the technical issue being addressed. -->
-We propose to introduce a new Plutus scripts type `Observe` in addition to those currently available e (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. 
+We propose to introduce a new Plutus scripts type `Observe` in addition to those currently available (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. 
 Since observe validators are decoupled from actions, you can run them in a transaction without needing to perform any associated action (ie you don't need to consume a script input, or mint a token, or withdraw from a staking script just to execute this validator). 
 
 ## Motivation: why is this CIP necessary?

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: ?
+CIP: 112
 Title: Observe Script Type
 Status: Proposed
 Category: Plutus

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -192,7 +192,7 @@ This change is not backwards-compatible and will need to go into a new Plutus la
 - [] Fully implemented in Cardano.
       
 ### Implementation Plan
-- [] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
+- [ ] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
       
 ## Copyright
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -6,7 +6,8 @@ Category: Plutus
 Authors:
     - Philip DiSarro <info@anastasialabs.com>
 Implementors: []
-Discussions: []
+Discussions: 
+    - https://github.com/cardano-foundation/CIPs/pull/418/
 Created: 2024-1-8
 License: CC-BY-4.0
 ---

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -13,13 +13,11 @@ License: CC-BY-4.0
 ---
 
 ## Abstract
-<!-- A short (\~200 word) description of the proposed solution and the technical issue being addressed. -->
 We propose to introduce a new Plutus scripts type `Observe` in addition to those currently available (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. 
 Since observe validators are decoupled from actions, you can run them in a transaction without needing to perform any associated action (ie you don't need to consume a script input, or mint a token, or withdraw from a staking script just to execute this validator). 
 Additionally, we propose to introduce a new assertion to native scripts that they can use to check that a particular script hash is in `required_observers` (which in turn enforces that the script must be executed successfully in the transaction). This addresses a number of technical issues discussed in other CIPs and CPS such as the redundant execution of spending scripts, and the inability to effectively use native scripts in conjunction with Plutus scripts. 
 
 ## Motivation: why is this CIP necessary?
-<!-- A clear explanation that introduces the reason for a proposal, its use cases and stakeholders. If the CIP changes an established design then it must outline design issues that motivate a rework. For complex proposals, authors must write a Cardano Problem Statement (CPS) as defined in CIP-9999 and link to it as the `Motivation`. -->
 Often in a plutus validator you want to check "a particular (different) Plutus script checked this transaction", but it's annoying (and wasteful) to have to have to lock an output in a script and then check if that output is consumed, or mint a token, or whatever else just to trigger script validation. 
 
 Currently the main design pattern used to achieve this is a very obscure trick involving staking validators and the fact that you can withdraw 0 from a staking validator to trigger the script validation. A summary of the trick is:
@@ -72,7 +70,6 @@ all the UTxOs that we would like to share the same spending condition into the f
 The above solution (enabled by this CIP) is more clear, concise, flexible and efficient than the alternatives discussed above.
 
 ## Specification
-<!-- The technical specification should describe the proposed improvement in sufficient technical detail. In particular, it should provide enough information that an implementation can be performed solely on the basis of the design in the CIP. This is necessary to facilitate multiple, interoperable implementations. This must include how the CIP should be versioned. If a proposal defines structure of on-chain data it must include a CDDL schema in it's specification.-->
 The type signature of this script type will be consistent with the type signature of minting and staking validators, namely:
 ```haskell
 Redeemer -> ScriptContext -> () 
@@ -178,10 +175,7 @@ Native scripts are typically represented in JSON syntax. We propose the followin
 
 
 ## Rationale: how does this CIP achieve its goals?
-<!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.
 
-It must also explain how the proposal affects the backward compatibility of existing solutions when applicable. If the proposal responds to a CPS, the 'Rationale' section should explain how it addresses the CPS, and answer any questions that the CPS poses for potential solutions.
--->
 Currently Plutus scripts (and native scripts) in a transaction will only execute when the transaction performs the associated ledger action (ie. a Plutus minting policy will only execute if the transaction mints or burns tokens with matching currency symbol). The only exception is the withdraw zero trick which relies on an obscure mechanic where zero amount withdrawals are not filtered by the ledger. Now using `required_observers` we can specify a list of scripts (supports both native and Plutus scripts) to be executed in the transaction independent of any ledger actions. The newly introduced `txInfoObservations` field in the script context provides a straightforward way for scripts to check that "a particular script validated this transaction".
 
 This change is not backwards-compatible and will need to go into a new Plutus language version.
@@ -195,15 +189,12 @@ This change is not backwards-compatible and will need to go into a new Plutus la
 ## Path to Active
 
 ### Acceptance Criteria
-<!-- Describes what are the acceptance criteria whereby a proposal becomes 'Active' -->
 - [] Fully implemented in Cardano.
       
 ### Implementation Plan
-<!-- A plan to meet those criteria. Or `N/A` if not applicable. -->
 - [] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
       
 ## Copyright
-<!-- The CIP must be explicitly licensed under acceptable copyright terms. -->
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 [CC-BY-4.0]: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -142,13 +142,13 @@ transaction_body =
   , ? 20 : proposal_procedures             ; Proposal procedures
   , ? 21 : coin                            ; current treasury value
   , ? 22 : positive_coin                   ; donation
-  , ? 23 : required_observations           ; New; observation scripts that must execute in phase 2 validation
+  , ? 23 : required_scripts                ; New; scripts that must execute in phase 2 validation
   }
 
-required_observations = set<scripthash>
+required_scripts = set<scripthash>
 ```
 
-The required observations (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
+The required scripts (field 23) is a set of script hashes that can be used to require the associated Plutus script to present in the witness set and is executed in the transaction. If a script hash is present but the corresponding Plutus script is not in the witness set or present in a reference script, the transaction will fail in phase 1 validation. This way plutus scripts can check the script context to know which observation scripts were executed in the transaction.
 
 ## Rationale: how does this CIP achieve its goals?
 <!-- The rationale fleshes out the specification by describing what motivated the design and what led to particular design decisions. It should describe alternate designs considered and related work. The rationale should provide evidence of consensus within the community and discuss significant objections or concerns raised during the discussion.

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -142,7 +142,7 @@ transaction_body =
   , ? 20 : proposal_procedures             ; Proposal procedures
   , ? 21 : coin                            ; current treasury value
   , ? 22 : positive_coin                   ; donation
-  , ? 23 : required_scripts                ; New; scripts that must execute in phase 2 validation
+  , ? 23 : required_scripts                ; New; observation scripts that must execute in phase 2 validation
   }
 
 required_scripts = set<scripthash>

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -63,7 +63,7 @@ forwardWithStakeTrick obsScriptCred tkIdx ctx = fst (head stakeCertPairs) == obs
     info = txInfo ctx 
     stakeCertPairs = AssocMap.toList (txInfoWdrl info)
 ```
-IE check that the StakingCredential is in the first pair in the `txInfoWdrl`.  This script is **O(1)** in the case where you limit it to one Observe script, or if you don't want to break composability with other Observe scripts, then it becomes** O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction.
+IE check that the StakingCredential is in the first pair in the `txInfoWdrl`.  This script is **O(1)** in the case where you limit it to one Observe script, or if you don't want to break composability with other Observe scripts, then it becomes **O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction.
 
 This proposal makes this design pattern indepedent from implementation details of stake validators and withdrawals, and improves efficiency and readability for validators that implement it. 
 

--- a/cip-observe-script-type/README.md
+++ b/cip-observe-script-type/README.md
@@ -63,8 +63,13 @@ forwardWithStakeTrick obsScriptCred tkIdx ctx = fst (head stakeCertPairs) == obs
   where 
     info = txInfo ctx 
     stakeCertPairs = AssocMap.toList (txInfoWdrl info)
+
+stakeValidatorWithSharedLogic :: AssetClass -> BuiltinData -> ScriptContext -> () 
+stakeValidatorWithSharedLogic stateToken _rdmr ctx = assetClassValueOf stateToken (valueSpent (txInfo ctx)) == 1
 ```
-IE check that the StakingCredential is in the first pair in the `txInfoWdrl`.  This script is **O(1)** in the case where you limit it to one Observe script, or if you don't want to break composability with other Observe scripts, then it becomes **O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction.
+For the staking validator trick (demonstrated above), we are simply checking that the StakingCredential of the the staking validator containing the shared validation logic is in the first pair in `txInfoWdrl`. If the StakingCredential is present in `txInfoWdrl`, that means the staking validator (with our shared validation logic) successfully executed in the transaction. This script is **O(1)** in the case where you limit it to one shared logic validator (staking validator), or if you don't want to break composability with other staking validator, 
+then it becomes** O(obs_N)** where `obs_N` is the number of Observe validators that are executed in the transaction as you have to verify that the StakingCredential is present in `txInfoWdrl`.
+
 
 This proposal makes this design pattern indepedent from implementation details of stake validators and withdrawals, and improves efficiency and readability for validators that implement it. 
 


### PR DESCRIPTION
We propose to introduce a new Plutus scripts type Observe in addition to those currently available (spending, certifying, rewarding, minting, drep). The purpose of this script type is to allow arbitrary validation logic to be decoupled from any ledger action. Since observe validators are decoupled from actions, you can run them in a transaction without needing to perform any associated action (ie you don't need to consume a script input, or mint a token, or withdraw from a staking script just to execute this validator).

---

[Rendered Proposal on Fork](https://github.com/colll78/CIPs/blob/Observe-Script-Type/cip-observe-script-type/README.md)