### PR TITLE
CIP-0108 | Ensure "CIP-0008" is in capital letters

### DIFF
--- a/CIP-0108/examples/no-confidence.jsonld
+++ b/CIP-0108/examples/no-confidence.jsonld
@@ -67,7 +67,7 @@
     "authors": [
       {
         "witness": {
-          "witnessAlgorithm": "cip-0008",
+          "witnessAlgorithm": "CIP-0008",
           "publicKey": "7ea09a34aebb13c9841c71397b1cabfec5ddf950405293dee496cac2f437480a",
           "signature": "84582aa201276761646472657373581d610fdc780023d8be7c9ff3a6bdc0d8d3b263bd0cc12448c40948efbf42a166686173686564f458204a7ecc544559df67ece3f7f90f76c4e3e7e329a274c79a06dcfbf28351db600e5840a5dc881ddabdec69e0e4dabdd43a922ef474f7be1029facdbb9106429e17ec61deda22f2778eda21005127f0c6d10f8a4b0210b8177d03d2ae4618d2423d0807"
         }

--- a/CIP-0108/test-vector.md
+++ b/CIP-0108/test-vector.md
@@ -34,7 +34,7 @@ Blake2b-256 hash digest of canonicalized body: `68d6fe27087457acf0164e65414238c4
 ### Motion of No-Confidence
 
 Example metadata document file: [no-confidence.jsonld](./examples/no-confidence.jsonld).
-Blake2b-256 of the file content (to go onchain): `6c27e5bd0d7cdec7ddb30956be0b5eac892a8330e00689692d18f3815a71bf9f`
+Blake2b-256 of the file content (to go onchain): `87ba5c10c89484c52265b50d669b4acf116aaeb8a6fa35fbf06e5ec67cda9270`
 
 #### Intermediate files
 

--- a/CIP-0108/test-vector.md
+++ b/CIP-0108/test-vector.md
@@ -91,7 +91,7 @@ For [Treasury Withdrawal](#treasury-withdrawal), this will result in: `68d6fe270
 
 ### 4. Authors witness over the hash of canonicalized `body`
 
-Use the hash produced in [3.](#3-hash-the-canonicalized-body) as the payload for the witnessing. For a `witnessAlgorithm` of `ed25519` refer to [CIP-100 Hashing and Signatures](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#hashing-and-signatures), for `cip-0008` refer to [CIP-108 New Witness Type](./README.md#new-witness-type).
+Use the hash produced in [3.](#3-hash-the-canonicalized-body) as the payload for the witnessing. For a `witnessAlgorithm` of `ed25519` refer to [CIP-100 Hashing and Signatures](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#hashing-and-signatures), for `CIP-0008` refer to [CIP-108 New Witness Type](./README.md#new-witness-type).
 
 One tool for Ed25519 signatures is [Ed25519 Online Tool](https://cyphr.me/ed25519_tool/ed.html).
 


### PR DESCRIPTION
This PR addresses the issue https://github.com/cardano-foundation/CIPs/issues/949, by ensuring `CIP-0008` is used in capital letters in the `witnessAlgorithm` field of the `witness` type in CIP-0108, updating the "no-confidence" example and the test vector Markdown documentation.

Fixes #949.