### PR TITLE
Add top level CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -3,4 +3,4 @@ See project Wiki: https://github.com/cardano-foundation/CIPs/wiki
 To view the Wiki offline:
 
 1) git clone https://github.com/cardano-foundation/CIPs.wiki.git
-2) read Home.md first, then remaining pages in lexicographic order.
+2) Read Home.md first, then remaining pages in lexicographic order.

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,6 @@
+See project Wiki: https://github.com/cardano-foundation/CIPs/wiki
+
+To view the Wiki offline:
+
+1) git clone https://github.com/cardano-foundation/CIPs.wiki.git
+2) read Home.md first, then numbered pages in lexicographic order.

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -3,4 +3,4 @@ See project Wiki: https://github.com/cardano-foundation/CIPs/wiki
 To view the Wiki offline:
 
 1) git clone https://github.com/cardano-foundation/CIPs.wiki.git
-2) read Home.md first, then numbered pages in lexicographic order.
+2) read Home.md first, then remaining pages in lexicographic order.


### PR DESCRIPTION
This answers suggestion https://github.com/cardano-foundation/CIPs/issues/793#issuecomment-2033983895 from the initial consideration of the new CIPs Wiki (https://github.com/cardano-foundation/CIPs/wiki).

However, it would be a huge duplication of effort to [build & maintain a CONTRIBUTING.md file](https://mozillascience.github.io/working-open-workshop/contributing/) because it's already accessible & up to date in the Wiki itself.  Still, to carry on the tradition of offline access through these top-level files (e.g. `LICENSE`), I've included brief instructions to build an offline copy of the Wiki with `git clone`.

So I believe the file should just be these 2 pieces of information.  In my opinion it's even too much overhead to use Markdown, and as a text file it follows the convention set by the `LICENSE` file to omit the usual `.txt` extension.