### PR TITLE
CIP-0001 | Annual overhaul and process update

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -29,9 +29,7 @@ The Cardano Foundation intends CIPs to be the primary mechanisms for proposing n
 ## Motivation: why is this CIP necessary?
 
 CIPs aim to address two challenges mainly:
-
 1. The need for various parties to agree on a common approach to ease the interoperability of tools or interfaces.
-
 2. The need to propose and discuss changes to the protocol or established practice of the ecosystem.
 
 The CIP process does not _by itself_ offer any form of governance. For example, it does not govern the process by which proposed changes to the Cardano protocol are implemented and deployed. Yet, it is a crucial, community-driven component of the governance decision pipeline as it helps to collect thoughts and proposals in an organised fashion. Additionally, specific projects may choose to actively engage with the CIP process for some or all changes to their project.

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -293,7 +293,7 @@ Any guidelines for this cooperation should be described by a dedicated CIP whene
 
 Editors occasionally invite representatives from enlisted categories to speak during review meetings and solicit them for ultimate approvals of proposals in their area of expertise.
 
-> **Note** Optionally, projects may show their enlisting using the following badge on their introductory README: ![](https://github.com/cardano-foundation/CIPs](https://raw.githubusercontent.com/cardano-foundation/CIPs/master/.github/badge.svg)
+**Note** Optionally, projects may show their enlisting using the following badge on their introductory README: ![https://github.com/cardano-foundation/CIPs](https://raw.githubusercontent.com/cardano-foundation/CIPs/master/.github/badge.svg)
 >
 > ```md
 > ![https://github.com/cardano-foundation/CIPs](https://raw.githubusercontent.com/cardano-foundation/CIPs/master/.github/badge.svg)

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -260,7 +260,7 @@ Tokens   | About tokens (fungible or non-fungible) and minting policies in gener
 Metadata | For proposals around metadata (on-chain or off-chain)
 Tools    | A broad category for ecosystem features not falling into any other category
 
-Additionally, representatives of ecosystem categories may explicitly _enlist_ their categories (see next section) to suggest a closer relationship with the CIP process.  The following categories are confirmed as enslisted according to CIPs which define that relationship:
+Additionally, representatives of ecosystem categories may explicitly _enlist_ their categories (see next section) to suggest a closer relationship with the CIP process. The following categories are confirmed as enlisted according to CIPs which define that relationship:
 
 Category | Description
 ---      | ---

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -412,6 +412,12 @@ Current editors are listed here below:
 [@Crypto2099]: https://github.com/Crypto2099
 [@perturbing]: https://github.com/perturbing
 
+Emeritus editors:
+- Frederic Johnson - [@crptmppt](https://github.com/crptmppt)
+- Sebastien Guillemot - [@SebastienGllmt](https://github.com/SebastienGllmt)
+- Matthias Benkort - [@KtorZ](https://github.com/KtorZ)
+- Duncan Coutts - [@dcoutts](https://github.com/dcoutts)
+
 ## Rationale: how does this CIP achieve its goals?
 
 ### Key changes from CIP-0001 (version 1)

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -251,40 +251,48 @@ This must be subdivided into two sub-sections:
 
 CIPs are classified into distinct categories that help organise (and thus, find) them. Categories are meant to be flexible and evolve as new domains emerge. Authors may leave the category as `?` should they not be sure under which category their proposal falls; editors will eventually assign one or reject the proposal altogether should it relate to an area where the CIP process does not apply.
 
-At present, we consider the following list of initial categories:
+Submission in these categories can be used whenever appropriate without following any particular submission guidelines:
 
-Category               | Description
----                    | ---
-Meta                   | Designates meta-CIPs, such as this one, which typically serves another category or group of categories.
-Wallets                | For standardisation across wallets (hardware, full-node or light).
-Tokens                 | About tokens (fungible or non-fungible) and minting policies in general.
-Metadata               | For proposals around metadata (on-chain or off-chain).
-Tools                  | A broad category for ecosystem tools not falling into any other category.
+Category | Description
+---      | ---
+Meta     | Designates meta-CIPs, such as this one, which typically serve another category or group of categories
+Wallets  | For standardisation across wallets (hardware, full-node or light)
+Tokens   | About tokens (fungible or non-fungible) and minting policies in general
+Metadata | For proposals around metadata (on-chain or off-chain)
+Tools    | A broad category for ecosystem features not falling into any other category
 
-Additionally, projects of the ecosystem may explicitly enlist as new categories. The following section describes how projects can engage with the CIP process.
-
-Registered categories for explicitly enlisted projects are otherwise listed below.
+Additionally, representatives of ecosystem categories may explicitly _enlist_ their categories (see next section) to suggest a closer relationship with the CIP process.  The following categories are confirmed as enslisted according to CIPs which define that relationship:
 
 Category | Description
 ---      | ---
 Plutus   | Changes or additions to Plutus, following the process described in [CIP-0035][]
 Ledger   | For proposals regarding the Cardano ledger, following the process described in [CIP-0084][]
-Catalyst | For proposals affecting Project Catalyst or the Jörmungandr project, following the process described in ?
+
+These tenatively enlisted categories await CIPs to describe any enlistment relationship:
+
+Category  | Description
+---       | ---
+Catalyst  | For proposals affecting Project Catalyst or the Jörmungandr project
+Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
+Network   | Specifications and implementations of Cardano's network protocols and applications
 
 #### Project Enlisting
 
-Projects of the Cardano ecosystem that intend to follow the CIP process must explicitly enlist themselves and commit to the following:
+Project representatives intending to follow an "enlisted" category above agree to coordinate with related development by sharing efforts to review and validate new proposals.
+It should be noted that single organisations can no longer repesent any ecosystem or development category, which makes these enlistment guidelines both decentralised and cooperative, including whenver possible:
 
-- a) allocating time to **review** proposals from actors of the community when solicited by editors (i.e. after one first round of reviews);
-- b) defining additional rules and processes whereby external actors can engage with their project as part of the CIP process;
-- c) defining boundaries within their project for which the CIP process does apply;
-- d) writing CIPs for significant changes introduced in their projects when it applies.
+- allocating time to **review** proposals from actors of the community when solicited by editors (i.e. after one first round of reviews);
+- defining additional rules and processes whereby external actors can engage with their project as part of the CIP process;
+- defining boundaries within their project for which the CIP process does apply;
+- establishing points of contact and any designated reviews for a category;
+- agreeing upon how proposals move from the state of idea (i.e. CIP) to actual implementation work;
+- writing CIPs for significant changes introduced in their projects when it applies.
 
-Enlisting for the CIP process happens by creating a CIP. That CIP must encapsulate the information listed above, as well as any other pieces of information deemed helpful to future authors. Of course, only team members of a target project can author such a proposal.
+Any guidelines for this cooperation should be described by a dedicated CIP whenever possible.  When such a CIP is posted or supersedes another one, it will be entered into the above table in the Categories section.  Participants of enlisted categories should follow the requirements outlined in that CIP and should update such proposals whenever these requirements or relationships change.
 
-> **Warning** A positive review by the maintainers of a project does not constitute a commitment to implement the CIP. It is still the CIP author's responsibility to create an implementation plan and identify implementors. The maintainers of the project may volunteer to participate in implementation, but also may not. Projects' maintainers ultimately define how a proposal can move from the state of idea (i.e. CIP) to actual implementation work. We, however, expect each team that enlists in the CIP process to provide clarity on these elements as they enlist.
+> **Warning** A positive review by any enlisted project representative does not constitute a commitment to implement the CIP. It is still the CIP author's responsibility to create an implementation plan and identify implementors.
 
-Editors occasionally invite project maintainers to speak during review meetings and solicit them for ultimate approvals of proposals affecting a project under their authority. Said differently, CIPs that concern (part of) an enlisted project will only be merged after explicit acceptance of the enlisted reviewers.
+Editors occasionally invite representatives from enlisted categories to speak during review meetings and solicit them for ultimate approvals of proposals in their area of expertise.
 
 > **Note** Optionally, projects may show their enlisting using the following badge on their introductory README: ![](https://github.com/cardano-foundation/CIPs](https://raw.githubusercontent.com/cardano-foundation/CIPs/master/.github/badge.svg)
 >
@@ -299,6 +307,8 @@ Editors occasionally invite project maintainers to speak during review meetings 
 ##### 1.a. Authors open a pull request
 
 Proposals must be submitted to the [cardano-foundation/CIPs][Repository] repository as a pull request named after the proposal's title. The pull request title **should not** include a CIP number (and use `?` instead as number); the editors will assign one. Discussions may precede a proposal. Early reviews and discussions streamline the process down the line.
+
+> **Note** Pull requests should not include implementation code: any code bases should instead be provided as links to a code repository.
 
 > **Note** Proposals addressing a specific CPS should also be listed in the corresponding CPS header, in _'Proposed Solutions'_, to keep track of ongoing work.
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -129,7 +129,7 @@ License: CC-BY-4.0
 ```
 
 Especially because Markdown link syntax is not supported in the header preamble, labels can be added to clarify list items; e.g.:
-```
+```yaml
 Implementors:
     - Mlabs: https://mlabs.city
 ```

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -12,8 +12,8 @@ Authors:
     - Robert Phair <rphair@cosd.com>
 Implementors: N/A
 Discussions:
-    - https://github.com/cardano-foundation/cips/pull/366
-    - https://github.com/cardano-foundation/cips/pull/331
+    - https://github.com/cardano-foundation/CIPs/pull/366
+    - https://github.com/cardano-foundation/CIPs/pull/331
     - https://github.com/cardano-foundation/CIPs/tree/3da306f3bfe89fa7de8fe1bf7a436682aeee25c5/CIP-0001#abstract
     - https://github.com/cardano-foundation/CIPs/pull/924
 Created: 2020-03-21

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -130,8 +130,8 @@ License: CC-BY-4.0
 
 Especially because Markdown link syntax is not supported in the header preamble, labels can be added to clarify list items; e.g.:
 ```yaml
-Implementors:
-    - Mlabs: https://mlabs.city
+Discussions:
+    - Original-PR: https://github.com/cardano-foundation/CIPs/pull/366
 ```
 
 > **Note** A reference template is available in [.github/CIP-TEMPLATE.md][CIP-TEMPLATE.md]

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -278,7 +278,7 @@ Network   | Specifications and implementations of Cardano's network protocols an
 #### Project Enlisting
 
 Project representatives intending to follow an "enlisted" category above agree to coordinate with related development by sharing efforts to review and validate new proposals.
-It should be noted that single organisations can no longer repesent any ecosystem or development category, which makes these enlistment guidelines both decentralised and cooperative, including whenver possible:
+It should be noted that single organisations can no longer represent any ecosystem or development category, which makes these enlistment guidelines both decentralised and cooperative, including whenever possible:
 
 - allocating time to **review** proposals from actors of the community when solicited by editors (i.e. after one first round of reviews);
 - defining additional rules and processes whereby external actors can engage with their project as part of the CIP process;

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -122,7 +122,7 @@ Authors:
     - Duncan Coutts <duncan.coutts@iohk.io>
 Implementors: N/A
 Discussions:
-    - https://github.com/cardano-foundation/cips/pull/366
+    - https://github.com/cardano-foundation/CIPs/pull/366
 Created: 2020-03-21
 License: CC-BY-4.0
 ---

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -178,11 +178,11 @@ Field          | Description
 
 ##### Versioning
 
-CIPs must indicate how the defined Specification is versioned.  **Note** this does not apply to the CIP text, for which annotated change logs are automatically generated and available through the GitHub UI as a history of CIP files and directories.
+CIPs must indicate how the defined Specification is versioned.  **Note** this does not apply to the CIP text, for which annotated change logs are automatically generated and [available through the GitHub UI](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/differences-between-commit-views) as a history of CIP files and directories.
 
 Authors are free to describe any approach to versioning that allows versioned alterations to be added without author oversight.  Stipulating that the proposal must be superseded by another is also considered to be valid versioning.
 
-Since this is a functional definition it would typically be in one or more subsections of the Specification, but may also be placed in an optional Versioning section.
+A single Versioning scheme can be placed either as a subsection of the Specification section or in an optional Versioning top-level section near the end.  If the Specification contains multiple specification subsections, each of these can have a Versioning subsection with it.
 
 ##### Licensing
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -22,7 +22,7 @@ License: CC-BY-4.0
 
 ## Abstract
 
-A Cardano Improvement Proposal (CIP) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is; how the CIP process functions; the role of the CIP Editors; and how users should go about proposing, discussing and structuring a CIP.
+A Cardano Improvement Proposal (CIP) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is, how the CIP process functions, the role of the CIP Editors, and how users should go about proposing, discussing, and structuring a CIP.
 
 The Cardano Foundation intends CIPs to be the primary mechanisms for proposing new features, collecting community input on an issue, and documenting design decisions that have gone into Cardano. Plus, because CIPs are text files in a versioned repository, their revision history is the historical record of significant changes affecting Cardano.
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 1
-Title: Cardano Improvement Proposals
+Title: CIP Process
 Status: Active
 Category: Meta
 Authors:
@@ -9,6 +9,7 @@ Authors:
     - Matthias Benkort <matthias.benkort@cardanofoundation.org>
     - Duncan Coutts <duncan.coutts@iohk.io>
     - Michael Peyton Jones <michael.peyton-jones@iohk.io>
+    - Robert Phair <rphair@cosd.com>
 Implementors: N/A
 Discussions:
     - https://github.com/cardano-foundation/cips/pull/366
@@ -110,7 +111,7 @@ For example:
 ```yaml
 ---
 CIP: 1
-Title: Cardano Improvement Proposals
+Title: CIP Process
 Status: Active
 Category: Meta
 Authors:
@@ -120,10 +121,16 @@ Authors:
     - Duncan Coutts <duncan.coutts@iohk.io>
 Implementors: N/A
 Discussions:
-    - https://github.com/cardano-foundation/cips/pulls/1
+    - https://github.com/cardano-foundation/cips/pull/366
 Created: 2020-03-21
 License: CC-BY-4.0
 ---
+```
+
+Especially because Markdown link syntax is not supported in the header preamble, labels can be added to clarify list items; e.g.:
+```
+Implementors:
+    - Mlabs: https://mlabs.city
 ```
 
 > **Note** A reference template is available in [.github/CIP-TEMPLATE.md][CIP-TEMPLATE.md]

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -21,7 +21,7 @@ License: CC-BY-4.0
 
 ## Abstract
 
-A Cardano Improvement Proposal (CIP) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP  provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is; how the CIP process functions; the role of the CIP Editors; and how users should go about proposing, discussing and structuring a CIP.
+A Cardano Improvement Proposal (CIP) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is; how the CIP process functions; the role of the CIP Editors; and how users should go about proposing, discussing and structuring a CIP.
 
 The Cardano Foundation intends CIPs to be the primary mechanisms for proposing new features, collecting community input on an issue, and documenting design decisions that have gone into Cardano. Plus, because CIPs are text files in a versioned repository, their revision history is the historical record of significant changes affecting Cardano.
 
@@ -34,6 +34,8 @@ CIPs aim to address two challenges mainly:
 2. The need to propose and discuss changes to the protocol or established practice of the ecosystem.
 
 The CIP process does not _by itself_ offer any form of governance. For example, it does not govern the process by which proposed changes to the Cardano protocol are implemented and deployed. Yet, it is a crucial, community-driven component of the governance decision pipeline as it helps to collect thoughts and proposals in an organised fashion. Additionally, specific projects may choose to actively engage with the CIP process for some or all changes to their project.
+
+This document outlines the technical structure of the CIP and the technical requirements of the submission and review process.  The history, social features and human elements of the CIP process are described the [CIP repository Wiki][Wiki].
 
 ## Specification
 
@@ -324,6 +326,9 @@ As much as possible, commenters/reviewers shall remain unbiased in their judgeme
 
 By opening pull requests or posting comments, commenters and authors agree to our [Code of Conduct][CoC]. Any comment infringing this code of conduct shall be removed or altered without prior notice.
 
+> **Note** For acceptability guidelines, including a concise review checklist, see 
+[CIP Wiki > CIPs for Reviewers & Authors](https://github.com/cardano-foundation/CIPs/wiki/2.-CIPs-for-Reviewers-&-Authors).
+
 #### 2. Editors' role
 
 ##### 2.a. Triage in bi-weekly meetings
@@ -340,7 +345,7 @@ A dedicated Discord channel may also be created for some long-running discussion
 
 #### 3. Merging CIPs in the repository
 
-Once a proposal has reached all requirements for its target status (as explained in [Statuses](#Statuses)) and has been sufficiently and faithfully discussed by community members, it is merged with its target status.
+Once a proposal has reached all requirements for its target status (as explained in [Statuses](#statuses)) and has been sufficiently and faithfully discussed by community members, it is merged with its target status.
 
 > **Warning** Ideas deemed unsound shall be rejected with justifications or withdrawn by the authors. Similarly, proposals that appear abandoned by their authors shall be rejected until resurrected by their authors or another community member.
 
@@ -357,6 +362,8 @@ Once merged, implementors shall execute the CIP's _'Implementation Plan'_, if an
 Besides, once all of the _'Path to Active'_ requirements have been met, authors shall make another pull request to change their CIP's status to _'Active'_. Editors may also do this on occasion.
 
 ### Editors
+
+For a full, current description of Editor workflow, see [CIP Wiki > CIPs for Editors](https://github.com/cardano-foundation/CIPs/wiki/3.-CIPs-for-Editors).
 
 #### Missions
 
@@ -473,4 +480,5 @@ This CIP is licensed under [CC-BY-4.0][].
 [RFC 822]: https://www.ietf.org/rfc/rfc822.txt
 [Repository]: https://github.com/cardano-foundation/CIPs/pulls
 [CoC]: https://github.com/cardano-foundation/CIPs/tree/master/CODE_OF_CONDUCT.md
-[Discord]: https://discord.gg/Jy9YM69Ezf
+[Discord]: https://discord.gg/J8sGdCuKhs
+[Wiki]: https://github.com/cardano-foundation/CIPs/wiki

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -252,7 +252,7 @@ This must be subdivided into two sub-sections:
 
 CIPs are classified into distinct categories that help organise (and thus, find) them. Categories are meant to be flexible and evolve as new domains emerge. Authors may leave the category as `?` should they not be sure under which category their proposal falls; editors will eventually assign one or reject the proposal altogether should it relate to an area where the CIP process does not apply.
 
-Submission in these categories can be used whenever appropriate without following any particular submission guidelines:
+Submissions can be made to these categories whenever relevant, without following any particular submission guidelines:
 
 Category | Description
 ---      | ---

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -313,7 +313,7 @@ Proposals must be submitted to the [cardano-foundation/CIPs][Repository] reposit
 
 ###### Naming CIPs with similar subjects
 
-When a CIP title *and* subject matter share a common element, begin the CIP title with that common element and end it with the specifc portion, delimited with the `-` character.  Example (CIP-0095):
+When a CIP title *and* subject matter share a common element, begin the CIP title with that common element and end it with the specific portion, delimited with the `-` character.  Example (CIP-0095):
 
 > *Web-Wallet Bridge **-** Governance*
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -15,6 +15,7 @@ Discussions:
     - https://github.com/cardano-foundation/cips/pull/366
     - https://github.com/cardano-foundation/cips/pull/331
     - https://github.com/cardano-foundation/CIPs/tree/3da306f3bfe89fa7de8fe1bf7a436682aeee25c5/CIP-0001#abstract
+    - https://github.com/cardano-foundation/CIPs/pull/924
 Created: 2020-03-21
 License: CC-BY-4.0
 ---

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -183,7 +183,7 @@ CIPs must indicate how the defined Specification is versioned.  **Note** this do
 
 Authors are free to describe any approach to versioning that allows versioned alterations to be added without author oversight.  Stipulating that the proposal must be superseded by another is also considered to be valid versioning.
 
-A single Versioning scheme can be placed either as a subsection of the Specification section or in an optional Versioning top-level section near the end.  If the Specification contains multiple specification subsections, each of these can have a Versioning subsection with it.
+A single Versioning scheme can be placed either as a subsection of the Specification section or in an optional Versioning top-level section near the end.  If the Specification contains multiple specification subsections, each of these can have a Versioning subsection within it.
 
 ##### Licensing
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -267,7 +267,7 @@ Category | Description
 Plutus   | Changes or additions to Plutus, following the process described in [CIP-0035][]
 Ledger   | For proposals regarding the Cardano ledger, following the process described in [CIP-0084][]
 
-These tenatively enlisted categories await CIPs to describe any enlistment relationship:
+These tentatively enlisted categories await CIPs to describe any enlistment relationship:
 
 Category  | Description
 ---       | ---

--- a/CIP-9999/README.md
+++ b/CIP-9999/README.md
@@ -13,8 +13,6 @@ Created: 2022-10-14
 License: CC-BY-4.0
 ---
 
-# CIP-9999: Cardano Problem Statements
-
 ## Abstract
 
 A Cardano Problem Statement (CPS) is a formalized document for the Cardano ecosystem and the name of the process by which such documents are produced and listed. CPSs are meant to complement CIPs and live side-by-side in the CIP repository as first-class citizens.
@@ -187,7 +185,7 @@ This section is meant to _save time_, especially for problem statement authors w
 
 ### Implementation Plan
 
-- [ ] Schedule a retrospective in 2-3 months to assess the effectiveness of the process
+- [x] Confirm after repeated cycles of CPS submissions, reviews, and merges that the CPS process is both effective and accessible to the community.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more about the human factors of the CIP process, and to learn how to get inv
 
 A [Cardano Problem Statement (CPS)](./CIP-9999) is a formalised document for the Cardano ecosystem and the name of the process by which such documents are produced and listed. CPSs are meant to complement CIPs and live side-by-side in the CIP repository as first-class citizens.
 
-> **Note** For new CPS, a reference template is available in [.github/CPS-TEMPLATE.md](.github/CPS-TEMPLATE.md)
+> **Note** For new CPSs, a reference template is available in [.github/CPS-TEMPLATE.md](.github/CPS-TEMPLATE.md)
 
 ## Communication Channels
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CIP Editors meetings are public, recorded, and [published on Youtube](https://ww
 
 | #    | Title | Status |
 | ---- | --- | --- |
-| 0001 | [CIP process](./CIP-0001/) | Active |
+| 0001 | [CIP Process](./CIP-0001/) | Active |
 | 0002 | [Coin Selection Algorithms for Cardano](./CIP-0002/) | Active |
 | 0003 | [Wallet key generation](./CIP-0003/) | Active |
 | 0004 | [Wallet Checksums](./CIP-0004/) | Proposed |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more about the human factors of the CIP process, and to learn how to get inv
 
 A [Cardano Problem Statement (CPS)](./CIP-9999) is a formalised document for the Cardano ecosystem and the name of the process by which such documents are produced and listed. CPSs are meant to complement CIPs and live side-by-side in the CIP repository as first-class citizens.
 
-> **Note** For new CPSs, a reference template is available in [.github/CPS-TEMPLATE.md](.github/CPS-TEMPLATE.md)
+> **Note** For new CPSs, a reference template is available in [.github/CPS-TEMPLATE.md](./.github/CPS-TEMPLATE.md)
 
 ## Communication Channels
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Cardano Foundation intends CIPs to be the primary mechanisms for proposing n
 
 For more about the human factors of the CIP process, and to learn how to get involved, click the Wiki tab above (**[CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki)**).
 
-> **Note** For new CIPs, a reference template is available in [.github/CIP-TEMPLATE.md](.github/CIP-TEMPLATE.md)
+> **Note** For new CIPs, a reference template is available in [.github/CIP-TEMPLATE.md](./.github/CIP-TEMPLATE.md)
 
 ## Cardano Problem Statements (CPS)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## Cardano Improvement Proposals (CIPs)
 
-A [Cardano Improvement Proposal (CIP)](./CIP-0001) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP  provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is; how the CIP process functions; the role of the CIP Editors; and how users should go about proposing, discussing and structuring a CIP.
+A [Cardano Improvement Proposal (CIP)](./CIP-0001) is a formalised design document for the Cardano community and the name of the process by which such documents are produced and listed. A CIP provides information or describes a change to the Cardano ecosystem, processes, or environment concisely and in sufficient technical detail. In this CIP, we explain what a CIP is; how the CIP process functions; the role of the CIP Editors; and how users should go about proposing, discussing and structuring a CIP.
 
 The Cardano Foundation intends CIPs to be the primary mechanisms for proposing new features, collecting community input on an issue, and documenting design decisions that have gone into Cardano. Plus, because CIPs are text files in a versioned repository, their revision history is the historical record of significant changes affecting Cardano.
+
+For more about the and human factors of the CIP process, and to learn how to get involved, click the Wiki tab above **[CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki)**.
 
 > **Note** For new CIP, a reference template is available in [.github/CIP-TEMPLATE.md](.github/CIP-TEMPLATE.md)
 
@@ -16,9 +18,7 @@ A [Cardano Problem Statement (CPS)](./CIP-9999) is a formalised document for the
 
 Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.org/c/developers/cips/122), Cardano’s Official [Developer Telegram Group](https://t.me/CardanoDevelopersOfficial) or in `#developers` in Cardano Ambassadors Slack.
 
-CIP editors will review discussions and progress in bi-weekly meetings held [on Discord](https://discord.gg/Jy9YM69Ezf), then transcribe and summarise them [in the BikweeklyMeetings folder](https://github.com/cardano-foundation/CIPs/tree/master/BiweeklyMeetings).
-
-CIP Editors meetings are public, recorded, and [published on Youtube](https://www.youtube.com/playlist?list=PL831pmH4tfw1YkMK4FhBzoHyuSaadjdxn): do join and participate in discussions/PRs of significance to you.
+CIP editors facilitate discussions and progress submissions on GitHub, reviewing progress in bi-weekly meetings held [on Discord](https://discord.gg/J8sGdCuKhs) which are open to the public. The Discord server also has channels for CIP-based developer working groups.
 
 > **Note** To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A [Cardano Problem Statement (CPS)](./CIP-9999) is a formalised document for the
 
 Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.org/c/developers/cips/122), Cardano’s Official [Developer Telegram Group](https://t.me/CardanoDevelopersOfficial) or in `#developers` in Cardano Ambassadors Slack.
 
-CIP editors facilitate discussions and progress submissions on GitHub, reviewing progress in bi-weekly meetings held [on Discord](https://discord.gg/J8sGdCuKhs) which are open to the public. The Discord server also has channels for CIP-based developer working groups.
+CIP editors facilitate discussions and progress submissions on GitHub, reviewing progress in bi-weekly meetings held [on Discord](https://discord.gg/J8sGdCuKhs) which are open to the public. The Discord server also has channels for developer working groups to discuss details and implementations of selected CIPs.
 
 > **Note** To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A [Cardano Improvement Proposal (CIP)](./CIP-0001) is a formalised design docume
 
 The Cardano Foundation intends CIPs to be the primary mechanisms for proposing new features, collecting community input on an issue, and documenting design decisions that have gone into Cardano. Plus, because CIPs are text files in a versioned repository, their revision history is the historical record of significant changes affecting Cardano.
 
-For more about the and human factors of the CIP process, and to learn how to get involved, click the Wiki tab above **[CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki)**.
+For more about the human factors of the CIP process, and to learn how to get involved, click the Wiki tab above (**[CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki)**).
 
-> **Note** For new CIP, a reference template is available in [.github/CIP-TEMPLATE.md](.github/CIP-TEMPLATE.md)
+> **Note** For new CIPs, a reference template is available in [.github/CIP-TEMPLATE.md](.github/CIP-TEMPLATE.md)
 
 ## Cardano Problem Statements (CPS)
 


### PR DESCRIPTION
This has all the CIP-0001 pending updates I've collected, resulting from many review threads since the beginning of the year.  Most of these points have either been explicitly or tacitly agreed upon already but of course the changes need vigorous review: especially change to Enlistment as per https://github.com/cardano-foundation/CIPs/issues/898.

([updated CIP-0001](https://github.com/rphair/CIPs/blob/cip-0001-overhaul%2Bprocess-update/CIP-0001/README.md))

---

changed document title to `CIP Process` 
- To make consistent with [README table](https://github.com/cardano-foundation/CIPs/blob/master/README.md#cardano-improvement-proposals-cip)
- This title makes more sense as title on derived web sites, especially Developer Portal (https://github.com/cardano-foundation/CIPs/issues/900#issuecomment-2332955740)  

set myself as co-author (last on list), based on [commit history](https://github.com/cardano-foundation/CIPs/commits/master/CIP-0001/README.md?author=rphair) representing nearly 2 years of maintenance (about half the time CIP-0001 has been followed)  
- These are structural changes and/or rewrites, mostly to capture changes to the CIP process emergent from meetings, online review, and discussion of related issues... not including formatting fixes & mechanical updates (e.g. the recently changed list of editors):
- https://github.com/cardano-foundation/CIPs/pull/827
- https://github.com/cardano-foundation/CIPs/pull/763
- https://github.com/cardano-foundation/CIPs/pull/762
- https://github.com/cardano-foundation/CIPs/pull/730
- https://github.com/cardano-foundation/CIPs/pull/594
- https://github.com/cardano-foundation/CIPs/pull/585
- https://github.com/cardano-foundation/CIPs/pull/450
- https://github.com/cardano-foundation/CIPs/pull/411

suggest label items for lists in YAML header
- as tentatively agreed in (https://github.com/cardano-foundation/CIPs/pull/841#discussion_r1688947676)

update link to `#Statuses` (invalid on derived sites: https://github.com/cardano-foundation/developer-portal/pull/1335#issuecomment-2399291533)

changed Discord invitation link (in references footer) to the same one on the CIP Wiki front page (to try to stop these links from proliferating)
- also made same change on top level README

added references to the [CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki) when appropriate  
- initially: in Motivation, added link to Wiki & definition of its scope vs. the scope of CIP-0001 itself
- links for key sections, when CIP-0001 also talks about them:  
  - beginning of Editors section, since it's a more exhaustive & current list of editors' goals and requirements  
  - note at end of "Authors seek feedback" subsection (referring also review checklist)  
- NOT covering the relatively new GitHub [state tagging](https://github.com/cardano-foundation/CIPs/wiki/301.-State-tagging) in CIP-0001 since
  - characteristics like `Last Check`, and state flow in general, were never in CIP-0001 after being removed in the last overhaul;  
  - it's a "human element" of the process meant to deal with CIP workflow rather than the CIP itself.  

under Versioning
- added link how to see commit history in GitHub UI (since we are recommending this as an alternative to the customary Changelog)
- clarified some difficult language indicating when & how a Versioning subsection can be applied to subsections of the specification (https://github.com/cardano-foundation/CIPs/pull/730#issuecomment-1875956604) (cc @michaelpj)

don't include implementation code for the CIP in the CIP directory itself
- (https://github.com/cardano-foundation/CIPs/pull/848#issuecomment-2196997740) (cc @SamDelaney)
- (https://github.com/cardano-foundation/CIPs/pull/872#pullrequestreview-2222385937) (cc @bwbush)

added new categories, in same "enlisted" section as `Plutus` and `Ledger`  
- `Consensus` (https://github.com/cardano-foundation/CIPs/pull/872#discussion_r1704346855) cc @dnadales
- `Network` (https://github.com/cardano-foundation/CIPs/pull/876#discussion_r1710151948) cc @coot @jpraynaud @abailly @ch1bo
- Partitioned these categories (with Catalyst, which was never enlisted with its own CIP) in their own table away from the "officially" enlisted ones.  

rewritten "enlistment" section (https://github.com/cardano-foundation/CIPs/issues/898#issuecomment-2341368464) (cc @zliu41 @lehins @WhatisRT)
- following @Ryun1's suggestion about keeping the notion of enlistment mainly intact, without eradicating it altogether (https://github.com/cardano-foundation/CIPs/issues/898#issuecomment-2342066699)
- That whole section is rewritten but preserving the original language whenever possible: though generally "decentralising" it.  Mainly this eliminates the notion that there is a "maintainer" of any enlisted category.
- I still think the idea of the "enlistment badge" might be useful in "decentralised" enlistment... and probably even more so... so I've left that in.  

created section & added Emeritus editors (https://github.com/cardano-foundation/CIPs/pull/901#issue-2506735654) (cc @crptmppt @SebastienGllmt @KtorZ @dcoutts)  
- following EIP-1 [here](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md#eip-editors)
- for now have added in same order as appearing as authors in the CIP-0001 header (as opposed to oldest/newest activity OR began/departed OR somehow in order of significance)  

CIP-9999 updates:
- delete its unwanted H1 - an eyesore, especially on derived sites
- update Implementation Plan item: since the last remaining unticked item never happened & likely never will (though the CPS process has been validated by community usage instead)

Top-level README updates:
- added Wiki link in header, with invitation to use as pretext for community engagement
- Communication Channels = out of date & needed to be rewritten (no more YouTube or meeting transcripts; and plenty of activity happens on GitHub without waiting for the biweekly meetings... which we 

fixed miscellaneous spelling, white space, formatting and grammar.

changes decided NOT to make:
- what kind of language to avoid in CIPs (https://github.com/cardano-foundation/CIPs/pull/788#discussion_r1569309758): since the crucial question over "point of view" was already addressed in the Wiki [here](https://github.com/cardano-foundation/CIPs/wiki/2.-CIPs-for-Reviewers-&-Authors#test-assure-technical-rather-than-social-focus) and other breaches of writing style are left to the editors to determine (since mostly these are matters of common sense + imitating other kinds of standards documents)