### PR TITLE
CIP-0010 | Misspelled keyword for 1694 label

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -64,7 +64,7 @@
     "description": "CIP-72: dApp registration & Discovery"
   },
   {
-    "transaction_metadataum_label": 1694,
+    "transaction_metadatum_label": 1694,
     "description": "Voltaire - additional metadata for governance, provided in a separate transaction"
   },
   {


### PR DESCRIPTION
Noticed one entry had a typo, decided to fix it.