### PR TITLE
CPS-0003 | Withdraw candidate CIP-0125 as solution

### DIFF
--- a/CPS-0003/README.md
+++ b/CPS-0003/README.md
@@ -8,7 +8,6 @@ Authors:
     - Robert Phair <rphair@cosd.com>
 Proposed Solutions:
     - CIP-0113: https://github.com/cardano-foundation/CIPs/pull/444
-    - CIP-0125: https://github.com/cardano-foundation/CIPs/pull/832
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/382
     - https://github.com/cardano-foundation/CIPs/pull/947


### PR DESCRIPTION
Noting, according to https://github.com/cardano-foundation/CIPs/pull/832#issuecomment-2782841005, CIP-0125's proposed functionality seems already incorporated into candidate CIP-0113 due to being encompassed by the superseded CIP-143.