### PR TITLE
CIP-0057 | Add 'compiler' field

### DIFF
--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -15,6 +15,7 @@ Implementors:
 Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/258
   - https://discord.gg/yUkkhqBnyV
+  - https://github.com/aiken-lang/aiken/issues/972
 Created: 2022-05-15
 License: CC-BY-4.0
 ---
@@ -65,13 +66,23 @@ Note that examples of specifications are given later in the document to keep the
 
 The `preamble` fields stores meta-information about the contract such as version numbers or a short description. This field is mainly meant for humans as a mean to contextualize a specification.
 
-| Fields         | Description                                                              |
-| ---            | ---                                                                      |
-| title          | A short and descriptive title of the application                         |
-| ?description   | A more elaborate description                                             |
-| ?version       | A version number for the project.                                        |
-| ?plutusVersion | The Plutus version assumed for all validators                            |
-| ?license       | A license under which the specification and contract code is distributed |
+| Fields         | Description                                                                  |
+| ---            | ---                                                                          |
+| title          | A short and descriptive title of the application                             |
+| ?description   | A more elaborate description                                                 |
+| ?version       | A version number for the project.                                            |
+| ?compiler      | Information about the compiler or framework used to produce the validator(s) |
+| ?plutusVersion | The Plutus version assumed for all validators                                |
+| ?license       | A license under which the specification and contract code is distributed     |
+
+#### compiler
+
+The `compiler` field is optional, but allows specifying metadata about the toolkit that produced the validator and blueprint.
+
+| Fields   | Description                                                      |
+| ---      | ---                                                              |
+| name     | The name of the compiler/framework/tool that generated the file. |
+| ?version | An optional version number in any format.                        |
 
 #### validators
 

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -416,6 +416,7 @@ Yet, whereas there's a notion of purpose on-chain that is tightly coupled to the
   - [x] [Aiken](https://aiken-lang.org/)
   - [x] [Mesh.js](https://meshjs.dev/)
   - [x] [Lucid](https://lucid.spacebudz.io/)
+  - [x] [Bloxbean/cardano-client-lib](https://github.com/bloxbean/cardano-client-lib)
   - [ ] [PyCardano](https://pycardano.readthedocs.io)
   - [ ] [Demeter](https://demeter.run/)
 
@@ -427,7 +428,8 @@ Yet, whereas there's a notion of purpose on-chain that is tightly coupled to the
   - [x] JavaScript
   - [x] TypeScript
   - [ ] Python
-- [ ] (optional) develop a tool for rendering Plutus blueprint specifications as documentation
+- [x] (optional) develop a tool for rendering Plutus blueprint specifications as documentation
+  - [paima/aiken-mdx](https://www.npmjs.com/package/@paima/aiken-mdx)
 
 ## Copyright
 

--- a/CIP-0057/schemas/plutus-blueprint.json
+++ b/CIP-0057/schemas/plutus-blueprint.json
@@ -50,6 +50,19 @@
                     "type": "string",
                     "enum": [ "v1", "v2", "v3" ]
                 },
+                "compiler": {
+                    "type": "object",
+                    "required": [ "name" ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "license": {
                     "type": "string"
                 }


### PR DESCRIPTION
- :round_pushpin: **Add 'compiler' field to the blueprint.**
    This is a purely additive, and optional, change. So it shouldn't pose much problem to add (existing implementation that supports blueprints would keep working). Yet it documents a field that we've started using in Aiken and that has turned to be incredibly useful.

- :round_pushpin: **Document few more projects in connection with blueprints.**
  