### PR TITLE
add License field + Copyright section to all CPSs

### DIFF
--- a/CPS-0005/README.md
+++ b/CPS-0005/README.md
@@ -14,6 +14,7 @@ Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/497
   - https://github.com/input-output-hk/Developer-Experience-working-group
 Created: 2023-04-04
+License: CC-BY-4.0
 ---
 
 ## Abstract
@@ -167,3 +168,7 @@ Many of the above problems could be mitigated with a good metadata solution, and
 
 For example, simply knowing the script itself (i.e. the pre-image of the hash used in the script address) helps with problem 1, because then you can know that it’s a Plutus script.
 But it still doesn’t tell you what the form of the datum should be (problem 6), but this could be conveyed with additional metadata.
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0005/README.md
+++ b/CPS-0005/README.md
@@ -171,4 +171,4 @@ But it still doesn’t tell you what the form of the datum should be (problem 6)
 
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+This CPS is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0007/README.md
+++ b/CPS-0007/README.md
@@ -10,6 +10,7 @@ Proposed Solutions:
 Discussions:
   - https://discord.gg/hdqHwSgWvG
 Created: 2023-03-14
+License: CC-BY-4.0
 ---
 
 ## **Abstract**
@@ -97,3 +98,7 @@ Below are a set of philosophical questions applicable across a broad range of so
 4. What kinds of community standards are needed outside of the scope of a specific solution at the ledger layer?
 5. What kinds of incentives (or disinsentives) should we use to align behavior with our goals? Should we try to compensate actors for the time and effort they put in, or does that create corrupt and misaligned incentives of their own?
 6. Is the ability to delegate overall more helpful or harmful? Does the risk of "popularity" based delegation (as opposed to trust / expertise based delegation) dilute the votes of others more than it increases inclusivity?
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0007/README.md
+++ b/CPS-0007/README.md
@@ -101,4 +101,4 @@ Below are a set of philosophical questions applicable across a broad range of so
 
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+This CPS is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0010/README.md
+++ b/CPS-0010/README.md
@@ -358,4 +358,4 @@ How can we prevent duplication of functionality and make sure different APIs do 
 
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+This CPS is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0010/README.md
+++ b/CPS-0010/README.md
@@ -10,6 +10,7 @@ Proposed Solutions: []
 Discussions:
     - https://github.com/cardano-foundation/cips/pull/619
 Created: 2023-07-28
+License: CC-BY-4.0
 ---
 
 ## Abstract
@@ -354,3 +355,7 @@ What options do we have for integration with Cardano sidechains, rollups, hardfo
 
 ### How can we effectively police API scope?
 How can we prevent duplication of functionality and make sure different APIs do not overlap?
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0011/README.md
+++ b/CPS-0011/README.md
@@ -66,4 +66,4 @@ Non-goals:
 
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+This CPS is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0011/README.md
+++ b/CPS-0011/README.md
@@ -9,6 +9,7 @@ Proposed Solutions: []
 Discussions:
     - https://github.com/cardano-foundation/cips/pulls/742
 Created: 2024-01-10
+License: CC-BY-4.0
 ---
 
 ## Abstract
@@ -62,3 +63,7 @@ Non-goals:
 - How can we programmatically or manually test the constructed schema file?
 - How to encode long integer arithmetic? Some JSON encoding implementations simply refuse to handle long integers, e.g. [CSL](https://github.com/Emurgo/cardano-serialization-lib/blob/4a35ef11fd5c4931626c03025fe6f67743a6bdf9/rust/src/plutus.rs#L1370).
 - [RFC8949](https://www.rfc-editor.org/rfc/rfc8949.html#name-converting-data-between-cbo) and [RFC8610](https://datatracker.ietf.org/doc/html/rfc8610#appendix-E) contain recommendations for developers who want to maintain interoperability with JSON. Can we apply these in our context?
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0013/README.md
+++ b/CPS-0013/README.md
@@ -100,3 +100,7 @@ Since map operations currently have much worse complexity than a good map data s
 ## References
 
 - https://x.com/Quantumplation/status/1733298551571038338?s=20
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CPS-0013/README.md
+++ b/CPS-0013/README.md
@@ -103,4 +103,4 @@ Since map operations currently have much worse complexity than a good map data s
 
 ## Copyright
 
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+This CPS is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).


### PR DESCRIPTION
Implements change agreed in #762 for all merged CPSs.  These all add CC licensing (vs. Apache, so far) since, as mainly will be true for CPSs, they're all narrative & no code.

This is also a check to see if there will be any downstream problems, mainly due to the new mandatory field in the YAML preamble, on (cc @fill-the-fill @katomm):
- `cips.cardano.org` ([cf-cip-frontend](https://github.com/cardano-foundation/cf-cip-frontend))
- the CIP / CPS build script on the Dev Portal

TODO wait before merging to confirm no downstream problems before:
- [ ] merging this PR
- [ ] updating PRs for other CPSs in progress
