### PR TITLE
CIP-0001, CIP-9999, README & templates: periodic update

### DIFF
--- a/.github/CIP-TEMPLATE.md
+++ b/.github/CIP-TEMPLATE.md
@@ -14,14 +14,16 @@ License: CC-BY-4.0
 
 <!-- Existing categories:
 
-- Meta     | For meta-CIPs which typically serves another category or group of categories.
-- Wallets  | For standardisation across wallets (hardware, full-node or light).
-- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata | For proposals around metadata (on-chain or off-chain).
-- Tools    | A broad category for ecosystem tools not falling into any other category.
-- Plutus   | Changes or additions to Plutus
-- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
+- Meta      | For meta-CIPs which typically serves another category or group of categories.
+- Wallets   | For standardisation across wallets (hardware, full-node or light).
+- Tokens    | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata  | For proposals around metadata (on-chain or off-chain).
+- Tools     | A broad category for ecosystem tools not falling into any other category.
+- Plutus    | Changes or additions to Plutus
+- Ledger    | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst  | For proposals affecting Project Catalyst / the Jörmungandr project
+- Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
+- Network   | Specifications and implementations of Cardano's network protocols and applications
 
 -->
 

--- a/.github/CIP-TEMPLATE.md
+++ b/.github/CIP-TEMPLATE.md
@@ -21,7 +21,6 @@ License: CC-BY-4.0
 - Tools     | A broad category for ecosystem tools not falling into any other category.
 - Plutus    | Changes or additions to Plutus
 - Ledger    | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst  | For proposals affecting Project Catalyst / the Jörmungandr project
 - Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
 - Network   | Specifications and implementations of Cardano's network protocols and applications
 

--- a/.github/CPS-TEMPLATE.md
+++ b/.github/CPS-TEMPLATE.md
@@ -1,8 +1,8 @@
 ---
 CPS: ?
 Title: ?
-Status: Open
 Category: ?
+Status: Open
 Authors:
     - John Doe <john.doe@email.domain>
 Proposed Solutions: []
@@ -14,14 +14,16 @@ License: CC-BY-4.0
 
 <!-- Existing categories:
 
-- Meta     | For meta-CIPs which typically serves another category or group of categories.
-- Wallets  | For standardisation across wallets (hardware, full-node or light).
-- Tokens   | About tokens (fungible or non-fungible) and minting policies in general.
-- Metadata | For proposals around metadata (on-chain or off-chain).
-- Tools    | A broad category for ecosystem tools not falling into any other category.
-- Plutus   | Changes or additions to Plutus
-- Ledger   | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst | For proposals affecting Project Catalyst / the Jörmungandr project
+- Meta      | For meta-CIPs which typically serves another category or group of categories.
+- Wallets   | For standardisation across wallets (hardware, full-node or light).
+- Tokens    | About tokens (fungible or non-fungible) and minting policies in general.
+- Metadata  | For proposals around metadata (on-chain or off-chain).
+- Tools     | A broad category for ecosystem tools not falling into any other category.
+- Plutus    | Changes or additions to Plutus
+- Ledger    | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
+- Catalyst  | For proposals affecting Project Catalyst / the Jörmungandr project
+- Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
+- Network   | Specifications and implementations of Cardano's network protocols and applications
 
 -->
 

--- a/.github/CPS-TEMPLATE.md
+++ b/.github/CPS-TEMPLATE.md
@@ -21,7 +21,6 @@ License: CC-BY-4.0
 - Tools     | A broad category for ecosystem tools not falling into any other category.
 - Plutus    | Changes or additions to Plutus
 - Ledger    | For proposals regarding the Cardano ledger (including Reward Sharing Schemes)
-- Catalyst  | For proposals affecting Project Catalyst / the Jörmungandr project
 - Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
 - Network   | Specifications and implementations of Cardano's network protocols and applications
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -194,15 +194,15 @@ CIPs are licensed in the public domain. More so, they must be licensed under one
 | For software / code | Apache-2.0 - [Apache License, version 2.0][Apache-2.0]                                 |
 | For documentation   | CC-BY-4.0 - [Creative Commons Attribution 4.0 International Public License][CC-BY-4.0] |
 
