### PR TITLE
CPS-0003 | Remove deprecated candidate CIP-0143 as solution

### DIFF
--- a/CPS-0003/README.md
+++ b/CPS-0003/README.md
@@ -9,7 +9,6 @@ Authors:
 Proposed Solutions:
     - CIP-0113: https://github.com/cardano-foundation/CIPs/pull/444
     - CIP-0125: https://github.com/cardano-foundation/CIPs/pull/832
-    - CIP-0143: https://github.com/cardano-foundation/CIPs/pull/944
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/382
     - https://github.com/cardano-foundation/CIPs/pull/947


### PR DESCRIPTION
This is a trivial change since CPS-0003 was written long before any of its solution CIPs emerged, so discussion of those methods isn't integral to the text: we need only remove the header link.  Confirmation (or to dispute):
- https://github.com/cardano-foundation/CIPs/pull/444#pullrequestreview-2596450921
- https://github.com/cardano-foundation/CIPs/pull/944#issuecomment-2637744389