### PR TITLE
CIP-0010 | Add 1668 label for Begin Wallet: dApp rating

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -72,6 +72,10 @@
     "description": "CIP-72: dApp registration & Discovery"
   },
   {
+    "transaction_metadatum_label": 1668,
+    "description": "Begin Wallet: dApp rating record from dApp Store"
+  },
+  {
     "transaction_metadatum_label": 1694,
     "description": "Voltaire - additional metadata for governance, provided in a separate transaction"
   },


### PR DESCRIPTION
This label will be used to record the metadata that confirms a dApp Rating onchain.

We've just implemented a full dApp Store using base data from Cardano Cube, and we're enhancing it with the first-ever Rating system for dApps.

Along with an offchain index and average tracker, we're recording onchain the metadata related to the each users rate.

Here's a sample of the metadata that other wallets and dApps can use to show the latest rate for that dApp.

**Label: 1668** 

```
{
  "type": "dapp-rating",
  "uuid": "bbfc8a90-6eb4-40b8-9e02-e3a49f04da90",
  "origin": "Begin Wallet",
  "ratings": [
    { "logo": "https://cdn.cardanocube.com/zy9gja7hc5ouedh62i0vlzla5yxk", "name": "NMKR", "dappId": "nmkr", "rating": 5, "category": "NFT & Token Minting" },
    { "logo": "https://cdn.cardanocube.com/2b8gnpyi6zvojaf562pmyn81pl64", "name": "VyFinance", "dappId": "vy-finance", "rating": 4, "category": "Exchanges (DEX)" },
    { "logo": "https://cdn.cardanocube.com/5xbmaf0dpaxcahmirzjy5zncxfqn", "name": "Splash", "dappId": "splash", "rating": 5, "category": "Exchanges (DEX)" }
  ],
  "voterId": "stake1u986aacj5hrl6suhv2zn06zk0pgp8zvjkt7tc38y4nu6fzcsg3cxt"
}
```