### PR TITLE
CIP-???? | Trustless BTC Bridge

### DIFF
--- a/CPS-0017/README.md
+++ b/CPS-0017/README.md
@@ -1,0 +1,94 @@
+---
+CPS: 17
+Title: eBTC – A Trustless BTC Bridge on Cardano
+Category: Standards / Token
+Authors: An <anrodz42@gmail.com>
+Status: Draft
+Created: 2024-12-20
+License: CC-BY-4.0
+---
+
+## Abstract
+
+This proposal defines **eBTC**: a trustless, one-way bridge allowing BTC to enter Cardano as a native token. Users burn BTC on Bitcoin and present cryptographic proofs (NIPoPoW/SPV) to a Cardano smart contract, which mints a corresponding amount of eBTC. This solution removes reliance on custodians and oracles, enabling purely decentralized conversion and unlocking BTC’s liquidity for Cardano DeFi.
+
+## Motivation
+
+1. **Expand BTC Use Cases**: Enable advanced DeFi, NFTs, and smart contracts for BTC-derived value without centralized wrappers.
+2. **Trustless Design**: Existing “wrapped BTC” models rely on custodians. This CIP removes single points of failure.
+3. **One-Way Simplification**: Irreversibility ensures finality. No need for complex two-way bridging with Bitcoin’s limited scripting.
+
+## Specification
+
+### Key Components
+
+1. **Burn Operation**
+    
+    - User sends BTC to an unspendable “burn” address.
+    - This permanently removes BTC from circulation.
+2. **Proof Construction**
+    
+    - User gathers minimal block headers to prove transaction inclusion.
+    - Uses NIPoPoW or SPV-like approach.
+    - Merkle proof shows burned transaction is part of the main chain.
+3. **Proof Submission**
+    
+    - Plutus contract on Cardano verifies the block headers, ensures chain validity.
+    - If valid, mints eBTC 1:1 with the burned BTC.
+    - Updates the user’s “cumulative burn” state.
+4. **State Management**
+    
+    - Contract stores:
+        - **Last Processed Block Height** for each burn address.
+        - **Total BTC Burned** at that height.
+    - Each proof must demonstrate a block height above the last processed height to avoid double-claims.
+5. **User Ownership**
+    
+    - Users register a unique burn address.
+    - Must prove ownership/control of that Bitcoin address.
+    - Only that user can mint eBTC from that address’s burns.
+
+### CIP Format Compliance
+
+Follow the [standard CIP file structure](https://github.com/cardano-foundation/CIPs). Provide:
+
+- **CIP header** with metadata.
+- **Detailed specification** (this section).
+- **Rationale** and **path to implementation**.
+
+## Rationale
+
+- **Full Decentralization**: Eliminates need for centralized custody or oracles.
+- **Security**: Proof-of-Work chain verification via NIPoPoW/SPV.
+- **Simplicity**: One-way bridging avoids complex BTC redeems.
+- **Scalability**: Cumulative burn tracking reduces on-chain storage overhead.
+
+## Security Considerations
+
+1. **Forks & Reorgs**
+    - Proof must prove finality with enough confirmations.
+    - Contract only updates state when the chain is deemed stable.
+2. **Invalid Header Submissions**
+    - Plutus logic checks block headers and PoW proofs.
+    - Rejects fake or incomplete data.
+3. **Spam or DOS**
+    - Each proof requires transaction fees.
+    - Off-chain proof generation can be expensive, discouraging spam.
+
+## Implementation Details
+
+- **On-Chain Verification**
+    - Plutus script needs to parse Bitcoin headers.
+    - Validate chain difficulty and Merkle inclusion.
+- **Data Structures**
+    - Store minimal header data (e.g., block height, prev block hash, Merkle root).
+    - Maintain a map of user addresses to (last height, total burned).
+- **Transaction Workflow**
+    1. User calls `burnBTC` on Bitcoin.
+    2. Collects block headers and Merkle paths.
+    3. Submits them in a Cardano transaction to `eBTCMintingScript`.
+    4. Script verifies and, if passed, mints new eBTC tokens to the user’s Cardano address.
+
+## Reference Implementation
+
+A minimal Plutus code snippet (pseudo-code):

--- a/CPS-1856/README.md
+++ b/CPS-1856/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: ???
+CPS: ???
 Title: eBTC – A Trustless BTC Bridge on Cardano
 Category: Standards / Token
 Authors:
@@ -15,91 +15,114 @@ Discussions:
 
 ## Abstract
 
-This proposal defines eBTC: a trustless, one-way bridge allowing Bitcoin (BTC) value to enter Cardano as a native token. Users burn BTC on Bitcoin and present cryptographic proofs (for example, using NIPoPoW [1]) to a Cardano smart contract, which mints a corresponding amount of eBTC. Unlike centralized solutions, there are no custodians or oracles. This opens BTC liquidity to Cardano’s DeFi, NFTs, and other on-chain functionalities.
+This document defines eBTC: a trustless, one-way bridge for bringing Bitcoin (BTC) value onto Cardano as a native token. Users burn BTC on Bitcoin’s chain and submit cryptographic proofs (e.g., using NIPoPoW [1]) to a Cardano smart contract, which mints a corresponding quantity of eBTC. Unlike custodial “wrapped” models, eBTC requires no trusted third parties or oracles. Instead, proofs rely on Bitcoin’s proof-of-work, maintaining a decentralized approach. The aim is to create a **Cardano Proposed Standard (CPS)** for seamlessly integrating BTC liquidity and functionality within Cardano’s ecosystem—without modifying core Cardano or Bitcoin protocols.
 
-## Motivation: Why is this CIP necessary?
+## Motivation: Why is this CPS necessary?
 
-1. Expand BTC use cases.
-   BTC has limited scripting, restricting DeFi and smart contract capabilities. eBTC brings BTC-derived value onto Cardano for greater utility and financial integration.
+1. **Expand BTC Use Cases**
+   Bitcoin’s scripting is limited, preventing direct DeFi, NFT, or complex smart contract interactions. By bridging BTC onto Cardano (via eBTC), BTC holders can access decentralized finance, identity solutions, token swaps, and other advanced features built on Cardano.
 
-2. Trustless design.
-   Existing wrapped BTC tokens rely on third-party custodians. eBTC eliminates this centralized point of failure by leveraging verifiable on-chain proofs.
+2. **Trustless Design**
+   Existing wrapped BTC tokens generally depend on custodians, exposing users to counterparty and management risks. eBTC eliminates this reliance by using cryptographic proofs of BTC “burn” directly validated through a Cardano smart contract.
 
-3. One-way migration.
-   By burning BTC, the bridging mechanism is simpler and avoids two-way complexities. This finality preserves trustlessness and ensures a clear supply correlation.
+3. **One-Way Migration**
+   Burning BTC is irreversible, which simplifies the bridging mechanism and preserves decentralization. Users trade the finality of BTC for eBTC’s functionality on Cardano. This is ideal for those who want direct, trust-minimized access to Cardano’s DeFi and dApp ecosystem.
 
-4. Potential decimal expansion.
-   BTC transactions often involve fractional satoshis, so eBTC may need sufficient decimal places (such as 8 or more) to handle microtransactions and avoid rounding issues.
+4. **Avoiding Protocol Changes**
+   Since eBTC does not require alterations to the Cardano ledger rules or Bitcoin’s consensus, it remains a purely application-layer standard, making it suitable as a CPS rather than a CIP.
+
+5. **Decimal Expansion**
+   BTC transactions can involve many decimal places, so eBTC must provide enough precision (e.g., 8 or more decimals) to handle fractional satoshis. This approach prevents rounding or liquidity fragmentation.
 
 ## Specification
 
-### Key Components
+### Core Components
 
-1. Burn operation.
-   - The user sends BTC to a publicly verifiable, unspendable “burn address” on the Bitcoin network.
-   - This permanently removes those BTC from circulation.
+1. **Burn Operation**
+   - The user sends their BTC to a publicly known “burn address” on Bitcoin, rendering those BTC unspendable.
+   - This action permanently removes the burned BTC from circulation in Bitcoin.
 
-2. Proof construction.
-   - The user compiles minimal Bitcoin block headers and NIPoPoW [1] data.
-   - These proofs demonstrate that the burn transaction was included in the valid main chain.
+2. **Proof Construction**
+   - The user collects a minimal set of Bitcoin block headers and Non-Interactive Proofs of Proof-of-Work (NIPoPoW) [1].
+   - This proof demonstrates that the burn transaction is included in the main Bitcoin chain up to a certain block height.
 
-3. Proof submission.
-   - A Plutus contract on Cardano checks the provided block headers.
-   - If the proof is valid, it mints new eBTC (at a 1:1 ratio with burned BTC).
+3. **Proof Submission**
+   - The user submits the proof to a dedicated Plutus contract on Cardano.
+   - Upon successful verification, the contract mints new eBTC for the user, at a 1:1 ratio with the burned BTC amount.
 
-### State Management (Cumulative Burn Model)
+4. **State Management (Cumulative Burn Model)**
+   - Users periodically provide updated proofs referencing progressively higher Bitcoin block heights.
+   - The contract maintains each user’s “cumulative burned BTC” total.
+   - When a new proof shows a higher burn total, the script mints the difference in eBTC.
+   - This approach avoids logging each transaction ID individually, simplifying on-chain data.
 
-To prevent complex tracking of every single burn transaction:
+5. **User Ownership**
+   - Users demonstrate control over their unique Bitcoin burn address (e.g., by signing a message).
+   - Once associated with a Cardano address, only that user can claim eBTC tied to burns from that specific BTC address.
+   - No central registry is needed; all verification is done through cryptographic proofs on-chain.
 
-- Each user provides proofs showing the total BTC they have cumulatively burned at a certain Bitcoin block height.
-- The contract compares this new cumulative figure against the last recorded total for that address.
-- If the new proof shows a higher burn total, the contract mints the difference in eBTC.
-- This avoids storing data for every transaction ID or satoshi burned, reducing on-chain state overhead.
+### Rationale: How does this CPS achieve its goals?
 
-### User Ownership
+- **Decentralized**: No single custodian or oracle is involved. The security model relies on Bitcoin’s proof-of-work, validated via NIPoPoW in Plutus.
+- **Secure**: The burn transaction is irreversible, ensuring no double-spend. The minimal block headers and proofs reduce the attack surface.
+- **Simple & Scalable**: A one-way bridge is conceptually simpler. The cumulative burn approach avoids state bloat.
+- **Self-Contained**: Because the approach uses existing Cardano smart-contract capabilities (Plutus) and standard Bitcoin transactions, no changes to either network’s consensus or ledger rules are required.
 
-- Users provide their unique Bitcoin burn address and cryptographic proof of control.
-- The contract links that address to the user so that only that address’s rightful owner can mint eBTC from its burns.
-- No centralized registry is required; all information is verified on-chain via proofs.
+## Path to Acceptance
 
-## Rationale: How does this CIP achieve its goals?
+Since this is a CPS, its path to acceptance involves:
 
-- Decentralization.
-  eBTC removes reliance on custodians by verifying burns with Bitcoin’s proof-of-work.
-- Security.
-  Uses minimal proof-of-work headers and NIPoPoW data, reducing attack surfaces.
-- Simplicity.
-  One-way bridging (BTC → Cardano) avoids intricate two-way redeem logic.
+1. **Community Discussion**
+   - Ongoing reviews and debates in public forums, e.g., Cardano Forum threads, developer chats, or GitHub PRs.
+   - Incorporate feedback from SPOs, wallet devs, DApp builders, and other stakeholders.
 
-## Path to Active
+2. **Prototype Implementation**
+   - A reference Plutus script or library demonstrating how to parse minimal Bitcoin headers and validate proofs.
+   - Example transactions burned on Bitcoin testnet for demonstration, then minted as eBTC on a Cardano test environment.
 
-### Acceptance Criteria
+3. **Open-Source Release**
+   - Publish code repositories under permissive licenses (e.g., Apache 2.0 or MIT).
+   - Provide documentation guiding users on how to generate proofs, submit them, and interact with the contract.
 
-- Broad community agreement that trustless, one-way bridging is beneficial.
-- Working proof-of-concept demonstrating on-chain validation of minimal Bitcoin headers with no reliance on external oracles.
-
-### Implementation Plan
-
-1. Prototype.
-   - Implement a Plutus script to parse minimal Bitcoin headers, verify chain difficulty, and confirm transaction inclusion.
-2. Community testing.
-   - Deploy a testnet version of the script, invite public trials to validate performance, security, and feasibility.
-3. Mainnet rollout.
-   - Once proven stable, define a timeline for mainnet release and specify final parameters (e.g., required confirmations, decimal precision).
+4. **Adoption & Tooling**
+   - Encourage wallet providers and DApps to add eBTC support.
+   - If widely adopted, eBTC can become a de facto standard for bridging BTC to Cardano.
 
 ## Security Considerations
 
-- Forks and reorganizations.
-  The script should require a certain number of confirmations to ensure the burn transaction remains in Bitcoin’s main chain.
-- Header validation.
-  The Plutus contract must correctly parse and verify each block header’s proof-of-work.
-- Spam or denial of service.
-  Transaction fees for on-chain proofs discourage frivolous submissions. Off-chain proof generation is intentionally non-trivial.
+1. **Bitcoin Forks or Reorgs**
+   - The smart contract should only trust burn proofs after sufficient confirmations to reduce risk of chain reorganization.
+   - The number of confirmations is configurable (e.g., 6, 12, or more), balancing user convenience and safety.
+
+2. **Header Validation**
+   - The Plutus script or an off-chain aggregator needs to validate chain difficulty and check proof-of-work compliance.
+   - NIPoPoW data must match actual Bitcoin main chain history.
+
+3. **Proof Spam / DOS**
+   - Because each on-chain submission requires Cardano transaction fees, spam should be uneconomical.
+   - Off-chain proof generation is intentionally computational, limiting frivolous creation.
+
+4. **Irreversibility**
+   - BTC burned is permanently lost to the user if they decide they no longer want eBTC. This tradeoff must be clear.
+
+## Implementation Plan
+
+1. **MVP**
+   - Implement a sample Plutus script that checks minimal block headers and NIPoPoW-based inclusion proofs.
+   - Test with small burns on Bitcoin testnet, verifying eBTC minting on Cardano testnet.
+
+2. **Public Testing & Audit**
+   - Invite experts to review code and logic.
+   - Address performance constraints, storage challenges, or potential exploits.
+
+3. **Mainnet Deployment**
+   - Deploy final contract on Cardano mainnet once robustly tested and audited.
+   - Establish recommended best practices (e.g., block confirmation thresholds).
+
+4. **Ecosystem Integration**
+   - Approach wallet providers and DEXes to list eBTC.
+   - Encourage dApps to adopt eBTC as collateral or payment.
 
 ## References
 
-[1] Non-Interactive Proofs of Proof-of-Work (NIPoPoWs). Kiayias et al. (IOHK Research). https://eprint.iacr.org/2017/963.pdf
-
-## Copyright
-
-This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+[1] Non-Interactive Proofs of Proof-of-Work (NIPoPoWs). A. Kiayias et al. https://eprint.iacr.org/2017/963.pdf.

--- a/CPS-1856/README.md
+++ b/CPS-1856/README.md
@@ -1,128 +1,167 @@
 ---
-CPS: ???
-Title: eBTC – A Trustless BTC Bridge on Cardano
-Category: Standards / Token
+CIP: CIP-XXXX
+Title: eBTC: A Trustless BTC Bridge on Cardano
 Authors:
   - An <anrodz42@gmail.com>
-Implementors:
-  - TBD
+Discussions-To:
+  - https://github.com/siran/CIPs/pull/1856
+  - https://forum.cardano.org/t/ebtc-a-trustless-btc-bridge-on-cardano/141117
 Status: Draft
+Type: Standards
 Created: 2024-12-21
 License: CC-BY-4.0
-Discussions:
-  - https://forum.cardano.org/t/ebtc-a-trustless-btc-bridge-on-cardano/141117
 ---
 
 ## Abstract
 
-This document defines eBTC: a trustless, one-way bridge for bringing Bitcoin (BTC) value onto Cardano as a native token. Users burn BTC on Bitcoin’s chain and submit cryptographic proofs (e.g., using NIPoPoW [1]) to a Cardano smart contract, which mints a corresponding quantity of eBTC. Unlike custodial “wrapped” models, eBTC requires no trusted third parties or oracles. Instead, proofs rely on Bitcoin’s proof-of-work, maintaining a decentralized approach. The aim is to create a **Cardano Proposed Standard (CPS)** for seamlessly integrating BTC liquidity and functionality within Cardano’s ecosystem—without modifying core Cardano or Bitcoin protocols.
+This proposal defines eBTC: a trustless mechanism for moving Bitcoin (BTC) value onto Cardano as a native token, unlocking BTC liquidity for Cardano DeFi. Originally conceived as a **one-way, burn-and-mint** design, this CIP also explores a more advanced **two-way** approach using on-chain key management. The one-way approach involves burning BTC on the Bitcoin network, presenting cryptographic proofs (NIPoPoW/SPV) to a Cardano smart contract, and minting a corresponding amount of eBTC. The two-way extension allows redeeming BTC by carefully managing a unique Bitcoin wallet private key on-chain. Both approaches aim at allowing BTC to benefit from Cardano’s advanced smart contract functionalities.
 
-## Motivation: Why is this CPS necessary?
+## Motivation
 
-1. **Expand BTC Use Cases**
-   Bitcoin’s scripting is limited, preventing direct DeFi, NFT, or complex smart contract interactions. By bridging BTC onto Cardano (via eBTC), BTC holders can access decentralized finance, identity solutions, token swaps, and other advanced features built on Cardano.
+Bitcoin (BTC) remains the most recognized and liquid cryptocurrency in the blockchain ecosystem, yet it lacks robust smart contract capabilities on its native chain. Existing wrapped BTC solutions on other chains typically rely on centralized custodians or oracles, introducing trust and counterparty risk.
 
-2. **Trustless Design**
-   Existing wrapped BTC tokens generally depend on custodians, exposing users to counterparty and management risks. eBTC eliminates this reliance by using cryptographic proofs of BTC “burn” directly validated through a Cardano smart contract.
+A trust-minimized bridge helps the Cardano ecosystem tap into BTC’s liquidity while leveraging Cardano’s smart contracts for DeFi applications. This CIP:
 
-3. **One-Way Migration**
-   Burning BTC is irreversible, which simplifies the bridging mechanism and preserves decentralization. Users trade the finality of BTC for eBTC’s functionality on Cardano. This is ideal for those who want direct, trust-minimized access to Cardano’s DeFi and dApp ecosystem.
+- Removes reliance on external custodians.
+- Avoids complex bridging or cross-chain custody solutions.
+- Enables BTC to participate in Cardano-based lending, decentralized exchanges (DEXs), and other DeFi protocols.
 
-4. **Avoiding Protocol Changes**
-   Since eBTC does not require alterations to the Cardano ledger rules or Bitcoin’s consensus, it remains a purely application-layer standard, making it suitable as a CPS rather than a CIP.
-
-5. **Decimal Expansion**
-   BTC transactions can involve many decimal places, so eBTC must provide enough precision (e.g., 8 or more decimals) to handle fractional satoshis. This approach prevents rounding or liquidity fragmentation.
+Initially, a simpler one-way approach was proposed: burning BTC to an unspendable address on Bitcoin, then issuing eBTC on Cardano. Subsequent discussions have revealed that a more complex but feasible **two-way** version could be built, where the Cardano contract generates and holds (in encrypted form) the private key of a **unique** Bitcoin address. This key is only released once eBTC is burned, allowing BTC to be reclaimed without trusting a centralized custodian.
 
 ## Specification
 
-### Core Components
+### Overview of Two Options
 
-1. **Burn Operation**
-   - The user sends their BTC to a publicly known “burn address” on Bitcoin, rendering those BTC unspendable.
-   - This action permanently removes the burned BTC from circulation in Bitcoin.
+1. Option A: One-Way Burn-and-Mint (Simpler)
+2. Option B: Two-Way On-Chain Key Management (Advanced)
 
-2. **Proof Construction**
-   - The user collects a minimal set of Bitcoin block headers and Non-Interactive Proofs of Proof-of-Work (NIPoPoW) [1].
-   - This proof demonstrates that the burn transaction is included in the main Bitcoin chain up to a certain block height.
+Below, we detail the simpler, one-way process first (as originally conceived), followed by an extended specification for a fully on-chain, two-way design.
 
-3. **Proof Submission**
-   - The user submits the proof to a dedicated Plutus contract on Cardano.
-   - Upon successful verification, the contract mints new eBTC for the user, at a 1:1 ratio with the burned BTC amount.
+---
 
-4. **State Management (Cumulative Burn Model)**
-   - Users periodically provide updated proofs referencing progressively higher Bitcoin block heights.
-   - The contract maintains each user’s “cumulative burned BTC” total.
-   - When a new proof shows a higher burn total, the script mints the difference in eBTC.
-   - This approach avoids logging each transaction ID individually, simplifying on-chain data.
+### Option A: One-Way Burn-and-Mint
 
-5. **User Ownership**
-   - Users demonstrate control over their unique Bitcoin burn address (e.g., by signing a message).
-   - Once associated with a Cardano address, only that user can claim eBTC tied to burns from that specific BTC address.
-   - No central registry is needed; all verification is done through cryptographic proofs on-chain.
+1. Burning BTC on the Bitcoin Chain
+   - Burn Address: Define a standard, provably unspendable Bitcoin address, such as one using an `OP_RETURN` script or a well-known “burn” address.
+   - Burn Transaction: The user sends BTC to this burn address, removing those BTC from circulation.
 
-### Rationale: How does this CPS achieve its goals?
+2. Proof Generation (NIPoPoW/SPV)
+   - The user (or an off-chain service) constructs an SPV or NIPoPoW proof verifying that the burn transaction was included in a valid Bitcoin block on the main chain.
+   - This proof, along with relevant block headers, is submitted to Cardano.
 
-- **Decentralized**: No single custodian or oracle is involved. The security model relies on Bitcoin’s proof-of-work, validated via NIPoPoW in Plutus.
-- **Secure**: The burn transaction is irreversible, ensuring no double-spend. The minimal block headers and proofs reduce the attack surface.
-- **Simple & Scalable**: A one-way bridge is conceptually simpler. The cumulative burn approach avoids state bloat.
-- **Self-Contained**: Because the approach uses existing Cardano smart-contract capabilities (Plutus) and standard Bitcoin transactions, no changes to either network’s consensus or ledger rules are required.
+3. Cardano Smart Contract Verification
+   - A Plutus contract confirms the proof corresponds to a valid burn transaction and that the transaction has sufficient confirmations to mitigate reorg risks.
+   - Upon success, the contract mints an equivalent amount of eBTC (1:1) for the user on Cardano.
 
-## Path to Acceptance
+4. Usage of eBTC
+   - eBTC can be used for Cardano DeFi (lending, DEX trading, liquidity provisioning, etc.).
+   - Since BTC was burned, there is no “redemption” back to Bitcoin in this one-way model.
 
-Since this is a CPS, its path to acceptance involves:
+5. Key Benefits
+   - Extremely simple, minimal trust.
+   - No need to store or manage Bitcoin keys.
+   - Guaranteed supply limit: the eBTC supply is constrained by the total BTC burned.
 
-1. **Community Discussion**
-   - Ongoing reviews and debates in public forums, e.g., Cardano Forum threads, developer chats, or GitHub PRs.
-   - Incorporate feedback from SPOs, wallet devs, DApp builders, and other stakeholders.
+---
 
-2. **Prototype Implementation**
-   - A reference Plutus script or library demonstrating how to parse minimal Bitcoin headers and validate proofs.
-   - Example transactions burned on Bitcoin testnet for demonstration, then minted as eBTC on a Cardano test environment.
+### Option B: Two-Way On-Chain Key Management
 
-3. **Open-Source Release**
-   - Publish code repositories under permissive licenses (e.g., Apache 2.0 or MIT).
-   - Provide documentation guiding users on how to generate proofs, submit them, and interact with the contract.
+The following specification describes an **on-chain** approach that allows redeeming BTC after eBTC has been minted, without a third-party custodian. It utilizes a unique Bitcoin address per bridging session. The contract encrypts the private key so that no one can move the BTC unless eBTC is first burned.
 
-4. **Adoption & Tooling**
-   - Encourage wallet providers and DApps to add eBTC support.
-   - If widely adopted, eBTC can become a de facto standard for bridging BTC to Cardano.
+1. Unique Bitcoin Address Generation
+   - The Cardano contract deterministically or randomly generates a fresh Bitcoin public/private keypair on-chain.
+   - It displays only the public portion to the user.
+   - The private key remains encrypted within the contract’s storage so that no entity (not even the user) can access it yet.
+
+2. Locking BTC to Mint eBTC
+   - The user sends BTC to the generated Bitcoin address.
+   - Using NIPoPoW or SPV proofs, the user shows the Cardano contract that the BTC is confirmed to be at that address.
+   - The contract mints eBTC (1:1 with the locked BTC) and sends it to the user on Cardano.
+   - Because the private key to this Bitcoin address is inaccessible, the BTC cannot be moved on the Bitcoin chain until eBTC is destroyed (burned).
+
+3. Burning eBTC to Redeem BTC
+   - To reclaim the locked BTC, the user burns eBTC by calling the contract with a “redeem” function.
+   - Once eBTC is burned, the contract may reveal the encrypted key only after eBTC is burned.
+   - User can then use keys to move its BTC.
+
+4. Security Principles
+   - The private key remains encrypted and is never accessible until eBTC is burned.
+   - No double-spend is possible: the user cannot move BTC on Bitcoin while still holding eBTC on Cardano.
+   - Once eBTC is destroyed, the user can spend the BTC.
+
+5. On-Chain Feasibility
+   - All logic (generation of unique addresses, encryption, gating conditions) is handled on Cardano.
+   - Proof of BTC locking uses standard SPV or NIPoPoW.
+   - Broadcasting the Bitcoin transaction is done by the Bitcoin chain.
+
+6. Considerations
+   - This approach is more complex than a straightforward burn-and-mint.
+   - The contract must implement robust cryptography to generate and store the private key securely.
+   - The Cardano environment must support or expose the cryptographic functions (ECDSA for Bitcoin, encryption, etc.) necessary to sign a Bitcoin transaction on-chain or to release a private key in a secure manner.
+
+---
+
+## Rationale
+
+1. Why a Simple One-Way Bridge (Option A)?
+   - Minimal complexity: only requires proving a burn on Bitcoin and minting eBTC on Cardano.
+   - Removes custodian risk entirely, with no need for advanced key management.
+   - Feels natural for permanent “migration” of BTC into Cardano DeFi.
+
+2. Why Offer a Two-Way Alternative (Option B)?
+   - Allows users to exit back to Bitcoin if desired, removing the permanent burn condition.
+   - Achieves decentralized custody by storing the Bitcoin private key in the Cardano contract itself.
+   - Avoids reliance on multi-signature federations or centralized custodians, maintaining trust-minimized principles.
+
+3. Trade-Offs
+   - The two-way approach is feasible with proper cryptographic capabilities and robust contract code.
+   - One-way bridging is simpler and presents fewer attack surfaces.
+   - Depending on user requirements (e.g., “I want to come back to Bitcoin eventually”), Option B may be worth the added complexity.
+
+---
+
+## Backward Compatibility
+
+- The CIP does not alter Cardano’s consensus or ledger rules; it proposes new smart contracts and token policies.
+
+---
+
+## Reference Implementation
+
+1. On-Chain Key Generation
+   - For Option A (One-Way): no key management is needed.
+   - For Option B (Two-Way): the contract could generate a Bitcoin keypair on-chain, store it encrypted, and control its release or usage.
+
+2. SPV/NIPoPoW Proof Submission
+   - A module or library for constructing minimal proofs from the Bitcoin blockchain.
+   - The Cardano contract checks that the proofs reference the correct transaction, block height, and chain of greatest cumulative work.
+
+3. Mint/Burn Mechanism
+   - Plutus or other Cardano contract language can define the minting policy to issue eBTC upon verifying the proof.
+   - Similarly, the policy and contract ensure eBTC is burned before Option B’s private key is revealed.
+
+4. Example Workflow
+   - Option A: (Burn on Bitcoin) → (Prove on Cardano) → (Mint eBTC). No redemption step.
+   - Option B: (Generate BTC address on-chain) → (User locks BTC) → (Prove and mint eBTC) → (User burns eBTC) → (Contract finalizes Bitcoin transaction to release locked BTC).
+
+---
 
 ## Security Considerations
 
-1. **Bitcoin Forks or Reorgs**
-   - The smart contract should only trust burn proofs after sufficient confirmations to reduce risk of chain reorganization.
-   - The number of confirmations is configurable (e.g., 6, 12, or more), balancing user convenience and safety.
+1. For Option A (One-Way)
+   - The main security concern is accurate verification of the Bitcoin burn transaction.
+   - Once BTC is burned, it cannot reappear on Bitcoin, ensuring no double-spend.
 
-2. **Header Validation**
-   - The Plutus script or an off-chain aggregator needs to validate chain difficulty and check proof-of-work compliance.
-   - NIPoPoW data must match actual Bitcoin main chain history.
+2. For Option B (Two-Way)
+   - The contract must store and manage a Bitcoin private key in a way that absolutely prevents premature access.
+   - Cardano’s contract environment must support cryptographic operations for generating BTC addresses.
 
-3. **Proof Spam / DOS**
-   - Because each on-chain submission requires Cardano transaction fees, spam should be uneconomical.
-   - Off-chain proof generation is intentionally computational, limiting frivolous creation.
+3. Common Considerations
+   - SPV/NIPoPoW proofs need sufficient confirmations to avoid chain reorganizations on Bitcoin.
+   - eBTC minting policies must strictly bind to the contract logic, preventing unauthorized minting.
 
-4. **Irreversibility**
-   - BTC burned is permanently lost to the user if they decide they no longer want eBTC. This tradeoff must be clear.
+---
 
-## Implementation Plan
+## Copyright
 
-1. **MVP**
-   - Implement a sample Plutus script that checks minimal block headers and NIPoPoW-based inclusion proofs.
-   - Test with small burns on Bitcoin testnet, verifying eBTC minting on Cardano testnet.
-
-2. **Public Testing & Audit**
-   - Invite experts to review code and logic.
-   - Address performance constraints, storage challenges, or potential exploits.
-
-3. **Mainnet Deployment**
-   - Deploy final contract on Cardano mainnet once robustly tested and audited.
-   - Establish recommended best practices (e.g., block confirmation thresholds).
-
-4. **Ecosystem Integration**
-   - Approach wallet providers and DEXes to list eBTC.
-   - Encourage dApps to adopt eBTC as collateral or payment.
-
-## References
-
-[1] Non-Interactive Proofs of Proof-of-Work (NIPoPoWs). A. Kiayias et al. https://eprint.iacr.org/2017/963.pdf.
+This CIP is licensed under CC-BY-4.0. Feel free to share and adapt it with attribution.


### PR DESCRIPTION
## Abstract

This proposal defines **eBTC**: a trustless, one-way bridge allowing BTC to enter Cardano as a native token. Users burn BTC on Bitcoin and present cryptographic proofs (NIPoPoW/SPV) to a Cardano smart contract, which mints a corresponding amount of eBTC. This solution removes reliance on custodians and oracles, enabling purely decentralized conversion and unlocking BTC’s liquidity for Cardano DeFi.

---

([latest document](https://github.com/siran/CIPs/blob/CPS-1856/CPS-1856/README.md)) - @siran please keep updating this link whenever pathname changes.