### PR TITLE
Add Updates section to top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ The following link lists "candidate" CPSs still under discussion with the commun
 
 **[CPS pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECPS-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)**
 
+## Updates under consideration
+
+The following link shows updates to existing CIPs and CPSs that have entered the review process:
+
+**[CIP and CPS updates under consideration](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+label%3AUpdate)**
+
 ## Stalled / Waiting For Authors
 
 The following links list proposals deemed ready for review but requiring further update

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following link lists "candidate" CPSs still under discussion with the commun
 
 **[CPS pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECPS-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)**
 
-## Updates under consideration
+## Updates Under Consideration
 
 The following link shows updates to existing CIPs and CPSs that have entered the review process:
 


### PR DESCRIPTION
After consideration in https://github.com/cardano-foundation/CIPs/pull/887#issuecomment-2310470656 — for increased visibility in the community, especially to attract attention from stakeholders & implementors for any affected CIPs.

This uses a low bar for query compared to the _Candidate_ list: only querying the `Update` tag without checking for a review `State:` tag... relying on that one bit of editor confirmation to keep spam or inappropriate update requests from being linked from the front page.

I don't see the harm in including likely "abandoned" or "deprecated" `Update` PR's here... in fact I believe it's important to include them because CIP/CPS updates aren't included in the _Stalled / Waiting For Authors_ list (since the latter is only for new CIPs/CPSs).

---

([newly added section, rendered in branch](https://github.com/rphair/CIPs/blob/readme-add-updates-section/README.md#updates-under-consideration))