### PR TITLE
CIP-0010 | Add oracle tx metadata tag to registry

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -52,6 +52,10 @@
     "description": "finitum.io token bridge transactions metadata"
   },
   {
+    "transaction_metadatum_label": 1226,
+    "description": "Oracle related transaction metadata"
+  },
+  {
     "transaction_metadatum_label": 1564,
     "description": "Marlowe - a DSL for writing and executing financial contracts"
   },


### PR DESCRIPTION
Provides a general purpose tag specifically for indexing and other uses off-chain by oracles and oracle consumers.