### PR TITLE
CIP-0005 | Define bech32 prefixes for extended pool operator keys

### DIFF
--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -215,8 +215,8 @@ In order to make it easy to keep up with updates to this CIP, we include the fol
 
 | ID  | Date        | Summary of changes                                              | Pull Request                                                  |
 | --- | ---         | ---                                                             | ---                                                           |
-| 1   | 2025-04-22  | Defined bech32 prefixes for genesis keys and created changelog. | [#1027](https://github.com/cardano-foundation/CIPs/pull/1027) |
 | 2   | 2025-05-13  | Defined bech32 prefixes for extended pool operator keys         | [#1036](https://github.com/cardano-foundation/CIPs/pull/1036) |
+| 1   | 2025-04-22  | Defined bech32 prefixes for genesis keys and created changelog. | [#1027](https://github.com/cardano-foundation/CIPs/pull/1027) |
 
 ## Copyright
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -77,6 +77,8 @@ We define the following set of common prefixes with their corresponding semantic
 | `policy_vk`        | CIP-1855's policy public key                                          | Ed25519 public key                 |
 | `pool_sk`          | Pool operator signing key                                             | Ed25519 private key                |
 | `pool_vk`          | Pool operator verification key                                        | Ed25519 public key                 |
+| `pool_xsk`         | Pool operator extended signing key                                    | Ed25519-bip32 extended private key |
+| `pool_xvk`         | Pool operator extended verification key                               | Ed25519 public key with chain code |
 | `root_sk`          | CIP-1852's root private key                                           | Ed25519 private key                |
 | `root_vk`          | CIP-1852's root public key                                            | Ed25519 public key                 |
 | `root_xsk`         | CIP-1852's extended root private key                                  | Ed25519-bip32 extended private key |
@@ -200,6 +202,7 @@ The only prior work done towards that direction has been [jcli](https://input-ou
   - [x] cardano-wallet
   - [x] Blockfrost
   - [x] cardanoscan, cexplorer
+  - [x] cardano-signer 
   - ... and more
 
 ### Implementation Plan
@@ -212,7 +215,8 @@ In order to make it easy to keep up with updates to this CIP, we include the fol
 
 | ID  | Date        | Summary of changes                                              | Pull Request                                                  |
 | --- | ---         | ---                                                             | ---                                                           |
-| 1   | 2024-04-22  | Defined bech32 prefixes for genesis keys and created changelog. | [#1027](https://github.com/cardano-foundation/CIPs/pull/1027) |
+| 1   | 2025-04-22  | Defined bech32 prefixes for genesis keys and created changelog. | [#1027](https://github.com/cardano-foundation/CIPs/pull/1027) |
+| 2   | 2025-05-13  | Defined bech32 prefixes for extended pool operator keys         | [#](https://github.com/cardano-foundation/CIPs/pull/) |
 
 ## Copyright
 

--- a/CIP-0005/README.md
+++ b/CIP-0005/README.md
@@ -216,7 +216,7 @@ In order to make it easy to keep up with updates to this CIP, we include the fol
 | ID  | Date        | Summary of changes                                              | Pull Request                                                  |
 | --- | ---         | ---                                                             | ---                                                           |
 | 1   | 2025-04-22  | Defined bech32 prefixes for genesis keys and created changelog. | [#1027](https://github.com/cardano-foundation/CIPs/pull/1027) |
-| 2   | 2025-05-13  | Defined bech32 prefixes for extended pool operator keys         | [#](https://github.com/cardano-foundation/CIPs/pull/) |
+| 2   | 2025-05-13  | Defined bech32 prefixes for extended pool operator keys         | [#1036](https://github.com/cardano-foundation/CIPs/pull/1036) |
 
 ## Copyright
 


### PR DESCRIPTION
[CIP-0005](https://cips.cardano.org/cip/CIP-0005) does not specify bech32 prefixes for extended pool operator keys.

These were added to cardano-api with https://github.com/IntersectMBO/cardano-api/pull/781 and is now part of cardano-cli with https://github.com/IntersectMBO/cardano-cli/pull/1091 (addresses https://github.com/IntersectMBO/cardano-cli/issues/1076)

This PR modifies CIP-0005 to define a standard set of prefixes for them:
  - `pool_xsk` for pool operator extended signing key
  - `pool_xvk` for pool operator extended verification key
 
Other changes:
- Added [cardano-signer](https://github.com/gitmachtl/cardano-signer) to the list of tools (acceptance criteria)
- Added an entry in the `Changelog table`
- Corrected the false date of the `ID=1` entry in the `Changelog table` from `2024` to `2025`