### PR TITLE
Add Thomas Vellekoop as a CIP editor

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -380,8 +380,8 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 
 Current editors are listed here below:
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
-| ---                            | ---                            | ---                             |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] | Thomas Vellekoop <br/> [@perturbing][] |
+| ---                            | ---                            | ---                             | ---                                    |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -386,6 +386,7 @@ Current editors are listed here below:
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099
+[@perturbing]: https://github.com/perturbing
 
 ## Rationale: how does this CIP achieve its goals?
 

--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ Proposals stalled without any updates from their authors will eventually be clos
 
 ## Editors
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] |
-| ---                            | ---                            | ---                             |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] | Thomas Vellekoop <br/> [@perturbing][] |
+| ---                            | ---                            | ---                             | ---                                    |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
 [@Crypto2099]: https://github.com/Crypto2099
+[@perturbing]: https://github.com/perturbing
 


### PR DESCRIPTION
With this PR I would like to put myself forward in the role as a CIP editor. Given this [PR](https://github.com/cardano-foundation/CIPs/pull/901), I would love to fill these big shoes and contribute to the continuation of the CIP process as it is now. 

A big thanks to both @KtorZ and @SebastienGllmt for their effort and, above all, their great technical minds.

Regarding my competence for this role, I have contributed to various CIP's and even co-authored some myself. I hope others recognize this and have faith in my ability to execute this role successfully :smiley: 