### PR TITLE
CIP-9999 | Structure and template revisions

### DIFF
--- a/.github/CPS-TEMPLATE.md
+++ b/.github/CPS-TEMPLATE.md
@@ -42,3 +42,5 @@ Finally, goals may also serve as evaluation metrics to assess how good a propose
 
 ## Open Questions
 <!-- A set of questions to which any proposed solution should find an answer. Questions should help guide solutions design by highlighting some foreseen vulnerabilities or design flaws. Solutions in the form of CIP should thereby include these questions as part of their 'Rationale' section and provide an argued answer to each. -->
+
+<!-- OPTIONAL SECTIONS: see CIP-0001 > Document > Structure table -->

--- a/.github/CPS-TEMPLATE.md
+++ b/.github/CPS-TEMPLATE.md
@@ -43,4 +43,4 @@ Finally, goals may also serve as evaluation metrics to assess how good a propose
 ## Open Questions
 <!-- A set of questions to which any proposed solution should find an answer. Questions should help guide solutions design by highlighting some foreseen vulnerabilities or design flaws. Solutions in the form of CIP should thereby include these questions as part of their 'Rationale' section and provide an argued answer to each. -->
 
-<!-- OPTIONAL SECTIONS: see CIP-0001 > Document > Structure table -->
+<!-- OPTIONAL SECTIONS: see CIP-9999 > Specification > CPS > Structure table -->

--- a/CIP-9999/README.md
+++ b/CIP-9999/README.md
@@ -47,6 +47,7 @@ Problem            | A more detailed description of the problem and its context.
 Use cases          | A concrete set of examples written from a user's perspective, describing what and why they are trying to do. When they exist, this section should give a sense of the current alternatives and highlight why they are unsuitable.
 Goals              | A list of goals and non-goals a project is pursuing, ranked by importance. These goals should help understand the design space for the solution and what the underlying project is ultimately trying to achieve. <br/><br/>Goals may also contain requirements for the project. For example, they may include anything from a deadline to a budget (in terms of complexity or time) to security concerns. <br/><br/>Finally, goals may also serve as evaluation metrics to assess how good a proposed solution is.
 Open Questions     | A set of questions to which any proposed solution should find an answer. Questions should help guide solutions design by highlighting some foreseen vulnerabilities or design flaws. Solutions in the form of CIP should thereby include these questions as part of their _'Rationale'_ section and provide an argued answer to each.
+_optional sections_| If necessary, these sections may also be included in any order:<br/>**References**<br/>**Appendices**<br>Do not add material in an optional section if it pertains to one of the standard sections.
 
 ##### Header preamble
 


### PR DESCRIPTION
To fix:
- the CPS half of https://github.com/cardano-foundation/CIPs/issues/731 (already fixed for CIPs)
- to legitimise the top level `References` section - and maybe other optional sections - as per discussion beginning https://github.com/cardano-foundation/CIPs/pull/638#discussion_r1439333464
- to complete what was started in #730 which added optional sections for the CIP but not for the CPS.

Whatever _optional sections_ we agree on for CPSs should be more reserved than for CIPs which have more of a precent for formality... otherwise the less formal problem statements will have arbitrary top-level sections everywhere for things that would be better focused into the 5 major headings so that CIP authors can more readily use them.
- This is why I left out the "custom" sections which we have recently admitted for the CIP format.

**BONUS QUESTION**: Should we add a _Copyright_ section to CPSs?
- Related question: why was _Copyright_ not added to the CPS in the first place, while it's always been a _de rigueur_ part of the CIP?
- asked already here: https://github.com/cardano-foundation/CIPs/pull/730#discussion_r1439757810

This is a short change initially but could end up longer if the format "rules" end up being more flexible or more rigorous.  cc @KtorZ @michaelpj