### PR TITLE
CPS-0021 | Fix inappropriate status

### DIFF
--- a/CPS-0021/README.md
+++ b/CPS-0021/README.md
@@ -2,7 +2,7 @@
 CPS: 21
 Title: Ouroboros Randomness Manipulation
 Category: Consensus
-Status: Proposed
+Status: Open
 Authors:
     - Nicolas Henin <nicolas.henin@iohk.io>
     - Raphael Toledo <raphael.toledo@iohk.io>


### PR DESCRIPTION
@nhenin one thing we missed in review: the `Status:` of `Proposed` is only for CIPs which are not `Active` yet... similarly, CPSs are `Open` until they are `Solved`.

@Ryun1 @Crypto2099 we might as well give a triple check to the front matter & other features we sometimes speed read through, after the double check during the meeting today when we were trying to cover so many other discussion points concurrently.