### PR TITLE
CIP-???? | On-Chain Parameter Application

### DIFF
--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -102,10 +102,10 @@ credential.
 ## Path to Active
 
 ### Acceptance Criteria
-- [] Fully implemented in Cardano.
+- [ ] Fully implemented in Cardano.
 
 ### Implementation Plan
-- [] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
+- [ ] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
 
 ## Copyright
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -72,7 +72,7 @@ In short, we'll get:
 Implementing such a validation on-chain would involve a few steps.
 
 First, the whole target contract has to be wrapped within an outer function
-which the parameters will be applied to it. This leads to single occurances of
+which the parameters will be applied to. This leads to single occurances of
 the parameters throughout the script's CBOR.
 
 Secondly, each parameter will be required to have fixed lengths in order to

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -43,7 +43,7 @@ builtinApplyParams :: BuiltinByteString -> [BuiltinData] -> ScriptHash
 
 Where the first argument is the unapplied script's CBOR, and
 the `BuiltinData` list is all the parameters that are to be applied in order.
-Finally the result will be hash of the applied script.
+Finally, output will be the hash of the applied script.
 
 
 ### Cost Model

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -64,13 +64,12 @@ used to generate an instance's script hash.
 
 In short, we'll get:
 * Easier and cheaper parameter verification on-chain
-* A more automation friendly build for such architectures
+* A more automation-friendly build for such architectures
 * Less error prone builds
 
 ### Alternatives 
 
-Continuing to use the [example above](#motivation-why-is-this-cip-necessary), implementing
-such a validation on-chain would involve a few key steps.
+Implementing such a validation on-chain would involve a few steps.
 
 First, the whole target contract has to be wrapped within an outer function
 which the parameters will be applied to it. This leads to single occurances of
@@ -82,7 +81,7 @@ assuming these parameters are all hashes, and that their corresponding values
 will be provided via the redeemer.
 
 Next, in order to validate a given script is an instance of a known script,
-first few bytes of an instance must be provided (up until where the parameter is
+first bytes of an instance must be provided (up until where the parameters are
 placed). With this "prefix" at hand, the instance's CBOR can be constructed
 on-chain as such:
 ```hs

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -1,0 +1,83 @@
+---
+CIP: ????
+Title: On-Chain Parameter Application
+Status: Proposed
+Category: Plutus
+Authors:
+    - Keyan M. <keyanmaskoot@gmail.com>
+Implementors: []
+Discussions: 
+    - https://github.com/cardano-foundation/CIPs/pull/999/
+Created: 2024-11-04
+License: CC-BY-4.0
+---
+
+## Abstract
+We propose a new Plutus builtin function `builtinApplyParams` with the
+signature `BuiltinByteString -> [BuiltinData] -> ScriptHash` in order to enable
+simple and low cost on-chain check for validating instances of unapplied
+scripts.
+
+## Motivation: why is this CIP necessary?
+Complex contracts tend to depend on multiple scripts, and in some cases,
+validation from scripts with some unknown parameters are required.
+
+As a simple example, assume a minting script which needs to validate that the
+destination of its token is a a parameterized spending that is uniquely
+instantiated for a user.
+
+The current solution involves wrapping the spending script with an inner lambda,
+expecting the parameters as hashed values to ensure their constant lengths, and
+expect each parameter to be provided via the redeemer. This approach allows
+slicing unapplied CBOR of the applied script at specific indexes in order to
+validate the presence of the expected hash.
+
+This, however, is a costly and relatively complex approach.
+
+With our proposed builtin function, the minting script of the example above can
+be provided with the unapplied script (either directly or indirectly), and have
+arbitrary values applied to it as parameters.
+
+## Specification
+
+### Function Definition
+
+we propose the Plutus builtin function `builtinApplyParams`, with the following
+type signature:
+```hs
+builtinApplyParams :: BuiltinByteString -> [BuiltinData] -> ScriptHash
+```
+
+Where the first argument is the unapplied script's CBOR, and
+the `BuiltinData` list is all the parameters that are to be applied in order.
+Finally the result will be hash of the applied script.
+
+
+### Cost Model
+
+TODO
+
+
+## Rationale: how does this CIP achieve its goals?
+
+With a builtin function, we'll get cheap and simple on-chain parameter
+validation. Consequently, this will enable easier implementation of advanced
+contracts with enhanced guarantees.
+
+### Alternatives 
+
+Please see example above under the [motivation section](#motivation-why-is-this-cip-necessary).
+
+## Path to Active
+
+### Acceptance Criteria
+- [] Fully implemented in Cardano.
+
+### Implementation Plan
+- [] Passes all requirements of both Plutus and Ledger teams as agreed to improve Plutus script efficiency and usability.
+
+## Copyright
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+[CC-BY-4.0]: https://creativecommons.org/licenses/by/4.0/legalcode
+[Apache-2.0]: http://www.apache.org/licenses/LICENSE-2.0

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -4,11 +4,13 @@ Title: On-Chain Parameter Application
 Status: Proposed
 Category: Plutus
 Authors:
+    - Philip DiSarro <info@anastasialabs.com>
     - Keyan M. <keyanmaskoot@gmail.com>
+    - Microproofs <kwhitemsg@gmail.com>
 Implementors: []
 Discussions: 
-    - https://github.com/cardano-foundation/CIPs/pull/999/
-Created: 2024-11-04
+    - https://github.com/cardano-foundation/CIPs/pull/934/
+Created: 2024-11-06
 License: CC-BY-4.0
 ---
 

--- a/CIP-param-application/README.md
+++ b/CIP-param-application/README.md
@@ -16,9 +16,9 @@ License: CC-BY-4.0
 
 ## Abstract
 We propose a new Plutus builtin function `builtinApplyParams` with the
-signature `BuiltinByteString -> [BuiltinData] -> ScriptHash` in order to enable
-simple and low cost on-chain check for validating instances of unapplied
-scripts.
+signature `BuiltinByteString -> [BuiltinByteString] -> BuiltinByteString` in
+order to enable simple and low cost on-chain check for validating instances of
+unapplied scripts.
 
 ## Motivation: why is this CIP necessary?
 Complex contracts tend to depend on multiple scripts, and in some cases,
@@ -40,12 +40,13 @@ arbitrary values applied to it as parameters.
 We propose the Plutus builtin function `builtinApplyParams`, with the following
 type signature:
 ```hs
-builtinApplyParams :: BuiltinByteString -> [BuiltinData] -> ScriptHash
+builtinApplyParams :: BuiltinByteString -> [BuiltinByteString] -> BuiltinByteString
 ```
 
 Where the first argument is the unapplied script's CBOR, and
-the `BuiltinData` list is all the parameters that are to be applied in order.
-Finally, output will be the hash of the applied script.
+the `BuiltinByteString` list is CBOR bytes of all the parameters that are to be
+applied in order. Finally, output will be the fully/partially applied script
+CBOR.
 
 
 ### Cost Model


### PR DESCRIPTION
We propose a new builtin Plutus function, `builtinApplyParams`, to reduce the costs and complexity of instantiating parameterized scripts on-chain.

A sample use-case for performing this computation on-chain would be enabling validation by a minting policy for the destinations of its tokens, ensuring that only instances of a specific script can be the recipients.

Without this builtin, apart from development complexities, script instances need to be limited to hashed parameters that must be resolved via the redeemer in each transaction, and therefore bloat the chain with duplicate data.

---

([latest version in branch](https://github.com/keyan-m/CIPs/blob/param-application/CIP-param-application/README.md))