### PR TITLE
CIP-0142? | Web-Wallet Bridge - Network Magic

### DIFF
--- a/CIP-0142/README.md
+++ b/CIP-0142/README.md
@@ -1,7 +1,7 @@
 ---
-CIP: 142
-Title: Cardano dApp-Wallet Network Magic Extension
-Status: Draft
+CIP: 0142
+Title: Web-Wallet Bridge - Network Determination
+Status: Proposed
 Category: Wallets
 Authors:
   - Steven Johnson <steven.johnson@iohk.io>
@@ -9,6 +9,9 @@ Authors:
 Implementors:
   - Lace <https://www.lace.io/>
 Discussions:
+  - https://github.com/cardano-foundation/CIPs/pull/209
+  - https://github.com/cardano-foundation/CIPs/pull/323
+  - https://github.com/cardano-foundation/CIPs/pull/960
 Created: 2024-01-17
 License: CC-BY-4.0
 ---
@@ -27,14 +30,14 @@ Currently, CIP-0030 only provides a way to distinguish between mainnet (1) and t
 
 This extension uses the following TEMPORARY identifier:
 ```ts
-{ "cip": XXXX }
+{ "cip": 0142 }
 ```
 
 ### API Extension
 
-When this extension is enabled, the following function is added to the API under the `cipXXXX` namespace:
+When this extension is enabled, the following function is added to the API under the `cip-0142` namespace:
 
-#### `api.cipXXXX.getNetworkMagic(): Promise<number>`
+#### `api.cip0142.getNetworkMagic(): Promise<number>`
 
 Errors: `APIError`
 
@@ -49,10 +52,10 @@ This function will return the same value unless the connected account changes ne
 Example usage:
 ```typescript
 const api = await window.cardano.lace.enable({
-  extensions: [{ cip: XXXX }]
+  extensions: [{ cip: 0142 }]
 });
 
-const magic = await api.cipXXXX.getNetworkMagic();
+const magic = await api.cip0142.getNetworkMagic();
 console.log(`Connected to network with magic number: ${magic}`);
 ```
 
@@ -76,7 +79,7 @@ While CIP-0030's `getNetworkId()` provides basic network identification, the gro
 
 ### Design Decisions
 
-1. **Explicit Namespacing**: The extension uses the `cipXXXX` namespace to clearly separate its functionality from the base CIP-0030 API.
+1. **Explicit Namespacing**: The extension uses the `cip-0142` namespace to clearly separate its functionality from the base CIP-0030 API.
 2. **Promise-based API**: Follows CIP-0030's pattern of returning Promises for consistency.
 3. **Reuse of Error Types**: Leverages existing error types from CIP-0030 to maintain consistency.
 
@@ -87,14 +90,25 @@ While CIP-0030's `getNetworkId()` provides basic network identification, the gro
 - [ ] Implementation by at least one wallet provider
 - [ ] No reported conflicts with other CIP-0030 extensions
 
+### Implementation Plan
 
-## Backwards Compatibility
+1. **Reach out to the Lace wallet team/architects**
+   - Validate technical feasibility of proposed changes
+   - Identify priorities for this implementation
+   - Identify potential integration challenges
+2. **Involve ops and products team to drive the plan further**
+   - First implementation on the Catalyst playground
+   - Create a plan, validate and collect feedback and suggestions
+3. **Implement the CIP-0142 extension in the Lace wallet**
+   - Implement and use the CIP-0142 extension in the Catalyst pla
+   - Validate against all specified acceptance criteria
+4. **Reach out to other Cardano wallet providers**
+   - Introduce the CIP-0142 extension to other wallet providers (Nami)
+   - Collect feedback and suggestions
+   - Validate against acceptance criteria
 
