### PR TITLE
CIP-0143? | Interoperable Programmable Tokens

### DIFF
--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -2,7 +2,7 @@
 CIP: 143
 Title: Interoperable Programmable Tokens
 Category: Tokens
-Status: Proposed
+Status: Inactive (incorporated into candidate CIP-0113)
 Authors:
     - Philip DiSarro <philipdisarro@gmail.com>
 Implementors: []

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -178,15 +178,15 @@ The above factors motivated the design of this framework. Some of the core uniqu
 ## Path to Active
 
 ### Acceptance Criteria
-- [ x ] Issuance of at-least one smart token via the proposed framework on the following networks:
-  - [ x ] 1. Preview testnet
-  - [ x ] 2. Mainnet
-- [ x ] End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
-- [ x ] Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
+- [x] Issuance of at-least one smart token via the proposed framework on the following networks:
+  - [x] 1. Preview testnet
+  - [x] 2. [Mainnet](https://cexplorer.io/asset/asset1dk6zekxuyuc6up56q7nkd7084k609k3gfl27n8/mint#data) 
+- [x] End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
+- [x] Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
 
 ### Implementation Plan
-- [ x ] Implement the contracts detailed in the specification.
-- [ x ] Implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
+- [x] Implement the contracts detailed in the specification. Done [here](https://github.com/input-output-hk/wsc-poc/tree/main/src/lib/SmartTokens).
+- [x] Implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. Done [here](https://github.com/input-output-hk/wsc-poc/tree/main/src/lib/Wst/Offchain).
 
 ## Copyright
 This CIP is licensed under [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -178,15 +178,15 @@ The above factors motivated the design of this framework. Some of the core uniqu
 ## Path to Active
 
 ### Acceptance Criteria
-- [ ] Issuance of at-least one smart token via the proposed framework on the following networks:
-  - [ ] 1. Preview testnet
-  - [ ] 2. Mainnet
-- [ ] End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
-- [ ] Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
+- [ x ] Issuance of at-least one smart token via the proposed framework on the following networks:
+  - [ x ] 1. Preview testnet
+  - [ x ] 2. Mainnet
+- [ x ] End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
+- [ x ] Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
 
 ### Implementation Plan
-- [ ] Implement the contracts detailed in the specification.
-- [ ] Implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
+- [ x ] Implement the contracts detailed in the specification.
+- [ x ] Implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
 
 ## Copyright
 This CIP is licensed under [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -8,6 +8,7 @@ Authors:
 Implementors: []
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/444
+    - https://github.com/cardano-foundation/CIPs/pull/944
 Created: 2024-12-3
 License: Apache-2.0
 ---

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -1,7 +1,7 @@
 ---
-CIP: ???
+CIP: CIP-143
 Title: Interoperable Programmable Tokens
-Category: Plutus
+Category: Tokens
 Status: Proposed
 Authors:
     - Philip DiSarro <philipdisarro@gmail.com>

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: CIP-143
+CIP: 143
 Title: Interoperable Programmable Tokens
 Category: Tokens
 Status: Proposed

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -138,17 +138,15 @@ The above factors motivated the design of this framework. Some of the core uniqu
 ## Path to Active
 
 ### Acceptance Criteria
-Issuance of at-least one smart token via the proposed framework on the following networks:
-1) Preview testnet
-2) Mainnet
-
-End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
-
-Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
+- [ ] Issuance of at-least one smart token via the proposed framework on the following networks:
+  - [ ] 1. Preview testnet
+  - [ ] 2. Mainnet
+- [ ] End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
+- [ ] Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
 
 ### Implementation Plan
-Implement the contracts detailed in the specification, and implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
-
+- [ ] Implement the contracts detailed in the specification.
+- [ ] Implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
 
 ## Copyright
 This CIP is licensed under [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/CIP-0143/README.md
+++ b/CIP-0143/README.md
@@ -47,65 +47,106 @@ The impact that the required script executions have on the cost of transactions 
 
 ## Specification
 
-### Smart Token Directory & Minting policy
-This smart contracts is responsible for the minting / creation of new programmable tokens and for maintaining an merkle patricia forestry of all smart tokens and their respective transfer policies, we call this the `directoryRootHash`. 
+### Programmable Logic Minting Policy
 
-```Haskell
--- directoryUTxO: a UTxO containing a state token NFT
---   address: ownScriptHash
---   value: ada <> directoryStateTokenNFT
---   datum: BuiltinByteString - the merkle patricia forestry root of the smart token directory
+The `mkProgrammableLogicMinting` smart contract is responsible for the minting and issuance of new programmable tokens. Additionally, the contract ensures that an entry is added to the onchain directory linked list that permenantly associates the issued programmable token with its transfer script logic and issuer script logic. 
 
--- Script Logic:
---    enforces that all minted tokens must be sent to instantiations of a base parameter script (the `ProgrammableLogicBaseScript` contract)
---    enforces that an entry with the key as `ownCurrencySymbol`, and the value as the script hash of it's `transferLogicScript` must be inserted into the merkle root in the datum of the directoryUTxO.
---    Enforces that the transaction only mints tokens with `ownScriptHash` as their currency symbol in this transaction (no other tokens are minted).
+```haskell
+mkProgrammableLogicMinting :: 
+    Credential -- Minting logic credential
+    -> ScriptContext 
+    -> ()  
+mkProgrammableLogicMinting mintingLogicCred = ... 
 ```
 
-Note that in this design there is only a single smart token directory UTxO. If we expect issuance of such token to be infrequent, then this is not an issue. However, if we expect issuance of programmable tokens to be a common occurrance than an [onchain linked list](https://github.com/Anastasia-Labs/plutarch-linked-list) data-structure should be used instead to prevent concurrency issues due to UTxO contention. In this case, each node on the linked list would contain the only Ada and a `nodeNFT` (which certifies that it is a valid linked list node, and as such the correctness of it's datum is enforced by the smart contract) and the datum of each node would contain:
-```
-data ProgrammableTokenDirectoryNode = ProgrammableTokenDirectoryNode
-  { key :: CurrencySymbol 
-  -- ^ Currency Symbol of the programmable token associated with this directory entry
-  , next :: CurrencySymbol 
-  -- ^ Currency Symbol of the programmable token associated with the next node in this directory.
-  , transferLogicScript :: ScriptHash 
-  -- ^ The transfer logic script that must be executed in every transaction that spends the programmable token associated with this directory entry. 
-  }
-```
-In either case, there is only a single directory (a single directory UTxO / single directory linked list) for all programmable tokens.
+The contract accepts a single parameter, *mintingLogicCred* that defines the specialized the minting logic for the programmable token. `mintingLogicCred` must be a `ScriptCredential` of a [withdraw-zero rewarding script](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md).
 
-### Transfer Logic Scripts
-The system guarantees that each programmable token must have a transfer logic script (located in either the directory UTxO or the directory linked list depending on the implementation). The transfer logic script for a programmable token is the smart contract that must be executed in every transaction that spends the programmable token. For example to have a stable coin that supports freezing / arrestability this script might require a non-membership merkle proof in a blacklist. This must be a staking script (or an observer script once CIP-112 is implemented), see 
-[the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md) for an explanation.
+#### Supported Actions
+
+The minting policy supports two actions:
+
+##### Token Registration (`PRegisterPToken`)
+
+- Enforces that an immutable entry for the programmable token is inserted into the programmable token directory.
+- The directory entry associates the programmable token with a transfer logic script and a issuer logic script.
+  - The transfer logic script is a withdraw-zero script that must be invoked in every user transaction that spends the programmable token.
+  - The issuer logic script is a withdraw-zero script that must be invoked in every permissioned transaction that spends the programmable token.
+    - A permissioned action is an action that can only be performed by the token issuer, that bypasses the normal transfer logic of the system. An example is seizure / clawbacks which allow the issuer of a programmable token to reclaim the token from any UTxO at their discretion. 
+- Enforces that only a single new type of programmable token is issued in the transaction.
+- Enforces that all minted programmable tokens must be sent to the `programmableLogicBase` contract. 
+- Enforces that the `mintingLogicCred` script is executed in the transaction see [the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md) 
+
+##### Token Minting/Burning (`PMintPToken`)
+
+- Responsible for validating the minting / burning of programmable tokens.
+- If this action is used to mint programmable tokens, then it enforces that all minted programmable tokens must be sent to the `programmableLogicBase` contract.
+- Enforces that the `mintingLogicCred` script is executed in the transaction see [the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md)
 
 ### Programmable Logic Base Script
-This is a spending script that accepts 1 parameter, a credential which identifies the owner of the value that it locks.
 
-```Haskell
--- Script Logic:
---   Enforces that the witness associated with the credential `cred` is present in the transaction.
---     If the Credential is a PubKeyCredential then the public key hash must be present in txInfoSignatories
---     If the Credential is a ScriptCredential then the script must be present in txInfoWithdrawals (ie the script must be invoked in the tx)
---   For all non-ada tokens in the Spending script (directory UTxO implementation) either:
---     a. A non-membership proof of the token in the `directoryRootHash` must be provided in the transaction (this proves that the token is not a programmable token)
---     b. A membership proof of the token in the `directoryRootHash` must be provided, and the associated `transferLogicScript` is present in `txInfoWithdrawals`.
---   For all non-ada tokens in the Spending script (onchain linked list directory implementation) either:
---     a. Two adjacent node UTxOs in the onchain directory linked list such that the key of one is lexographically less than the currency symbol of the token, and the other is
---        lexographically greater than the currency symbol of the token must be provided as reference inputs (this proves that the token is not a programmable token)        
---     b. The node UTxO in the onchain directory linked list associated with the currency symbol must be provided as a reference input, and the associated `transferLogicScript` is present --        in `txInfoWithdrawals`.
---    
---   Enforces that outputs containing programmable tokens must be instances of `ProgrammableLogicBaseScript` (this ensures that the system is closed and programmable tokens cannot be 
---   smuggled). If the destination of a programmable token is a `ProgrammableLogicBaseScript` parameterized by a non-script credential (public key hash / public key staking credential)
---   then the output UTxO must only contain ada and the programmable token. This ensures that if a user's programmable token is frozen or otherwise ineligible for transfer due to its
---   transfer logic script, it will not cause other unaffiliated tokens to be locked. Note that such situations are unavoidable for dApp protocols (freezing a token in a liquidity pool
---   will cause the pool to be inoperable), as such we do not impose this restriction on transfers to script based instances of `ProgrammableLogicBaseScript`.
+The `mkProgrammableLogicBase` is a spending script that manages the ownership and transfer of programmable tokens. The `mkProgrammableLogicBase` script forwards its logic to the `mkProgrammableLogicGlobal` via [the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md). The `mkProgrammableLogicGlobal` script is responsible for ensuring that programmable tokens must always remain within the `mkProgrammableLogicBase` script and that the associated `transferLogicScript` is invoked (or  in the case of a permissioned action, that the associated `issuerLogicScript` is invoked) for each unique programmable token spent.
 
-mkProgrammableBaseScript :: Credential -> ScriptContext -> ()
-mkProgrammableBaseScript cred ctx = ...
+#### Ownership Mechanism
+
+The system enforces that programmable tokens must all reside at the `mkProgrammableLogicBase` script. As such the payment credential of any UTxO that contains programmable tokens will always be the `mkProgrammableLogicBase` script credential. This system leverages staking credentials to identify and manage ownership. This approach ensures that programmable tokens remain secure and can only be transferred by their rightful owners. The owner of a UTxO at the `mkProgrammableLogicBase` script is determined by its staking credential. If the UTxO's staking credential is a public key credential, then any transaction that spends that UTxO must be signed by the public key; the system refers to all such required signatures in a transaction as the transaction's required public key witnesses. If the UTxO's staking credential is a script credential then the associated script must be invoked in the transaction via [the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md); we refer to all such required scripts as the transaction's required script witnesses.
+
+#### Supported Actions
+
+The `mkProgrammableLogicGlobal` (and thus the `mkProgrammableLogicBase`) supports two actions:
+
+```haskell
+data ProgrammableLogicGlobalRedeemer
+  = PTransferAct
+      { proofs :: [PTokenProof]
+      }
+  | PSeizeAct
+      { seizeInputIdx :: Integer
+      , seizeOutputIdx :: Integer
+      , directoryNodeIdx :: Integer
+      }
 ```
 
-This framework doesn't require custom indexers to find user / script UTxOs, instead they can be easily queried by all existing indexers / wallets. For example, to obtain all the smart tokens in a user's wallet you can query their programmable token address (in the same way you would query any normal address). You can derive the user's programmable token address deterministically by applying their Credential to the `ProgrammableLogicBaseScript`.
+Where `PTokenProof` is defined as,
+```haskell
+data PTokenProof
+  = PTokenExists { nodeIdx :: Integer }
+  | PTokenDoesNotExist { nodeIdx :: Integer }
+```
+
+##### Transfer Action (`PTransferAct`)
+- Traverse the transaction inputs and compute the sum of all value spent from the `mkProgrammableLogicBase` script, which we refer to as the `totalValueSpent`.
+  - Enforce that the required witness for each input is present in the transaction
+      - If the staking credential of the input is a payment credential then the public key hash must be present in the transaction signatories.
+      - If the staking credential of the input is a script credential then the associated script must be invoked in the transaction. 
+- Simultaneously traverse the currency symbols in `totalValueSpent` and the `PTransferAct` proof list and compute the `totalProgrammableValueSpent` (value consisting of only programmable tokens).
+  - If a proof for a given currency symbol, `currentSymbol`, is `PTokenExists { nodeIdx ... }` then the reference input indexed by `nodeIdx` must satisfy the following:
+    - The reference input must be a valid programmable token directory node (i.e. it must contain a token with the `directoryNode` currency symbol).
+    - It must be the correct directory node for `currentSymbol` (i.e. the currency symbol must be equal to the node's key).
+    - The directory node's transfer logic script must be executed in the transaction.
+    - Together, these conditions enforce that the `currentSymbol` is indeed a programmable token and that the `transferLogicScript` associated with the programmable token is executed. 
+  - If a proof for a given currency symbol, `currentSymbol`, is `PTokenDoesNotExist { nodeIdx ... }` then the reference input indexed by `nodeIdx` must satisfy the following:
+    - The reference input must be a valid programmable token directory node (i.e. it must contain a token with the `directoryNode` currency symbol).
+    - The directory node's `key` must be lexographically less than the `currentSymbol` and the directory node's `next` must be lexographically greater than the `currentSymbol`. 
+    - Together, these conditions enforce that the `currentSymbol` is not a programmable token. 
+- Traverse the transaction outputs and compute `totalProgrammableValueProduced`, the sum of all value produced to the `mkProgrammableLogicBase` script.
+- Enforce that the `totalProgrammableValueProduced` is greater than or equal to the `totalProgrammableValueSpent`.
+  - This insures that programmable tokens always remain at the `mkProgrammableLogicBase` script.
+
+##### Seize Action (`PSeizeAct`)
+- Enforce that the transaction input indexed by `seizeInputIdx`, which we refer to as the `programmableTokenInput`, is a UTxO from the `mkProgrammableLogicBase` script.
+- Enforce that there is only a single input from the `mkProgrammableLogicBase` script in the transaction.
+- Enforce that the reference input indexed by `directoryNodeIdx`, which we refer to as the `indexedDirectoryNode`, is a valid directory node (i.e. it must contain a token with the `directoryNode` currency symbol).
+- Enforce that the `issuerLogicScript` in the directory node is invoked in the transaction.
+- Enforce the the transaction output indexed by `seizeOutputIdx`, which we refer to as the `programmableTokenOutput`, satisfies the following criteria:
+  - The address of the `programmableTokenOutput` equal to the address of the `programmableTokenInput`.
+  - The value in the `programmableTokenOutput` is equal to the value in the `programmableTokenInput` after filtering the currency symbol of the programmable token associated with the `indexedDirectoryNode` (the node's `key`).
+  - The datum in the `programmableTokenOutput` is equal to the datum in the `programmableTokenInput`
+  - Together these conditions enforce that the permissioned actions of a programmable token are limited in scope such that they can only be used to transfer the associated programmable token from UTxOs, and cannot be used to modify those UTxOs in any other manner. 
+
+The system guarantees that each programmable token must have a transfer logic script (located in the associated directory node in the directory linked list). The transfer logic script for a programmable token is the smart contract that must be executed in every transaction that spends the programmable token. For example to have a stable coin that supports freezing / arrestability this script might require a non-membership merkle proof in a blacklist. This must be a staking script (or an observer script once CIP-112 is implemented), see 
+[the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md) for an explanation.
+
+This framework doesn't require custom indexers to find user / script UTxOs, instead they can be easily queried by all existing indexers / wallets. For example, to obtain all the smart tokens in a user's wallet you can construct a franken-address where the payment credential is the `mkProgrammableLogicBase` credential and the staking credential is the user's public key credential and then query this address (in the same way you would query any normal address). 
 
 ## Rationale: how does this CIP achieve its goals?
 
@@ -126,14 +167,13 @@ The transfer scripts proposal is to introduce a new Plutus script type that woul
 Furthermore, all of the aforementioned proposals would require custom indexers and infrastructure to locate a user's (or smart contract's) programmable tokens. You could not simply query an address, instead you would need to query UTxOs from the contracts and check their datum / value (depending on the CIP) to determine the owner.
 
 The above factors motivated the design of this framework. Some of the core unique properties of this framework include: 
-1. Each users gets their own smart tokens address (that can be derived from staking keys, pub key hashes, and script hashes)
+1. Each user gets their own programmable token address that can be easily derived their credentials.
 2. Interoperability with existing dApps
 3. Introduces no new risk / vulnerabilities into existing protocols
 4. Doesn't require changes to the ledger
 5. Smart tokens cannot be revoked by dApps that fail to follow the standard (unlike the CIP 68 case in which they can)
 6. Very low effort (relative to the existing proposals) to implement and get it to production / mainnet adoption
 7. Completely permissionless and natively interoperable with other smart tokens. IE anyone can mint their own smart tokens with their own custom logic and the correctness of their behavior will be enforced
-
 
 ## Path to Active
 

--- a/CIP-interoperable-programmable-tokens/README.md
+++ b/CIP-interoperable-programmable-tokens/README.md
@@ -12,19 +12,6 @@ Created: 2024-12-3
 License: Apache-2.0
 ---
 
-<!-- Existing categories:
-
-- Meta     | For meta-CIPs which typically serves another category or group of categories.
-- Wallets  | For standardisation across wallets (hardware, full-node or light).
-- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata | For proposals around metadata (on-chain or off-chain).
-- Tools    | A broad category for ecosystem tools not falling into any other category.
-- Plutus   | Changes or additions to Plutus
-- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
-
--->
-
 ## Abstract
 
 This CIP proposes a robust framework for the issuance of interoperable programmable tokens on Cardano. Unlike all its predecessors, this framework allows these tokens to be used in existing dApps, and does not require dApps to be developed specifically for these tokens. 
@@ -60,7 +47,7 @@ The impact that the required script executions have on the cost of transactions 
 
 ## Specification
 
-# Smart Token Directory & Minting policy
+### Smart Token Directory & Minting policy
 This smart contracts is responsible for the minting / creation of new programmable tokens and for maintaining an merkle patricia forestry of all smart tokens and their respective transfer policies, we call this the `directoryRootHash`. 
 
 ```Haskell
@@ -88,11 +75,11 @@ data ProgrammableTokenDirectoryNode = ProgrammableTokenDirectoryNode
 ```
 In either case, there is only a single directory (a single directory UTxO / single directory linked list) for all programmable tokens.
 
-# Transfer Logic Scripts
+### Transfer Logic Scripts
 The system guarantees that each programmable token must have a transfer logic script (located in either the directory UTxO or the directory linked list depending on the implementation). The transfer logic script for a programmable token is the smart contract that must be executed in every transaction that spends the programmable token. For example to have a stable coin that supports freezing / arrestability this script might require a non-membership merkle proof in a blacklist. This must be a staking script (or an observer script once CIP-112 is implemented), see 
 [the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md) for an explanation.
 
-# Programmable Logic Base Script
+### Programmable Logic Base Script
 This is a spending script that accepts 1 parameter, a credential which identifies the owner of the value that it locks.
 
 ```Haskell
@@ -151,7 +138,6 @@ The above factors motivated the design of this framework. Some of the core uniqu
 ## Path to Active
 
 ### Acceptance Criteria
-<!-- Describes what are the acceptance criteria whereby a proposal becomes 'Active' -->
 Issuance of at-least one smart token via the proposed framework on the following networks:
 1) Preview testnet
 2) Mainnet
@@ -161,12 +147,8 @@ End-to-end tests of programmable token logic including arrestability, transfer f
 Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
 
 ### Implementation Plan
-<!-- A plan to meet those criteria or `N/A` if an implementation plan is not applicable. -->
 Implement the contracts detailed in the specification, and implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
 
-<!-- OPTIONAL SECTIONS: see CIP-0001 > Document > Structure table -->
 
 ## Copyright
-<!-- The CIP must be explicitly licensed under acceptable copyright terms. Uncomment the one you wish to use (delete the other one) and ensure it matches the License field in the header: -->
-
 This CIP is licensed under [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/CIP-interoperable-programmable-tokens/README.md
+++ b/CIP-interoperable-programmable-tokens/README.md
@@ -1,0 +1,150 @@
+---
+CIP: ???
+Title: Interoperable Programmable Tokens
+Category: Plutus
+Status: Proposed
+Authors:
+    - Philip DiSarro <philipdisarro@gmail.com>
+Implementors: []
+Discussions:
+    - https://github.com/cardano-foundation/CIPs/pull/444
+Created: 2024-12-3
+License: Apache-2.0
+---
+
+<!-- Existing categories:
+
+- Meta     | For meta-CIPs which typically serves another category or group of categories.
+- Wallets  | For standardisation across wallets (hardware, full-node or light).
+- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata | For proposals around metadata (on-chain or off-chain).
+- Tools    | A broad category for ecosystem tools not falling into any other category.
+- Plutus   | Changes or additions to Plutus
+- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
+
+-->
+
+## Abstract
+
+This CIP proposes a robust framework for the issuance of interoperable programmable tokens on Cardano. Unlike all its predecessors, this framework allows these tokens to be used in existing dApps, and does not require dApps to be developed specifically for these tokens. 
+
+## Motivation: why is this CIP necessary?
+
+This CIP proposes a solution to Cardano Problem Statement 3 ([CPS-0003](https://github.com/cardano-foundation/CIPs/pull/382/files?short_path=5a0dba0#diff-5a0dba075d998658d72169818d839f4c63cf105e4d6c3fe81e46b20d5fd3dc8f)).
+
+With this framework we achieve programmability over the transfer of tokens (meta-tokens) and their lifecycle without sacrificing composability with existing dApps. 
+
+Answers to the open questions of CPS-0003:
+
+1) How to support wallets to start supporting validators?
+
+For every user address you can easily derive the equivalent smart token address. So to obtain a users total wallet balance including their programmable tokens, the wallet can query their programmable token address and their normal address and combine the two results.  
+
+2) How would wallets know how to interact with these tokens? - smart contract registry?
+
+For any given programmable token transfer, wallets can easily determine which stake script needs to be invoked (that contains the transfer logic) directly from the chain (no offchain registry required) by querying the original minting tx. 
+
+3) Is there a possibility to have a transition period, so users won't have their funds blocked until the wallets start supporting smart tokens?
+
+This framework will not cause any funds to be blocked. Transfers of non-programmable tokens will remain unaffected.
+
+4) Can this be achieved without a hard fork?
+
+Yes, this framework has been possible since the Chang hard fork. 
+
+5) How to make validator scripts generic enough without impacting costs significantly?
+
+The impact that the required script executions have on the cost of transactions is negligible.  
+
+
+## Specification
+
+# Smart Token Directory & Minting policy
+This smart contracts is responsible for the minting / creation of new programmable tokens and for maintaining an merkle patricia forestry of all smart tokens and their respective transfer policies, we call this the `directoryRootHash`.
+
+```Haskell
+-- directoryUTxO: a UTxO containing a state token NFT
+--   address: ownScriptHash
+--   value: ada <> directoryStateTokenNFT
+--   datum: BuiltinByteString - the merkle patricia forestry root of the smart token directory
+
+-- Script Logic:
+--    enforces that all minted tokens must be sent to instantiations of a base parameter script (the `ProgrammableLogicBaseScript` contract)
+--    enforces that an entry with the key as `ownCurrencySymbol`, and the value as the script hash of it's `transferLogicScript` must be inserted into the merkle root in the datum of the directoryUTxO.
+--    Enforces that the transaction only mints tokens with `ownScriptHash` as their currency symbol in this transaction (no other tokens are minted).
+```
+
+# Transfer Logic Scripts
+The system guarantees that each programmable token must have a transfer logic script. The transfer logic script for a programmable token is the smart contract that must be executed in every transaction that spends the programmable token. For example to have a stable coin that supports freezing / arrestability this script might require a non-membership merkle proof in a blacklist. This must be a staking script (or an observer script once CIP-112 is implemented), see 
+[the withdraw-zero trick](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/STAKE-VALIDATOR-TRICK.md) for an explanation.
+
+# Programmable Logic Base Script
+This is a spending script that accepts 1 parameter, a credential which identifies the owner of the value that it locks.
+
+```Haskell
+-- Script Logic:
+--   Enforces that the witness associated with the credential `cred` is present in the transaction.
+--     If the Credential is a PubKeyCredential then the public key hash must be present in txInfoSignatories
+--     If the Credential is a ScriptCredential then the script must be present in txInfoWithdrawals (ie the script must be invoked in the tx)
+--   For all non-ada tokens in the Spending script either:
+--     a. A non-membership proof of the token in the `directoryRootHash` must be provided in the transaction (this proves that the token is not a programmable token)
+--     b. A membership proof of the token in the `directoryRootHash` must be provided, and the associated `transferLogicScript` is present in `txInfoWithdrawals`.
+
+mkProgrammableBaseScript :: Credential -> ScriptContext -> ()
+mkProgrammableBaseScript cred ctx = ...
+```
+
+This framework doesn't require custom indexers to find user / script UTxOs, instead they can be easily queried by all existing indexers / wallets. For example, to obtain all the smart tokens in a user's wallet you can query their programmable token address (in the same way you would query any normal address). You can derive the user's programmable token address deterministically by applying their Credential to the `ProgrammableLogicBaseScript`.
+
+## Rationale: how does this CIP achieve its goals?
+
+The existing proposed frameworks for programmable tokens are:
+1. Ethereum Account Abstraction (emulate Ethereum accounts via Plutus contract data)
+2. Smart Tokens - CIP 113
+3. Arrestable assets - CIP 125
+
+The issue with all of the above is that they are not interoperable with existing dApps. Thus entirely new dApps protocols would need to be developed specifically for transacting with the proposed smart tokens. They are not composable with existing DeFi, and so they will only work on smart-token enabled DeFi protocols. Furthermore, in some of the above CIPs, each smart-token enabled dApp must be thoroughly audited to ensure that it is a closed system (ie. there is no way for tokens to be smuggled to non-compliant addresses) and thus there needs to be a permissioned whitelist of which addresses are compliant.
+
+Additionally, these proposed solutions attempt to maintain interoperability:
+1. CIP 68 Smart Tokens
+2. Transfer Scripts (ledger changes required)
+
+The CIP 68 approach allows the tokens to be used anywhere but if the contract does not obey the logic then the token can be invalidated (ie revoked). So if you put it into a liquidity pool and the batcher does not obey the token logic then your tokens can be revoked and it wouldn't be your fault.
+The transfer scripts proposal is to introduce a new Plutus script type that would need to be invoked in any transaction that spends a smart token (identified by the policy id). The issue with this approach is that it introduces a huge potential for vulnerabilities and exploits to the existing ledger and these vulnerabilities are responsible for the vast majority of exploits and centralization risks in ecosystems with fully programmable tokens (ie Ethereum). Regardless, this means that these tokens could not be used on existing dApps, since they would require a new Plutus version with new features, and the ledger does not allow contracts that use new features to co-exist in transactions with contract from previous versions where those features did not exist. 
+
+Furthermore, all of the aforementioned proposals would require custom indexers and infrastructure to locate a user's (or smart contract's) programmable tokens. You could not simply query an address, instead you would need to query UTxOs from the contracts and check their datum / value (depending on the CIP) to determine the owner.
+
+The above factors motivated the design of this framework. Some of the core unique properties of this framework include: 
+1. Each users gets their own smart tokens address (that can be derived from staking keys, pub key hashes, and script hashes)
+2. Interoperability with existing dApps
+3. Introduces no new risk / vulnerabilities into existing protocols
+4. Doesn't require changes to the ledger
+5. Smart tokens cannot be revoked by dApps that fail to follow the standard (unlike the CIP 68 case in which they can)
+6. Very low effort (relative to the existing proposals) to implement and get it to production / mainnet adoption
+7. Completely permissionless and natively interoperable with other smart tokens. IE anyone can mint their own smart tokens with their own custom logic and the correctness of their behavior will be enforced. 
+
+
+## Path to Active
+
+### Acceptance Criteria
+<!-- Describes what are the acceptance criteria whereby a proposal becomes 'Active' -->
+Issuance of at-least one smart token via the proposed framework on the following networks:
+1) preview testnet
+2) preprod testnet
+3) mainnet
+
+End-to-end tests of programmable token logic including arrestability, transfer fees, and blacklisting. 
+
+Finally, a widely adopted wallet that can read and display programmable token balances to users and allow the user to conduct transfers of such tokens. 
+
+### Implementation Plan
+<!-- A plan to meet those criteria or `N/A` if an implementation plan is not applicable. -->
+Implement the contracts detailed in the specification, and implement the offchain code required to query programmable token balances and construct transactions to transfer such tokens. 
+
+<!-- OPTIONAL SECTIONS: see CIP-0001 > Document > Structure table -->
+
+## Copyright
+<!-- The CIP must be explicitly licensed under acceptable copyright terms. Uncomment the one you wish to use (delete the other one) and ensure it matches the License field in the header: -->
+
+This CIP is licensed under [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
## Abstract

This CIP proposes a robust framework for the issuance of interoperable programmable tokens on Cardano. Unlike all its predecessors, this framework allows these tokens to be used in existing dApps, and does not require dApps to be developed specifically for these tokens.

---

([latest version rendered from branch](https://github.com/colll78/CIPs/blob/patch-3/CIP-0143/README.md))