### PR TITLE
CIP-0010 | Adding 1517 metadata label for Reeve

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -60,6 +60,10 @@
     "description": "on-chain certification metadata"
   },
   {
+    "transaction_metadatum_label": 1517,
+    "description": "Reeve - transparent and verifiable financial records on-chain"
+  },
+  {
     "transaction_metadatum_label": 1564,
     "description": "Marlowe - a DSL for writing and executing financial contracts"
   },


### PR DESCRIPTION
We would like to register a new metadata label `1517` for the application Reeve. This application is developed by the Cardano Foundation. 
The first publication of this application can be found here: [CF Blog - Reeve](https://www.cardanofoundation.org/blog/boosting-transparency-on-chain-financial-report)

Reeve is an application, which will help organisations to publish their financial reports and transactions on-chain. 
The source code is OpenSource and the on-chain metadata format description can be found here: [cf-reeve-platform (Github)](https://github.com/cardano-foundation/cf-reeve-platform/blob/main/docs/onChainFormat.md) 

The label 1517 is chosen by the year of death of [Luca Pacioli](https://en.wikipedia.org/wiki/Luca_Pacioli) known for being an early contributor to the field of accounting. 