### PR TITLE
CIP-0069 | single argument Scripts

### DIFF
--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -65,11 +65,17 @@ data ScriptArgs =
   | RedeemerAndDatum Redeemer Datum
 ```
 
+In the case of a spend purpose, the ledger would execute the script with RedeemerAndDatum Redeemer Datum if a datum is present in the spending input. Otherwise the ledger would execute the script with RedeemerOnly Redeemer. In all other purposes the ledger would enforce only RedeemerOnly Redeemer is used with the script execution.
+
 ## Rationale: how does this CIP achieve its goals?
 
 Unifying of the script signature is a very elegant solution to the problem, streamlining the experience of developing on cardano.
 Given that accessing the datum is almost always made by a spending script, it makes sense to introduce that argument back to the `ScriptPurpose` that now plays a more important role.
 It begs the question if it should be added as an argument to all validators, to further emphasize that fact.
+
+I'm not sure what the above section is talking about?
+
+This CIP turns all scripts into 2 arg scripts with a variant for the first argument that can be matched on to determine if a datum and redeemer or only redeemer is present.
 
 ## Backwards compatibility
 

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -22,6 +22,8 @@ The exact change would be to have every validator take as argument the redeemer 
 
 ## Motivation: why is this CIP necessary?
 
+### Multi-purpose Scripts
+
 As it stands the scripts being made on cardano often suffer this problem, and the tokens usually are made to be able to be minted at any time. This leads to further checks being made on the frontend and further fragilitiy of the systems we create. When a mutual dependency arises we are forced to choose which script gets to statically know what's the hash of the other, and which has to be provided 'during runtime'.
 
 - Use Case 1: Minting validator checks datum given to spending validator. The spending validator requires the token be present as witness of the datum's correctness.
@@ -30,9 +32,23 @@ As it stands the scripts being made on cardano often suffer this problem, and th
 
 - Use Case 3 (taken from Minswap's Dex V1): NFT is minted for the same reason as above. It allows a minting policy to later mint LP tokens with that unique id token name.
 
-We see a similar pattern repeating over and over again as witnessed by dapp developers and auditors alike. By allowing the multi-purpose policies (spending and any other) we increase the security of Cardano by giving us more confidence and allowing to design protocols that have their architecture driven by Cardano's features, not limited by Cardano's language.
+We see a similar pattern repeating over and over again as witnessed by dapp developers and auditors alike. By allowing the multi-purpose scripts (spending and any other) we increase the security of Cardano by giving us more confidence and allowing to design protocols that have their architecture driven by Cardano's features, not limited by Cardano's language.
 
 This primarily manifests in the ability to use a single validator for both minting and spending but the proposed solution makes it possible to use one validator for any and all purposes at once.
+
+### No Datum Spend Purpose
+
+One of the major footguns of Plutus scripts is if a user sends to the script with a wrong or missing datum. This has happened in the recent case of the Nami wallet having a bug that caused the wrong address to be chosen. A wrong datum can be handled by the Plutus scripts themselves by having an alternative execution branch if type does not match the expected datum type. But in the case of no datum the script is not run and fails in phase 1. The other motivation of this CIP is to be able to create spend scripts that can handle the no datum case. 
+
+I see three major use cases when it comes to running spend scripts without datums:
+
+- Use Case 1: A script that acts as a wallet for users. By having no datum spending the user can send directly from exchanges or have friends send to their smart contract wallet with no datum needed.
+
+- Use Case 2: As a DAO treasury. The funds in this script would be controlled by a DAO and anyone can donate/contribute to the DAO without a datum.
+
+- Use Case 3: Allow dApp protocols to have a claim or withdraw mechanism (similar to Ethereum for tokens sent to a contract without call) for claiming tokens sent without a datum.
+
+I'd be remiss if I didn't mention CIP-0112 which has been expanded to improve native script capabilities to provide an alternative solution for use case 1 and 2. But for use case 3, CIP-0112 does not enable a "claim or withdraw mechanism" for contracts.
 
 ## Specification
 

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -38,7 +38,7 @@ This primarily manifests in the ability to use a single validator for both minti
 
 ### No Datum Spend Purpose
 
-One of the major footguns of Plutus scripts is if a user sends to the script with a wrong or missing datum. This has happened in the recent case of the Nami wallet having a bug that caused the wrong address to be chosen. A wrong datum can be handled by the Plutus scripts themselves by having an alternative execution branch if type does not match the expected datum type. But in the case of no datum the script is not run and fails in phase 1. The other motivation of this CIP is to be able to create spend scripts that can handle the no datum case. 
+One of the major footguns of Plutus scripts is if a user sends to the script with a wrong or missing datum. This has happened in the case of the Nami wallet having a bug that caused the wrong address to be chosen. There are other instances of user error where they send from a CEX to a script address. A wrong datum can be handled by the Plutus scripts themselves by having an alternative execution branch if type does not match the expected datum type. But in the case of no datum the script is not run and fails in phase 1. The other motivation of this CIP is to be able to create spend scripts that can handle the no datum case. 
 
 I see three major use cases when it comes to running spend scripts without datums:
 


### PR DESCRIPTION
Not sure if we should discuss here or in #769

The goal is to add additional clarity to this CIP or determine if another CIP is better suited to 2 major use cases

1. Having a spend script share the same script hash as a mint, withdrawing, observing, or certifying script without using a argument check workaround currently used in Opshin and Aiken
2. Giving smart contract creators the ability to handle the no datum case with spend contracts.