### PR TITLE
CIP-0057 | Fix schema validation error (strict mode)

### DIFF
--- a/CIP-0057/schemas/plutus-builtin.json
+++ b/CIP-0057/schemas/plutus-builtin.json
@@ -125,6 +125,7 @@
             }
         },
         "_pair": {
+            "type": "object",
             "dataType": "object",
             "required": [
                 "dataType",

--- a/CIP-0057/schemas/plutus-data.json
+++ b/CIP-0057/schemas/plutus-data.json
@@ -91,6 +91,7 @@
             }
         },
         "map": {
+            "type": "object",
             "dataType": "object",
             "required": [
                 "dataType",


### PR DESCRIPTION
This PR fixes a subtle mistake in the JSON schema that is caught by the popular JSON schema validator `ajv`:

```
Error: strict mode: missing type "object" for keyword "required" at "https://cips.cardano.org/cips/cip57/schemas/plutus-builtin.json#" (strictTypes)
    at checkStrictMode (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/util.js:174:15)
    at strictTypesError (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:286:32)
    at checkKeywordTypes (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:262:17)
    at checkStrictTypes (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:234:5)
    at schemaKeywords (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:189:9)
    at typeAndKeywords (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:128:5)
    at /home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:70:9
    at CodeGen.code (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/codegen/index.js:439:13)
    at /home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/validate/index.js:37:166
    at CodeGen.code (/home/yura/projects/cardano/plutus/node_modules/ajv/dist/compile/codegen/index.js:439:13)
```

See the context and example here: https://github.com/ajv-validator/ajv/issues/1553#issuecomment-1152409894

I've added explicit `"type": "object"` in a few places and it fixes the validation error.