### PR TITLE
CIP-0010 | Add 21325 label for PRISM

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -112,6 +112,10 @@
     "description": "fida.finance transaction metadata"
   },
   {
+    "transaction_metadatum_label": 21325,
+    "description": "PRISM's Verifiable Data Registry for the PRISM DID method"
+  },
+  {
     "transaction_metadatum_label": 61284,
     "description": "CIP-0015 - Catalyst registration"
   },


### PR DESCRIPTION
The Transaction Metadata Label to be registered is 21325.
This value 21325 represents the last 16 bits of 344977920845, which is the decimal representation of the concatenation of the hexadecimals 50 52 49 53 4d that form the word PRISM in ASCII.

https://github.com/input-output-hk/prism-did-method-spec