### PR TITLE
Top README: update modtime from #928

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 1855 | [Forging policy keys for HD Wallets](./CIP-1855/) | Active |
 | 9999 | [Cardano Problem Statements](./CIP-9999/) | Active |
 
-<p align="right"><i>Last updated on 2024-09-03</i></p>
+<p align="right"><i>Last updated on 2024-10-16</i></p>
 
 > 💡 For more details about CIP statuses, refer to [CIP-0001](./CIP-0001).
 


### PR DESCRIPTION
Now that the "candidates" list is being updated automatically, it's been harder to remember to update times of table modifications manually.
- CIP table is updated to match https://github.com/cardano-foundation/CIPs/pull/928/commits/4ab399f52b861374bcac596e92ada94845d46f9b of https://github.com/cardano-foundation/CIPs/pull/928
- CPS table was correctly updated in https://github.com/cardano-foundation/CIPs/pull/899

One thing I thought of adding: more precise modification times in UTC: now that we have editors working across 12 time zones again.  Why not:
- These changes don't just happen at the meeting, or the last commit in the meeting update PR, but over a period of all the editors approving them: which makes precision irrelevant and perhaps even misleading.
- I think we are looking forward to a day soon when the whole table will be updated by GitHub CI automatically upon each merge... then it will make sense to include a precise update time, so there's no point fine-tuning the manual process now.

On a related note I had to quickly go back and retitle all these PRs: https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+%22post+meeting%22+in%3Atitle ... since the `#` in the meeting name was being inappropriately interpreted as a GitHub reference on commit lists. 