### PR TITLE
CIP-100 | Remake example to fix incorrect capitalisation on references type

### DIFF
--- a/CIP-0100/example.body.json
+++ b/CIP-0100/example.body.json
@@ -44,7 +44,7 @@
     },
     "body": {
       "references": [
-        { "@type": "other", "label": "CIP-100", "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md" }
+        { "@type": "Other", "label": "CIP-100", "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md" }
       ],
       "comment": "This is a test vector for CIP-100",
       "externalUpdates": [

--- a/CIP-0100/example.body.nq
+++ b/CIP-0100/example.body.nq
@@ -1,9 +1,8 @@
-_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body> _:c14n1 .
-_:c14n1 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment> "This is a test vector for CIP-100"@en-us .
-_:c14n1 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates> _:c14n3 .
-_:c14n1 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references> _:c14n2 .
-_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#OtherReference> .
-_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label> "CIP-100"@en-us .
-_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri> "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md"@en-us .
+_:c14n0 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#body> _:c14n2 .
+_:c14n1 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-label> "CIP-100"@en-us .
+_:c14n1 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#reference-uri> "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md"@en-us .
+_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#comment> "This is a test vector for CIP-100"@en-us .
+_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#externalUpdates> _:c14n3 .
+_:c14n2 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#references> _:c14n1 .
 _:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-title> "Blog"@en-us .
 _:c14n3 <https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#update-uri> "https://314pool.com"@en-us .

--- a/CIP-0100/example.json
+++ b/CIP-0100/example.json
@@ -44,11 +44,11 @@
     },
     "hashAlgorithm": "blake2b-256",
     "authors": [
-      { "name": "Pi Lanningham", "witness": { "witnessAlgorithm": "ed25519", "publicKey": "7ea09a34aebb13c9841c71397b1cabfec5ddf950405293dee496cac2f437480a", "signature": "340c2ef8d6abda96769844ab9dca2634ae21ef97ddbfad1f8843bea1058e40d656455a2962143adc603d063bbbe27b54b88d002d23d1dff1cd0e05017cd4f506"}}
+      { "name": "Pi Lanningham", "witness": { "witnessAlgorithm": "ed25519", "publicKey": "7ea09a34aebb13c9841c71397b1cabfec5ddf950405293dee496cac2f437480a", "signature": "68078efeff90970d2320a2bb5021d1aea81bc4907bf33d54fd17989f020719f3f5c4da3dccf7aa61d51c1e6fececd95309c37e7eef331b199cd5f8e78992ea0d"}}
     ],
     "body": {
       "references": [
-        { "@type": "other", "label": "CIP-100", "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md" }
+        { "@type": "Other", "label": "CIP-100", "uri": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md" }
       ],
       "comment": "This is a test vector for CIP-100",
       "externalUpdates": [

--- a/CIP-0100/test-vector.md
+++ b/CIP-0100/test-vector.md
@@ -18,7 +18,7 @@ See [cip-0100.common.schema.json](./cip-0100.common.schema.json).
 
 CIP-100 off-chain metadata json example: [example.json](./example.json)
 
-Blake2b-256 hash of the file (to go on-chain): `04af1b48bccbf7cf9b3e3b7952dfbdde0cc851ccb87ae6643521672cc381b00d`
+Blake2b-256 hash of the file (to go on-chain): `7b7d4a28a599bbb8c08b239be2645fa82d63a848320bf4760b07d86fcf1aabdc`
 
 ### Intermediate files
 
@@ -28,7 +28,7 @@ Body files, used to correctly generate author's witness:
 - [example.body.json](./example.body.json)
 - [example.body.nq](./example.body.nq)
 
-Blake2b-256 hash digest of canonicalized body: `cc4ab8ead604ddb498ed4b2916af7b454c65ac783b5d836fddf388e72a40eccb`
+Blake2b-256 hash digest of canonicalized body: `6d17e71c5793ed5945f58bf48e13bb1b3543187ab9c2afbd280a21afb4a90d35`
 
 Whole document canonical representation, used to generate final hash:
 
@@ -71,7 +71,7 @@ For our example this will result in: `cc4ab8ead604ddb498ed4b2916af7b454c65ac783b
 
 Use the hash produced in [3.](#3-hash-the-canonicalized-body) as the payload for the witness as described in [Hashing and Signatures](./README.md#hashing-and-signatures) for the chosen `witnessAlgorithm`.
 
-For the provided [example.json](./example.json), we use the keys described in [Author](#author) resulting in a `signature` of: `340c2ef8d6abda96769844ab9dca2634ae21ef97ddbfad1f8843bea1058e40d656455a2962143adc603d063bbbe27b54b88d002d23d1dff1cd0e05017cd4f506`
+For the provided [example.json](./example.json), we use the keys described in [Author](#author) resulting in a `signature` of: `68078efeff90970d2320a2bb5021d1aea81bc4907bf33d54fd17989f020719f3f5c4da3dccf7aa61d51c1e6fececd95309c37e7eef331b199cd5f8e78992ea0d`
 
 #### 5. Add `authors` and `hashAlgorithm` to example.json
 
@@ -85,7 +85,7 @@ By adding this information we create our [example.json](example.json).
 
 To be able to create a final metadata hash which can be attached on-chain we simply hash the content of the file [example.json](example.json) as is
 
-This results in: `04af1b48bccbf7cf9b3e3b7952dfbdde0cc851ccb87ae6643521672cc381b00d`.
+This results in: `7b7d4a28a599bbb8c08b239be2645fa82d63a848320bf4760b07d86fcf1aabdc`.
 
 #### 7. Submit to chain
 


### PR DESCRIPTION

Thanks for raising this @disassembler 🤝

### Motivation

- Incorrect capitalisation of the reference type "Other" within the example, [here](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/example.json#L51C20-L51C27).

### Changes

- Fixed capitalisation within example.
- Remade all other downstream files from example.

### Notes

- Not sure why there was so much change within `example.body.nq`?