### PR TITLE
CIP-1694 | Reword note on info actions

### DIFF
--- a/CIP-1694/README.md
+++ b/CIP-1694/README.md
@@ -586,7 +586,7 @@ Actions that have been ratified in the current epoch are prioritized as follows 
 6. Treasury withdrawals
 7. Info
 
-> **Note** Enactment for _Info_ actions is a null action, since they do not have any effect on the protocol.
+> **Note** _Info_ actions cannot be ratified or enacted, since they do not have any effect on the protocol.
 
 ##### Order of enactment
 


### PR DESCRIPTION
I was trying to test ratification of info actions, before I was told that info actions can never be ratified or enacted. This change is intended to clarify that point.