-> **Warning**
->
+> [!WARNING]
 > All licenses not explicitly included in the above lists are not acceptable terms for a Cardano Improvement Proposal unless a later CIP extends this one to add them.
 
 #### Statuses
 
 CIPs can have three statuses: `Proposed`, `Active` or `Inactive`. [The CIP Process section](#process) highlights how CIPs move through these statuses; no CIP should be given one of these statuses without satisfying the criteria described here below.
 
-> **Note** There is no "draft" status: a proposal which has not been merged (and hence exists in a PR) is a draft CIP. Draft CIPs should include the status they are aiming for on acceptance. Typically, but not always, this will be _'Proposed'_.
+> [!NOTE]
+> There is no "draft" status: a proposal which has not been merged (and hence exists in a PR) is a draft CIP. Draft CIPs should include the status they are aiming for on acceptance. Typically, but not always, this will be _'Proposed'_.
 
 ##### Status: Proposed
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -377,7 +377,8 @@ A dedicated Discord channel may also be created for some long-running discussion
 
 Once a proposal has reached all requirements for its target status (as explained in [Statuses](#statuses)) and has been sufficiently and faithfully discussed by community members, it is merged with its target status.
 
-> **Warning** Ideas deemed unsound shall be rejected with justifications or withdrawn by the authors. Similarly, proposals that appear abandoned by their authors shall be rejected until resurrected by their authors or another community member.
+> [!WARNING]
+> Ideas deemed unsound shall be rejected with justifications or withdrawn by the authors. Similarly, proposals that appear abandoned by their authors shall be rejected until resurrected by their authors or another community member.
 
 CIPs are generally merged with the status _'Proposed'_ until they meet their _'Path to Active'_ requirements. In some rare cases (mainly when written after the facts and resulting in a broad consensus), proposals may be merged as _'Active'_ immediately.
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -274,7 +274,6 @@ These tentatively enlisted categories await CIPs to describe any enlistment rela
 
 Category  | Description
 ---       | ---
-Catalyst  | For proposals affecting Project Catalyst or the Jörmungandr project
 Consensus | For proposals affecting implementations of the Cardano Consensus layer and algorithms
 Network   | Specifications and implementations of Cardano's network protocols and applications
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -246,7 +246,8 @@ This must be subdivided into two sub-sections:
 
     In particular, an implementation that requires a hard-fork should explicitly mention it in its _'Implementation Plan'_.
 
-> **Note** the statuses of `Proposed` and `Active` _both_ require a _Path to Active_ section, making this a _required_ section for all viable proposals.  Even if a CIP is edited or submitted with an `Inactive` status, it may still be helpful to have a `Path to Active` if there are conditions that might lead to its acceptance or implementation.
+> [!NOTE]
+> The statuses of `Proposed` and `Active` _both_ require a _Path to Active_ section, making this a _required_ section for all viable proposals.  Even if a CIP is edited or submitted with an `Inactive` status, it may still be helpful to have a `Path to Active` if there are conditions that might lead to its acceptance or implementation.
 
 #### Categories
 
@@ -291,7 +292,8 @@ It should be noted that single organisations can no longer represent any ecosyst
 
 Any guidelines for this cooperation should be described by a dedicated CIP whenever possible.  When such a CIP is posted or supersedes another one, it will be entered into the above table in the Categories section.  Participants of enlisted categories should follow the requirements outlined in that CIP and should update such proposals whenever these requirements or relationships change.
 
-> **Warning** A positive review by any enlisted project representative does not constitute a commitment to implement the CIP. It is still the CIP author's responsibility to create an implementation plan and identify implementors.
+> [!WARNING]
+> A positive review by any enlisted project representative does not constitute a commitment to implement the CIP. It is still the CIP author's responsibility to create an implementation plan and identify implementors.
 
 Editors occasionally invite representatives from enlisted categories to speak during review meetings and solicit them for ultimate approvals of proposals in their area of expertise.
 

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -1,8 +1,8 @@
 ---
 CIP: 1
 Title: CIP Process
-Status: Active
 Category: Meta
+Status: Active
 Authors:
     - Frederic Johnson <frederic@advanceweb3.com>
     - Sebastien Guillemot <sebastien@dcspark.io>
@@ -88,7 +88,8 @@ Path to Active                                  | Organised in two sub-sections 
 _optional sections_                             | May appear in any order, or with custom titles, at author and editor discretion:<br/>**Versioning**: if [Versioning](#versioning) is not addressed in Specification<br/>**References**<br/>**Appendices**<br/>**Acknowledgements**
 Copyright                                       | The CIP must be explicitly licensed under acceptable copyright terms ([see below](#licensing)).
 
-> **Note** Each of these section titles (*Abstract* onward) should be an H2 heading (beginning with markdown `##`).  Subsections like _Versioning_ or _Acceptance Criteria_ should be H3 headings (e.g. `### Versioning`).  Don't include a H1 title heading (markdown `#`): for web friendly contexts, this will be generated from the Preamble.
+> [!NOTE]
+> Each of these section titles (*Abstract* onward) should be an H2 heading (beginning with markdown `##`).  Subsections like _Versioning_ or _Acceptance Criteria_ should be H3 headings (e.g. `### Versioning`).  Don't include a H1 title heading (markdown `#`): for web friendly contexts, this will be generated from the Preamble.
 
 ##### Header Preamble
 
@@ -97,9 +98,9 @@ Each CIP must begin with a YAML key:value style header preamble (also known as _
 Field          | Description
 ---            | ---
 `CIP`          | The CIP number (without leading 0), or "\?" before being assigned
-`Title`        | A succinct and descriptive title.  If necessary, use a `-` delimiter to begin with an applicable classification (see [Naming CIPs with similar subjects](#naming-cips-with-similar-subjects)).
+`Title`        | A succinct and descriptive title.  If necessary, use a `-` delimiter to begin with an applicable classification (see [Naming CIPs with similar subjects](#naming-cips-with-similar-subjects)).  Don't use backticks (<code>`</code>) in titles since they disrupt formatting in other contexts.
+`Category`     | One of the editorially accepted [categories](#categories) covering one area of the ecosystem.
 `Status`       | Proposed \| Active \| Inactive (.._reason_..)
-`Category`     | One of the registered [categories](#categories) covering one area of the ecosystem.
 `Authors`      | A list of authors' real names and email addresses (e.g. John Doe <john.doe@email.domain>)
 `Implementors` | A list of implementors committed to delivering an implementation of the proposal, when applicable. `N/A` when not applicable and `[]` when there's currently no implementor.
 `Discussions`  | A list of links where major technical discussions regarding this CIP happened. Links should include any discussion before submission, and _must_ include a link to the pull request that created the CIP and any pull request that modifies it.
@@ -113,8 +114,8 @@ For example:
 ---
 CIP: 1
 Title: CIP Process
-Status: Active
 Category: Meta
+Status: Active
 Authors:
     - Frederic Johnson <frederic.johnson@cardanofoundation.org>
     - Sebastien Guillemot <sebastien@dcspark.io>
@@ -134,7 +135,8 @@ Discussions:
     - Original-PR: https://github.com/cardano-foundation/CIPs/pull/366
 ```
 
-> **Note** A reference template is available in [.github/CIP-TEMPLATE.md][CIP-TEMPLATE.md]
+> [!TIP]
+> A reference template is available in [.github/CIP-TEMPLATE.md][CIP-TEMPLATE.md]
 
 ##### Repository Organization
 
@@ -305,11 +307,20 @@ Editors occasionally invite representatives from enlisted categories to speak du
 
 ##### 1.a. Authors open a pull request
 
-Proposals must be submitted to the [cardano-foundation/CIPs][Repository] repository as a pull request named after the proposal's title. The pull request title **should not** include a CIP number (and use `?` instead as number); the editors will assign one. Discussions may precede a proposal. Early reviews and discussions streamline the process down the line.
+Proposals must be submitted to the [cardano-foundation/CIPs][Repository] repository as a pull request named after the proposal's title. The pull request title **should not** include a CIP number (and use `?` instead as number); the editors will assign one. Discussions may precede a proposal: early reviews and discussions streamline the process down the line.
 
-> **Note** Pull requests should not include implementation code: any code bases should instead be provided as links to a code repository.
+PRs should not contain commits that also appear in other repository PR's: usually the consequence of re-using a branch in your fork or submitting your work from your fork's `master` branch.  To avoid this, please:
+- Don't submit your PR from your fork's `master` branch.
+- Create a new branch for every pull request that you intend to submit.
 
-> **Note** Proposals addressing a specific CPS should also be listed in the corresponding CPS header, in _'Proposed Solutions'_, to keep track of ongoing work.
+> [!TIP]
+> The CIP title in the pull request should be kept consistent with the CIP header `Title:`.
+
+> [!IMPORTANT]
+> Pull requests should not include implementation code: any code bases should instead be provided as links to a code repository.
+
+> [!NOTE]
+> Proposals addressing a specific CPS should also be listed in the corresponding CPS header, in _'Proposed Solutions'_, to keep track of ongoing work.
 
 ###### Naming CIPs with similar subjects
 
@@ -323,7 +334,16 @@ CIP editors will help determine these common elements and, whenever necessary, r
 
 In the original comment for your pull request, please include a link to the directory or the `README.md` for the CIP in your working branch, so readers and reviewers can easily follow your work.  This makes it easier for editors and the community to read and review your proposal.
 
-> **Note** If this link changes (e.g. from the CIP directory being renamed), please keep this link updated.
+> [!NOTE]
+> If this link changes (e.g. from the CIP directory being renamed), please keep this link updated.
+
+###### Follow a reviewer- and editor-friendly review process
+
+As review progresses:
+- When editors and reviewers submit changes that you accept, commit them from the GitHub UI so these review points are resolved.
+- Even if resolving these in your own environemnt, mark any review points Resolved as they are resolved: otherwise your PR will appear stalled and merging will likely be delayed.
+- **Don't "force push"**: which overwrites commit histories and disrupts change visibility during the review process.  Instead, `git merge` the PR branch back into your local environment: which will preserve any collaborative editing history.
+
 
 ##### 1.b. Authors seek feedback
 
@@ -335,7 +355,8 @@ As much as possible, commenters/reviewers shall remain unbiased in their judgeme
 
 By opening pull requests or posting comments, commenters and authors agree to our [Code of Conduct][CoC]. Any comment infringing this code of conduct shall be removed or altered without prior notice.
 
-> **Note** For acceptability guidelines, including a concise review checklist, see 
+> [!NOTE]
+> For acceptability guidelines, including a concise review checklist, see 
 [CIP Wiki > CIPs for Reviewers & Authors](https://github.com/cardano-foundation/CIPs/wiki/2.-CIPs-for-Reviewers-&-Authors).
 
 #### 2. Editors' role
@@ -366,7 +387,8 @@ Each proposal is unique and has a bespoke _'Path to Active'_, which must be revi
 
 Once merged, implementors shall execute the CIP's _'Implementation Plan'_, if any. If a proposal has no implementors or no _'Implementation Plan'_, it may simply remain as _'Proposed'_ in the repository.
 
-> **Warning** It is perfectly fine to submit ideas in the repository with no concrete implementation plan, yet they should be treated as such: ideas.
+> [!WARNING]
+> It is perfectly fine to submit ideas in the repository with no concrete implementation plan, yet they should be treated as such: ideas.
 
 Besides, once all of the _'Path to Active'_ requirements have been met, authors shall make another pull request to change their CIP's status to _'Active'_. Editors may also do this on occasion.
 

--- a/CIP-9999/README.md
+++ b/CIP-9999/README.md
@@ -1,8 +1,8 @@
 ---
 CIP: 9999
 Title: Cardano Problem Statements
-Status: Active
 Category: Meta
+Status: Active
 Authors:
     - Matthias Benkort <matthias.benkort@cardanofoundation.org>
     - Michael Peyton Jones <michael.peyton-jones@iohk.io>
@@ -17,7 +17,8 @@ License: CC-BY-4.0
 
 A Cardano Problem Statement (CPS) is a formalized document for the Cardano ecosystem and the name of the process by which such documents are produced and listed. CPSs are meant to complement CIPs and live side-by-side in the CIP repository as first-class citizens.
 
-> **Note** Read this CIP's number as "CIP minus 1"
+> [!NOTE]
+> Read this CIP's number as "CIP minus 1" (in [tens' complement](https://en.wikipedia.org/wiki/Method_of_complements#Decimal_example))
 
 ## Motivation: why is this CIP necessary?
 
@@ -56,8 +57,8 @@ Field                | Description
 ---                  | ---
 `CPS`                | CPS number (without leading 0), or "\?" before being assigned
 `Title`              | A succinct and descriptive title
-`Status`             | Open \| Solved \| Inactive (..._reason_...)
 `Category`           | One registered or well-known category covering one area of the ecosystem.
+`Status`             | Open \| Solved \| Inactive (..._reason_...)
 `Authors`            | A list of authors' real names and email addresses (e.g. John Doe <john.doe@email.domain>)
 `Proposed Solutions` | A list of CIPs addressing the problem, if any
 `Discussions`        | A list of links where major technical discussions regarding this CPS happened. Links should include any discussion before submission, a link to the pull request that created the CPS, and any pull request that modifies it.
@@ -70,8 +71,8 @@ For example:
 ---
 CPS: 1
 Title: The Blockchain Trilemma
-Status: Open
 Category: Consensus
+Status: Open
 Authors:
     - Alice <alice@domain.org>
     - Bob <bob@domain.org>
@@ -109,7 +110,8 @@ Open         | Any problem statement that is fully formulated but for which ther
 Solved       | Problems for which a complete solution has been found[^1] and implemented. When solved via one or multiple CIPs, the solved status should indicate it as such: `Solved: by <CIP-XXXX>[,<CIP-YYYY>,...]`.
 Inactive    | The statement is deemed obsolete or withdrawn for another reason. A short reason must be given between parentheses. For example: `Inactive (..._reason_...).
 
-> **Note** There is no "draft" status: a proposal which has not been merged (and hence exists in a PR) is a draft CPS. Draft CPSs should include the status they aim for on acceptance, typically but not always; this will be _'Open'_.
+> [!NOTE]
+> There is no "draft" status: a proposal which has not been merged (and hence exists in a PR) is a draft CPS. Draft CPSs should include the status they aim for on acceptance, typically but not always; this will be _'Open'_.
 
 #### Categories
 
@@ -124,8 +126,7 @@ CPSs are licensed in the public domain. More so, they must be licensed under one
 | For software / code | Apache-2.0 - [Apache License, version 2.0][Apache-2.0]                                 |
 | For documentation   | CC-BY-4.0 - [Creative Commons Attribution 4.0 International Public License][CC-BY-4.0] |
 
-> **Warning**
->
+> [!WARNING]
 > All licenses not explicitly included in the above lists are not acceptable terms for a Cardano Problem Statement unless a later CIP extends this one to add them.
 
 ### The CPS Process

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ The Cardano Foundation intends CIPs to be the primary mechanisms for proposing n
 
 For more about the human factors of the CIP process, and to learn how to get involved, click the Wiki tab above (**[CIP Wiki](https://github.com/cardano-foundation/CIPs/wiki)**).
 
-> **Note** For new CIPs, a reference template is available in [.github/CIP-TEMPLATE.md](./.github/CIP-TEMPLATE.md)
+> [!TIP]
+> For new CIPs, a reference template is available in [.github/CIP-TEMPLATE.md](./.github/CIP-TEMPLATE.md)
 
 ## Cardano Problem Statements (CPS)
 
 A [Cardano Problem Statement (CPS)](./CIP-9999) is a formalised document for the Cardano ecosystem and the name of the process by which such documents are produced and listed. CPSs are meant to complement CIPs and live side-by-side in the CIP repository as first-class citizens.
 
-> **Note** For new CPSs, a reference template is available in [.github/CPS-TEMPLATE.md](./.github/CPS-TEMPLATE.md)
+> [!TIP]
+> For new CPSs, a reference template is available in [.github/CPS-TEMPLATE.md](./.github/CPS-TEMPLATE.md)
 
 ## Communication Channels
 
@@ -20,7 +22,8 @@ Extend or discuss ‘ideas’ in the [Developer Forums](https://forum.cardano.or
 
 CIP editors facilitate discussions and progress submissions on GitHub, reviewing progress in bi-weekly meetings held [on Discord](https://discord.gg/J8sGdCuKhs) which are open to the public. The Discord server also has channels for developer working groups to discuss details and implementations of selected CIPs.
 
-> **Note** To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
+> [!NOTE]
+> To facilitate browsing and information sharing for non-Github users, an auto-generated site is also provided at [cips.cardano.org](https://cips.cardano.org/).
 
 ## Cardano Improvement Proposals (CIP)
 
@@ -141,13 +144,14 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 
 <p align="right"><i>Last updated on 2025-05-13</i></p>
 
-> 💡 For more details about CIP statuses, refer to [CIP-0001](./CIP-0001).
+> [!NOTE]
+> For more details about CIP statuses, see [CIP-0001 > Statuses](./CIP-0001/README.md#statuses).
 
 ### Proposals Under Review (CIP)
 
 The following link lists "candidate" CIPs still under discussion with the community; these are assigned numbers to avoid later clashes and to facilitate community discussion (see further below for stalled proposals):
 
-**[CIP pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECIP-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)**
+**[CIP pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECIP-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-desc)** (most recently discussed first)
 
 ## Cardano Problem Statements (CPS)
 
@@ -170,29 +174,30 @@ The following link lists "candidate" CIPs still under discussion with the commun
 
 <p align="right"><i>Last updated on 2025-04-15</i></p>
 
-> 💡 For more details about CPS statuses, refer to [CIP-9999](./CIP-9999).
+> [!NOTE]
+> For more details about CPS statuses, see [CIP-9999 > Statuses](./CIP-9999/README.md#statuses).
 
 ### Proposals Under Review (CPS)
 
 The following link lists "candidate" CPSs still under discussion with the community; these are assigned numbers to avoid later clashes and to facilitate community discussion (see further below for stalled proposals):
 
-**[CPS pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECPS-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)**
+**[CPS pull requests under active review](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+%2F%5ECPS-%2F+in%3Atitle+label%3A%22State%3A+Confirmed%22%2C%22State%3A+Last+Check%22+draft%3Afalse+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-desc)** (most recently discussed first)
 
 ## Updates Under Consideration
 
 The following link shows updates to existing CIPs and CPSs that have entered the review process:
 
-**[CIP and CPS updates under consideration](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+label%3AUpdate)**
+**[CIP and CPS updates under consideration](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+label%3AUpdate+sort%3Aupdated-desc)** (most recently discussed first)
 
 ## Stalled / Waiting For Authors
 
 The following links list proposals deemed ready for review but requiring further update
 from the original author(s) or other confirmation of proposal elgibility (if considered deprecated):
 
-[**Stalled CIPs and CPSs**](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Waiting+for+Author%22%2C%22State%3A+Likely+Abandoned%22%2C%22State%3A+Likely+Deprecated%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22) - consisting of:
-* [proposals Waiting for Author](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Waiting+for+Author%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)
-* [proposals Likely Abandoned](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Likely+Abandoned%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+)
-* [proposals Likely Deprecated](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Likely+Deprecated%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22)
+[**Stalled CIPs and CPSs**](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Waiting+for+Author%22%2C%22State%3A+Likely+Abandoned%22%2C%22State%3A+Likely+Deprecated%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-asc) (all lists least recently discussed first) - consisting of:
+* [proposals Waiting for Author](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Waiting+for+Author%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-asc)
+* [proposals Likely Abandoned](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Likely+Abandoned%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-asc)
+* [proposals Likely Deprecated](https://github.com/cardano-foundation/CIPs/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+in%3Atitle+label%3A%22State%3A+Likely+Deprecated%22+-label%3AUpdate%2CCorrection%2CTranslation%2C%22Bi-Weekly+Notes+%2F+Editorial+Housekeeping%22%2C%22CIP-0010%3A+new+registry+entry%22%2C%22CIP-0067%3A+new+label%22%2C%22CIP-0088%3A+new+extension%22+sort%3Aupdated-asc)
 
 Proposals stalled without any updates from their authors will eventually be closed. However, authors are invited to re-open pull requests or open new ones should they want to bring the discussion back to life.
 


### PR DESCRIPTION
A more-or-less annual update to fix/clarify these issues that came up over the last year or so (since #924):
- Don't include commits from previously submitted PR's... submit your new PR from a branch that's been rebased on `main` ([as described here](https://github.com/cardano-foundation/CIPs/pull/933#pullrequestreview-2414983753))
- Don't do "force push": with reason explained [here](https://github.com/cardano-foundation/CIPs/pull/938#issuecomment-2466654892) to someone who hadn't done it before, preemptively (in terms of usability of commit history)
- Don't put backticks in CIP titles (we had to [remove them here](https://github.com/cardano-foundation/CIPs/pull/930))
- Add `Consensus` and `Network` categories to CIP and CPS templates ([pointed out here](https://github.com/cardano-foundation/CIPs/pull/942#discussion_r1867566372))
- Ensure the ordering in the templates match the orderings in CIP 1 & -1 AND the prevailing document order ([as explained here](https://github.com/cardano-foundation/CIPs/pull/925#discussion_r1959958258)): with the more taxonomically significant term `Category` appearing before `Status` everywhere (not adjusting other CPS documents "out of sync" since field ordering is not agreed to really matter)
  - It would be even more important for `Category` to generally precede `Status` especially since contemporary discussions for different processes to be followed for different processes (e.g. Ledger especially) might lead to different possible `Status` per `Category` (see @WhatisRT [discussion point here](https://forum.cardano.org/t/managing-a-shared-ledger-new-cip-like-process/145575/3) - cc @yHSJ)  
- Migrated existing "notes" to [GitHub Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) (now that [they are supported](https://github.com/cardano-foundation/cf-cip-frontend/issues/46)) from things like lightbulb icons within ordinary blockquotes.
- Updated front page so lists of CIPs & CPSs appear with
  - most currently discussed actively reviewed proposals appearing first
  - least recently discussed flagged "not progressing" proposals appearing first
- For categories, changed "registered" to "editorially accepted" (since there is no central means of "registering" anything as there might have been during the formerly organisational process of "enlistment")

This is intended to provide a more current baseline in anticipation of further updates from one or more of these issues:
- https://github.com/cardano-foundation/CIPs/issues/937
- https://github.com/cardano-foundation/CIPs/issues/1028
- https://github.com/cardano-foundation/CIPs/issues/1040

---

([new front README](https://github.com/rphair/CIPs/blob/cip-proc-docs-annual-tuneup/README.md)) - ([new CIP-0001](https://github.com/rphair/CIPs/blob/cip-proc-docs-annual-tuneup/CIP-0001/README.md)) - ([new CIP-9999](https://github.com/rphair/CIPs/blob/cip-proc-docs-annual-tuneup/CIP-9999/README.md))