### PR TITLE
CIP-0101, CIP-0127 | Remove backticks from literals in titles

### DIFF
--- a/CIP-0101/README.md
+++ b/CIP-0101/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 101
-Title: Integration of `keccak256` into Plutus
+Title: Integration of keccak256 into Plutus
 Status: Proposed
 Category: Plutus
 Authors: 

--- a/CIP-0127/README.md
+++ b/CIP-0127/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 127
-Title: `ripemd-160` hashing in Plutus Core
+Title: ripemd-160 hashing in Plutus Core
 Status: Proposed
 Category: Plutus
 Authors:


### PR DESCRIPTION
As currently appearing with potential YAML parsing errors here:
- https://github.com/cardano-foundation/CIPs/blob/master/CIP-0101/README.md
- https://github.com/cardano-foundation/CIPs/blob/master/CIP-0127/README.md

and breaking downstream renderers as reported here:
- https://github.com/cardano-foundation/developer-portal/pull/1335#issuecomment-2420391244

I say "potential" because the backtick seems only to be a problem in the first position of the YAML value.  However, for the sake of authors & readers, if we don't allow it in the initial position it would be confusing to allow it anywhere... and irrational to ask authors & editors to rearrange the titles for the backticks only to appear in the middle.