### PR TITLE
CIP-0001 | Emphasise request to link PR OP to readable CIP

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -291,8 +291,6 @@ Editors occasionally invite project maintainers to speak during review meetings 
 
 Proposals must be submitted to the [cardano-foundation/CIPs][Repository] repository as a pull request named after the proposal's title. The pull request title **should not** include a CIP number (and use `?` instead as number); the editors will assign one. Discussions may precede a proposal. Early reviews and discussions streamline the process down the line.
 
-> **Note** In the original comment for your pull request, please include a link to the `README.md` for the CIP in your working branch, so readers and reviewers can easily follow your work.  If this link changes (e.g. from the CIP directory being renamed), please keep this link updated.
-
 > **Note** Proposals addressing a specific CPS should also be listed in the corresponding CPS header, in _'Proposed Solutions'_, to keep track of ongoing work.
 
 ###### Naming CIPs with similar subjects
@@ -302,6 +300,12 @@ When a CIP title *and* subject matter share a common element, begin the CIP titl
 > *Web-Wallet Bridge **-** Governance*
 
 CIP editors will help determine these common elements and, whenever necessary, rename both CIP document titles and PR titles accordingly.  The objective is to provide commonly recognisable names for similar developments (e.g. multiple extensions to another CIP or scheme).
+
+###### Link to proposal from PR first comment
+
+In the original comment for your pull request, please include a link to the directory or the `README.md` for the CIP in your working branch, so readers and reviewers can easily follow your work.  This makes it easier for editors and the community to read and review your proposal.
+
+> **Note** If this link changes (e.g. from the CIP directory being renamed), please keep this link updated.
 
 ##### 1.b. Authors seek feedback
 


### PR DESCRIPTION
Following up from https://github.com/cardano-foundation/CIPs/pull/810#issuecomment-2110422819 and based on the historical majority of CIPs not being submitted with authors linking a "Human readable version" in their original posting (OP) for the pull request.

We'd already added language for this (https://github.com/cardano-foundation/CIPs/blob/master/CIP-0001/README.md#1a-authors-open-a-pull-request) but it's been in a "Note:" which is apparently generally overlooked.  I've moved the text into a proper heading where it should stand out more, and emphasised it a bit.

Also I've added words that should leave authors free to link either to the CIP directory or its top level `README.md` as they see fit; following up on editors' comments made afterward.  In any case as long as a link is added then we save most of the trouble of editors having to maintain the readable proposal link.