### PR TITLE
Remove inactive editors from CIP editors lists

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -380,11 +380,10 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 
 Current editors are listed here below:
 
-| Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
+| Matthias Benkort <br/> [@KtorZ][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
 | ---                               | ---                                           | ---                            | ---                            | ---                             |
 
 [@KtorZ]: https://github.com/KtorZ
-[@SebastienGllmt]: https://github.com/SebastienGllmt
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -380,10 +380,9 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 
 Current editors are listed here below:
 
-| Matthias Benkort <br/> [@KtorZ][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
 | ---                               | ---                                           | ---                            | ---                            | ---                             |
 
-[@KtorZ]: https://github.com/KtorZ
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099

--- a/README.md
+++ b/README.md
@@ -179,11 +179,10 @@ Proposals stalled without any updates from their authors will eventually be clos
 
 ## Editors
 
-| Matthias Benkort <br/> [@KtorZ][] | Sebastien Guillemot <br/> [@SebastienGllmt][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
+| Matthias Benkort <br/> [@KtorZ][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
 | ---                               | ---                                           | ---                            | ---                            | ---                             |
 
 [@KtorZ]: https://github.com/KtorZ
-[@SebastienGllmt]: https://github.com/SebastienGllmt
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099

--- a/README.md
+++ b/README.md
@@ -179,10 +179,9 @@ Proposals stalled without any updates from their authors will eventually be clos
 
 ## Editors
 
-| Matthias Benkort <br/> [@KtorZ][] | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
 | ---                               | ---                                           | ---                            | ---                            | ---                             |
 
-[@KtorZ]: https://github.com/KtorZ
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099


### PR DESCRIPTION
Removes @SebastienGllmt as suggested 28 August on the CIP Discord's editor channel — without dispute as yet — after long period of inactivity.

BTW we are due for some CIP-0001 updates and in a soon-coming PR I'm going to suggest we add a small section _Emeritus editors_ as they have [in EIP-1](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md#eip-editors), with all (4) past CIP editors listed: since so far there are no retired editors who haven't significantly contributed to the work we have on file today.