-This extension is fully backward compatible with CIP-0030. It:
-- Does not modify any existing functionality
-- Is opt-in through the extensions mechanism
-- Uses its own namespace
-
+**Note:** This implementation plan is subject to iterative refinement based on ongoing technical assessments and stakeholder feedback.
+  
 ## Copyright
 
 This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode). 

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -1,0 +1,100 @@
+---
+CIP: XXXX
+Title: Cardano dApp-Wallet Network Magic Extension
+Status: Draft
+Category: Wallets
+Authors:
+  - Steven Johnson <steven.johnson@iohk.io>
+  - Nathan Bogale <nathan.bogale@iohk.io>
+Implementors:
+  - Lace <https://www.lace.io/>
+Discussions:
+Created: 2024-01-17
+License: CC-BY-4.0
+---
+
+## Abstract
+
+This CIP extends CIP-0030 to provide functionality for dApps to determine the specific network magic number of the connected Cardano network. While CIP-0030's `getNetworkId()` allows distinguishing between mainnet and testnet, this extension enables dApps to identify specific test networks through their magic numbers.
+
+## Motivation
+
+Currently, CIP-0030 only provides a way to distinguish between mainnet (1) and testnet (0) through the `getNetworkId()` function. However, there are multiple test networks in the Cardano ecosystem (preview, preprod, etc.), each with its own magic number. dApps often need to know the specific test network they're connected to for proper configuration and interaction. This extension addresses this limitation by providing access to the network magic number.
+
+## Specification
+
+### Extension Identifier
+
+This extension uses the following TEMPORARY identifier:
+```ts
+{ "cip": XXXX }
+```
+
+### API Extension
+
+When this extension is enabled, the following function is added to the API under the `cipXXXX` namespace:
+
+#### `api.cipXXXX.getNetworkMagic(): Promise<number>`
+
+Errors: `APIError`
+
+Returns the magic number of the currently connected network. For example:
+- Mainnet: 764824073
+- Preview Testnet: 2
+- Preprod Testnet: 1
+- Custom Testnet: (other values)
+
+This function will return the same value unless the connected account changes networks.
+
+Example usage:
+```typescript
+const api = await window.cardano.lace.enable({
+  extensions: [{ cip: XXXX }]
+});
+
+const magic = await api.cipXXXX.getNetworkMagic();
+console.log(`Connected to network with magic number: ${magic}`);
+```
+
+### Error Handling
+
+The function uses the existing `APIError` type from CIP-0030 with the following error codes:
+- `InvalidRequest` (-1): If the request is malformed
+- `InternalError` (-2): If an error occurs while retrieving the magic number
+- `Refused` (-3): If access to the magic number is refused
+- `AccountChange` (-4): If the account has changed
+
+## Rationale
+
+### Why a New Extension?
+
+While CIP-0030's `getNetworkId()` provides basic network identification, the growing Cardano ecosystem requires more specific network identification, especially for development and testing purposes. This extension:
+
+1. Maintains backward compatibility by not modifying existing CIP-0030 functionality
+2. Uses explicit namespacing to avoid conflicts
+3. Provides a simple, focused solution to a specific need
+
+### Design Decisions
+
+1. **Explicit Namespacing**: The extension uses the `cipXXXX` namespace to clearly separate its functionality from the base CIP-0030 API.
+2. **Promise-based API**: Follows CIP-0030's pattern of returning Promises for consistency.
+3. **Reuse of Error Types**: Leverages existing error types from CIP-0030 to maintain consistency.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] Implementation by at least one wallet provider
+- [ ] No reported conflicts with other CIP-0030 extensions
+
+
+## Backwards Compatibility
+
+This extension is fully backward compatible with CIP-0030. It:
+- Does not modify any existing functionality
+- Is opt-in through the extensions mechanism
+- Uses its own namespace
+
+## Copyright
+
+This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode). 

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: XXXX
+CIP: 142
 Title: Cardano dApp-Wallet Network Magic Extension
 Status: Draft
 Category: Wallets

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -64,7 +64,7 @@ The function uses the existing `APIError` type from CIP-0030 with the following 
 - `Refused` (-3): If access to the magic number is refused
 - `AccountChange` (-4): If the account has changed
 
-## Rationale
+## Rationale: how does this CIP achieve its goals?
 
 ### Why a New Extension?
 

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -17,7 +17,7 @@ License: CC-BY-4.0
 
 This CIP extends CIP-0030 to provide functionality for dApps to determine the specific network magic number of the connected Cardano network. While CIP-0030's `getNetworkId()` allows distinguishing between mainnet and testnet, this extension enables dApps to identify specific test networks through their magic numbers.
 
-## Motivation
+## Motivation: why is this CIP necessary?
 
 Currently, CIP-0030 only provides a way to distinguish between mainnet (1) and testnet (0) through the `getNetworkId()` function. However, there are multiple test networks in the Cardano ecosystem (preview, preprod, etc.), each with its own magic number. dApps often need to know the specific test network they're connected to for proper configuration and interaction. This extension addresses this limitation by providing access to the network magic number.
 


### PR DESCRIPTION
# Description

This PR introduces a new CIP that extends CIP-0030 to allow dApps to determine the specific network magic number of the connected Cardano network. While the existing `getNetworkId()` function only distinguishes between mainnet (1) and testnet (0), this extension enables dApps to identify specific test networks (preview, preprod, etc.) through their magic numbers.

Key features:
- Adds `getNetworkMagic()` function under `cipXXXX` namespace
- Maintains full backwards compatibility with CIP-0030
- Reuses existing error handling patterns
- Simple, focused solution for network identification

This extension will help dApps better configure themselves based on the specific test network they're connected to, improving the development and testing experience in the Cardano ecosystem.

---

([rendered proposal](https://github.com/input-output-hk/catalyst-CIPs/blob/CIP-XXXX/CIP-XXXX/README.md))