### PR TITLE
Top-level README, CIP-0001 | Fix table formatting

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -381,7 +381,7 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 Current editors are listed here below:
 
 | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
-| ---                               | ---                                           | ---                            | ---                            | ---                             |
+| ---                            | ---                            | ---                             |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Proposals stalled without any updates from their authors will eventually be clos
 ## Editors
 
 | Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
-| ---                               | ---                                           | ---                            | ---                            | ---                             |
+| ---                            | ---                            | ---                             |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1


### PR DESCRIPTION
Inadvertently introduced in https://github.com/cardano-foundation/CIPs/pull/901 - not noticing the 2 extra empty cells that stop the Markdown from rendering as a table.