### PR TITLE
CIP-0010 | Add DRep compensation metadatum tag

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -112,6 +112,10 @@
     "description": "cardahub.io services metadata"
   },
   {
+    "transaction_metadatum_label": 3692,
+    "description": "CIP-0149 - Optional DRep compensation"
+  },
+  {
     "transaction_metadatum_label": 6770,
     "description": "fortunes.coconutpool.com fortune teller"
   },


### PR DESCRIPTION
[CIP-149](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0149) utilizes a metadata tag but we didnt reserve one in CIP-10!