### PR TITLE
CIP-0057 | Include Plutus V3

### DIFF
--- a/CIP-0057/schemas/plutus-blueprint.json
+++ b/CIP-0057/schemas/plutus-blueprint.json
@@ -48,7 +48,7 @@
                 },
                 "plutusVersion": {
                     "type": "string",
-                    "enum": [ "v1", "v2" ]
+                    "enum": [ "v1", "v2", "v3" ]
                 },
                 "license": {
                     "type": "string"


### PR DESCRIPTION
While the next Plutus Ledger Language version is not yet available on mainnet, its conceivable that one might want to produce a Contract  Blueprint for it. 

This PR adds `v3` to the list of allowed `plutusVersion` values.