### PR TITLE
CIP-0088, CIP-0100 | Fix relative pathnames

### DIFF
--- a/CIP-0088/README.md
+++ b/CIP-0088/README.md
@@ -254,15 +254,15 @@ This entry, if present, should be a CIP ID indexed object containing additional 
 When and where possible the CIP-Specific registration should follow the CBOR-like declaration syntax to ensure that
 the content is well-formed and easily parseable.
 
-| CIP | Name                          | Version | Status | CDDL                                     | Rationale           |
-|-----|-------------------------------|---------|--------|------------------------------------------|---------------------|
-| 25  | Token Metadata                | 1       | Active | [CIP25_v1.cddl](CIPs/0025/CIP25_v1.cddl) | [CIP-25](CIPs/0025) |
-| 26  | Fungible Token Information    | 1       | Active | [CIP26_v1.cddl](CIPs/0026/CIP26_v1.cddl) | [CIP-26](CIPs/0026) |
-| 27  | Token Royalties               | 1       | Active | [CIP27_v1.cddl](CIPs/0027/CIP27_v1.cddl) | [CIP-27](CIPs/0027) |
-| 48  | Metadata References           | 1       | Draft  | [CIP48_v1.cddl](CIPs/0048/CIP48_v1.cddl) | [CIP-48](CIPs/0048) |
-| 60  | Music Token Metadata          | 1       | Draft  | [CIP60_v1.cddl](CIPs/0060/CIP60_v1.cddl) | [CIP-60](CIPs/0060) |
-| 68  | Datum Token Metadata          | 1       | Active | [CIP68_v1.cddl](CIPs/0068/CIP68_v1.cddl) | [CIP-68](CIPs/0068) |
-| 86  | Token Metadata Update Oracles | 1       | Active | [CIP86_v1.cddl](CIPs/0086/CIP86_v1.cddl) | [CIP-86](CIPs/0086) |
+| CIP | Name                          | Version | Status | CDDL                                       | Rationale             |
+|-----|-------------------------------|---------|--------|--------------------------------------------|-----------------------|
+| 25  | Token Metadata                | 1       | Active | [CIP25_v1.cddl](./CIPs/0025/CIP25_v1.cddl) | [CIP-25](./CIPs/0025) |
+| 26  | Fungible Token Information    | 1       | Active | [CIP26_v1.cddl](./CIPs/0026/CIP26_v1.cddl) | [CIP-26](./CIPs/0026) |
+| 27  | Token Royalties               | 1       | Active | [CIP27_v1.cddl](./CIPs/0027/CIP27_v1.cddl) | [CIP-27](./CIPs/0027) |
+| 48  | Metadata References           | 1       | Draft  | [CIP48_v1.cddl](./CIPs/0048/CIP48_v1.cddl) | [CIP-48](./CIPs/0048) |
+| 60  | Music Token Metadata          | 1       | Draft  | [CIP60_v1.cddl](./CIPs/0060/CIP60_v1.cddl) | [CIP-60](./CIPs/0060) |
+| 68  | Datum Token Metadata          | 1       | Active | [CIP68_v1.cddl](./CIPs/0068/CIP68_v1.cddl) | [CIP-68](./CIPs/0068) |
+| 86  | Token Metadata Update Oracles | 1       | Active | [CIP86_v1.cddl](./CIPs/0086/CIP86_v1.cddl) | [CIP-86](./CIPs/0086) |
 
 ***Note: CIP-0068 Tokens***
 

--- a/CIP-0100/README.md
+++ b/CIP-0100/README.md
@@ -139,7 +139,7 @@ Note: Any URI's in the @context field SHOULD be content-addressable and robustly
 
 In CIP-1694 (and likely any alternative or future evolution of it), there are a number of certificates that can be attached to a transaction pertaining to governance; each of these is equipped with an "anchor", which is a URI at which can be found additional metadata.
 
-While this metadata can be published anywhere, external hosting may be unavailable to some users. Therefore, we recognize the transaction metadata as an effective tool for a "common town square" for hosting and discoverability, and reserve [metadatum label 1694](../CIP-0010/README.md) for publishing governance related metadata on-chain.
+While this metadata can be published anywhere, external hosting may be unavailable to some users. Therefore, we recognize the transaction metadata as an effective tool for a "common town square" for hosting and discoverability, and reserve [metadatum label 1694](../CIP-0010) for publishing governance related metadata on-chain.
 
 With the help of [CIP-?](https://github.com/cardano-foundation/CIPs/pull/635), the anchor can then refer to the metadata of another transaction, or even the metadata of the transaction being published itself.
 


### PR DESCRIPTION
This I believe will fix the errors currently appearing when building the Developer Portal (cc @katomm), going on several weeks now since the last updates of CIP-0088 (@Crypto2099) and CIP-0100 (@Ryun1):

```
- On source page path = /docs/governance/cardano-improvement-proposals/CIP-0088:
   -> linking to CIPs/0025/CIP25_v1.cddl (resolved as: /docs/governance/cardano-improvement-proposals/CIPs/0025/CIP25_v1.cddl)
   -> linking to CIPs/0025 (resolved as: /docs/governance/cardano-improvement-proposals/CIPs/0025)
   -> linking to CIPs/0026/CIP26_v1.cddl (resolved as: /docs/governance/cardano-improvement-proposals/CIPs/0026/CIP26_v1.cddl)
   -> linking to CIPs/0026 (resolved as: /docs/governance/cardano-improvement-proposals/CIPs/0026)
   -> /* a few more in the same pattern */
- On source page path = /docs/governance/cardano-improvement-proposals/CIP-0100:
   -> linking to ./CIP-0010/README.md (resolved as: /docs/governance/cardano-improvement-proposals/CIP-0010/README.md)
```

I'm counting that the Rationale column of the table in CIP-0088 - which points to directories, and works normally on GitHub which displays that directory's README file - will also work in Docusaurus (my understanding of its routing is that it will; and also that hard-coding a trailing path component of `README.md` would cause a problem).

Following that last principle, the inter-CIP link in CIP-0100 has been corrected by removing the trailing `README.md` (simply `../CIP-0010`) following the example of CIP-0009 which works on the Developer Portal (but currently not on `cips.cardano.org`... cc @fill-the-fill).

Sometimes these problems have been more generally fixed by replacing relative links with absolute links to GitHub... but then we have the problem of changing reference frames from the derived web site back to GitHub which many readers will find disorienting.  But otherwise, this juggling relative links around has been going on for 2 or 3 years and I still have yet to find or determine any conclusive set of rules to follow for links between CIPs for complete portability with the derived sites. 🤔 cc @KtorZ