### PR TITLE
CIP-0068 | Allow [* bounded_bytes] for images

### DIFF
--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -191,7 +191,7 @@ metadata =
 ; A valid Uniform Resource Identifier (URI) as a UTF-8 encoded bytestring.
 ; The URI scheme must be one of `https` (HTTP), `ipfs` (IPFS), `ar` (Arweave) or `data` (on-chain).
 ; Data URLs (on-chain data) must comply to RFC2397.
-uri = bounded_bytes ; UTF-8
+uri = bounded_bytes / [ * bounded_bytes ] ; UTF-8
   
 ; Custom user defined plutus data.
 ; Setting data is optional, but the field is required

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -200,7 +200,7 @@ extra = plutus_data
 
 datum = #6.121([metadata, version, extra])
 
-version = 1 / 2
+version = 1 / 2 / 3
 ```
 
 Example datum as JSON:
@@ -316,7 +316,7 @@ extra = plutus_data
 
 datum = #6.121([metadata, version, extra])
 
-version = 1 / 2
+version = 1 / 2 / 3
 ```
 
 Example datum as JSON:
@@ -442,7 +442,7 @@ extra = plutus_data
 
 datum = #6.121([metadata, version, extra])
 
-version = 2
+version = 3
 ```
 
 Example datum as JSON:
@@ -572,6 +572,10 @@ versions of the affected tokens. `asset_name_labels` **MUST** only be marked obs
 #### version 2
 
 - Added new RFT asset class (444)
+
+#### version 3
+
+- Added plutus data array support to the image and src tags on the metadata 
 
 ## Rationale: how does this CIP achieve its goals?
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -307,7 +307,7 @@ metadata =
 ; A valid Uniform Resource Identifier (URI) as a UTF-8 encoded bytestring.
 ; The URI scheme must be one of `https` (HTTP), `ipfs` (IPFS), `ar` (Arweave) or `data` (on-chain).
 ; Data URLs (on-chain data) must comply to RFC2397.
-uri = bounded_bytes ; UTF-8
+uri = bounded_bytes / [ * bounded_bytes ] ; UTF-8
 
 ; Custom user defined plutus data.
 ; Setting data is optional, but the field is required

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -433,7 +433,7 @@ metadata =
 ; A valid Uniform Resource Identifier (URI) as a UTF-8 encoded bytestring.
 ; The URI scheme must be one of `https` (HTTP), `ipfs` (IPFS), `ar` (Arweave) or `data` (on-chain).
 ; Data URLs (on-chain data) must comply to RFC2397.
-uri = bounded_bytes / [ * bounded_bytes ] ; UTF-8
+uri = bounded_bytes ; UTF-8
 
 ; Custom user defined plutus data.
 ; Setting data is optional, but the field is required
@@ -550,7 +550,8 @@ version of these tokens from any point in time with the following format:
 
 1. [6d897eb](https://github.com/cardano-foundation/CIPs/tree/6d897eb60805a58a3e54821fe61284d5c5903764/CIP-XXXX)
 2. [45fa23b](https://github.com/cardano-foundation/CIPs/tree/45fa23b60806367a3e52231e552c4d7654237678/CIP-XXXX)
-3. **Current**
+3. [bfc6fde](https://github.com/cardano-foundation/CIPs/tree/bfc6fde340280d8b51f5a7131b57f4cc6cc5f260/CIP-XXXX)
+4. **Current**
 ```
 
 Each time a new version is introduced the previous version's link MUST be updated to match the last commit corresponding
@@ -575,7 +576,7 @@ versions of the affected tokens. `asset_name_labels` **MUST** only be marked obs
 
 #### version 3
 
-- Added plutus data array support to the image and src tags on the metadata 
+- Added [* bounded_bytes] support to the image and src tags on the metadata 
 
 ## Rationale: how does this CIP achieve its goals?
 


### PR DESCRIPTION
In the Cardano node, Plutus Data bytes are limited to 64 bytes. There is an issue where IPFS V2 uris are 66 bytes so they require the use of an NFT.

This is already the case for CIP-25 NFTs so it should also be the case for CIP-68.

This pr adds: / [ * bounded_bytes ] to the uri pattern.