### PR TITLE
CIP-0158? | Cardano URIs - Browse Authority

### DIFF
--- a/CIP-0158/README.md
+++ b/CIP-0158/README.md
@@ -4,10 +4,10 @@ Title: Cardano URIs - Browse Application
 Category: Wallets
 Status: Proposed
 Authors:
-Authors:
     - Adam Dean <adam@crypto2099.io>
     - Alex Dochioiu (VESPR Wallet) <alex@vespr.xyz> 
 Implementors:
+    - VESPR Wallet (https://vespr.xyz)
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/1058
 Created: 2025-07-17
@@ -57,7 +57,7 @@ interaction (for example).
 
 By defining this standard to instantly transport the user from a browser or
 QR-based "deeplink" to a precise session or page within an application, we
-enable developers to build richer, safer and more interactive experiences such
+enable developers to build richer, safer, and more interactive experiences such
 as:
 
 * Showing a full "checkout" process and later "receipt" to the user on their
@@ -66,6 +66,16 @@ as:
   prone to user data-entry errors and typos
 
 ## Specification
+
+#### ABNF Grammar
+
+``` 
+cardanourn = "web+cardano:" authority
+authority = "//browse" version
+version = "/v1" pathquery
+pathquery = ( "?" encodedpath)
+encodedpath = "uri=" text
+```
 
 ### URI Format
 
@@ -109,9 +119,16 @@ web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 * Parse and validate version, scheme, and domain.
 * Forward the entire app-specific path and query string to the app.
 * Suggested allowlist/blocklist and security policies:
-    * Each wallet may optionally implement its own allowed list of trusted domains where navigation would not require explicit permissions
-    * Each wallet may optionally implement a blacklist of known untrusted domains where the user would be shown a clear warning that the website is known to be malicious. With very explicit user permission user should still be allowed to navigate.
-    * For domains outside of allowlist / blacklist, wallet may want to show a warning and request explicit permission before navigating. This is to prevent unwanted IP / device info / other data exfiltration which can be obtained simply by loading a webpage
+    * Each wallet may optionally implement its own allowed list of trusted 
+      domains where navigation would not require explicit permissions
+    * Each wallet may optionally implement a blacklist of known untrusted 
+      domains where the user would be shown a clear warning that the website is 
+      known to be malicious. With very explicit user permission user should 
+      still be allowed to navigate.
+    * For domains outside an allowlist/blacklist, wallet may want to show a 
+      warning and request explicit permission before navigating. This is to 
+      prevent unwanted IP / device info / other data exfiltration which can be 
+      obtained simply by loading a webpage
 
 ### Security Considerations
 
@@ -136,11 +153,10 @@ payment or metadata intents, improving clarity and interoperability.
 
 ### Acceptance Criteria
 
-- [ ] At least one major Cardano wallet implements support for the browse
+- [ ] At least two major Cardano wallets implement support for the browse
   authority in web+cardano URIs, including launching its embedded browser with
   the specified path.
-  that work reliably across supported wallets.
-- [ ] Demonstrated user success in navigating from mobile device (e.g., native
+- [ ] Demonstrable user success in navigating from a mobile device (e.g., native
   camera or link) into a wallet and then directly into the dApp or application
   flow.
 - [ ] Positive feedback or validation from the community or wallet/dApp

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -139,7 +139,6 @@ payment or metadata intents, improving clarity and interoperability.
 - [ ] At least one major Cardano wallet implements support for the browse
   authority in web+cardano URIs, including launching its embedded browser with
   the specified path.
-- [ ] At least one dApp publishes deep links or QR codes using the browse scheme
   that work reliably across supported wallets.
 - [ ] Demonstrated user success in navigating from mobile device (e.g., native
   camera or link) into a wallet and then directly into the dApp or application

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -154,8 +154,6 @@ payment or metadata intents, improving clarity and interoperability.
   handling in at least one wallet.
     - Reference Implementation: https://github.com/crypto2099/cardano-uri-parser
     - NPM Package: https://www.npmjs.com/package/cardano-uri-parser
-- [ ] Collaborate with at least one dApp team to generate example deep links and
-  test them live (e.g., at events or with public beta testers).
 - [ ] Write integration guides or example code for wallet and dApp developers.
 - [ ] Monitor ecosystem adoption and collect feedback for potential refinements
   or amendments to the standard.

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -7,7 +7,7 @@ Authors:
     - Adam Dean <adam@crypto2099.io>
 Implementors:
 Discussions:
-    - https://github.com/cardano-foundation/CIPs/pull/?
+    - https://github.com/cardano-foundation/CIPs/pull/1058
 Created: 2025-07-17
 License: CC-BY-4.0
 ---

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: XXXX
-Title: Cardano URIs | Browse Application
+Title: Cardano URIs - Browse Application
 Category: Wallets
 Status: Proposed
 Authors:

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -108,10 +108,10 @@ web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 
 * Parse and validate version, scheme, and domain.
 * Forward the entire app-specific path and query string to the app.
-* Apply allowlist/blocklist and security policies:
-    * Warn on `http` and `localhost`.
-    * Allow `https` by default.
-    * Resolve `ipfs` via trusted gateway or native resolver.
+* Suggested allowlist/blocklist and security policies:
+    * Each wallet may optionally implement its own allowed list of trusted domains where navigation would not require explicit permissions
+    * Each wallet may optionally implement a blacklist of known untrusted domains where the user would be shown a clear warning that the website is known to be malicious. With very explicit user permission user should still be allowed to navigate.
+    * For domains outside of allowlist / blacklist, wallet may want to show a warning and request explicit permission before navigating. This is to prevent unwanted IP / device info / other data exfiltration which can be obtained simply by loading a webpage
 
 ### Security Considerations
 

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -16,7 +16,7 @@ License: CC-BY-4.0
 
 This CIP proposes a new URI scheme authority, `browse`, under `web+cardano` to
 enable Cardano wallets to launch external or embedded applications and dApps
-with full path and context, using a standardized, interoperable URI format.
+with the full path and context, using a standardized, interoperable URI format.
 
 ## Motivation: why is this CIP necessary?
 
@@ -41,46 +41,84 @@ This reduces friction, improves dApp discoverability, and creates a smoother
 experience for both developers and end-users, particularly in mobile and
 cross-device contexts.
 
+### Security Benefits & Considerations
+
+The existing process for transferring sessions and information between devices
+or from physical to digital is fraught with opportunity for accidents, errors,
+and malicious interception.
+
+Existing standards for `web+cardano://` URIs describe some rudimentary
+interactions that may be automated by following the specification such as
+sending payment or claiming airdrops. However, no current standards exist to
+easily point a mobile user to a complex application that requires smart contract
+interaction (for example).
+
+By defining this standard to instantly transport the user from a browser or
+QR-based "deeplink" to a precise session or page within an application, we
+enable developers to build richer, safer and more interactive experiences such
+as:
+
+* Showing a full "checkout" process and later "recipt" to the user on their
+  mobile device rather than simply a payment request out of context
+* Navigating users directly to complex application paths that would otherwise be
+  prone to user data-entry errors and typos
+
 ## Specification
 
 ### URI Format
 
 ```
-web+cardano://browse/<scheme>/<namespaced_domain>/<app-specific-path>?<parameters>
+web+cardano://browse/<version>/<scheme>/<namespaced_domain>/<app-specific-path>?<parameters>
 ```
 
 * **Authority (REQUIRED):** `browse`
+* **Version (REQUIRED):** `v1`
 * **Scheme (REQUIRED):** `https`, `http`, `ipfs`, etc.
 * **Namespaced domain (REQUIRED):** reverse domain name (e.g., `fi.sundae.app`)
-* **App-specific path (OPTIONAL):** full path within the app
-* **Query parameters (OPTIONAL):** optional, passed as-is to the app
+* **App-specific path (OPTIONAL):** full, url-encoded path within the app
+* **Query parameters (OPTIONAL):** optional, url-encoded query parameters passed
+  as-is to the app
+
+### Versioning
+
+This document describes `Version 1` of this specification. Once this CIP is
+merged and canonized as `Accepted` this `Version 1` should no longer be modified
+to avoid potentially introducing breaking changes with legacy integrations.
+
+Instead, those seeking to amend, extend, or modify the `browse` authority should
+introduce a new CIP that iterates this standard and increments the Version
+Number by a single whole integer value (i.e., the next CIP will be `Version 2`).
+
+Extensions to this standard should follow whatever accepted criteria exist at
+the time of their authoring in terms of acceptance and adoption.
 
 ### Example URIs
 
-* Web app (SundaeSwap ADA <=> USDM Trading Page):
+Web app (SundaeSwap ADA <=> USDM Trading Page):
 
-  ```
-  web+cardano://browse/https/fi.sundae.app/exchange?given=ada.lovelace&taken=c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d&routeIdent=64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
-  ```
+```
+web+cardano://browse/v1/https/fi.sundae.app/exchange?given=ada.lovelace&taken=c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d&routeIdent=64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
+```
 
-* IPFS app (simulated CID):
+IPFS app (simulated CID):
 
-  ```
-  web+cardano://browse/ipfs/QmXkYpAbC1234567890abcdef1234567890abcdef/actionPage
-  ```
+```
+web+cardano://browse/v1/ipfs/QmXkYpAbC1234567890abcdef1234567890abcdef/actionPage
+```
 
-* Local development app (HTTP localhost with port):
+Local development app (HTTP localhost with port):
 
-  ```
-  web+cardano://browse/http/localhost:3000/devPage
-  ```
+```
+web+cardano://browse/v1/http/localhost:3000/devPage
+```
 
 ### ABNF Grammar
 
 ``` 
 cardano-browse-uri = "web+cardano:" browse-path
 
-browse-path = "//browse" "/" scheme "/" namespaced-domain [ "/" app-path ] [ query ]
+browse-path = "//browse" "/" version "/" scheme "/" namespaced-domain [ "/" app-path ] [ query ]
+version = "v1"
 scheme = ALPHA *( ALPHA / DIGIT / "." / "+" / "-" )
 namespaced-domain = *( ALPHA / DIGIT / "." / "-" )
 app-path = *( unreserved / pct-encoded / sub-delims / "/" )
@@ -89,7 +127,7 @@ query = "?" *( unreserved / pct-encoded / sub-delims / "=" / "&" )
 
 ### Wallet Behavior
 
-* Parse and validate scheme and domain.
+* Parse and validate version, scheme, and domain.
 * Forward the entire app-specific path and query string to the app.
 * Apply allowlist/blocklist and security policies:
 
@@ -105,18 +143,18 @@ query = "?" *( unreserved / pct-encoded / sub-delims / "=" / "&" )
   sensitive or user-specific data; app developers are responsible for ensuring
   that no long-lived secrets or sensitive information are embedded in shared
   links.
-* Wallets SHOULD provide clear UI to inform users of the destination and allow
+* Wallets SHOULD provide a clear UI to inform users of the destination and allow
   cancellation before proceeding.
 * dApp developers SHOULD design links and query parameters with privacy and
-  security in mind, using short-lived or ephemeral tokens where needed and
-  avoiding embedding sensitive user data.
+  security in mind, using short-lived or ephemeral tokens where needed and avoid
+  embedding sensitive user data.
 
 ## Rationale: how does this CIP achieve its goals?
 
 A dedicated `browse` authority isolates app navigation and launch intents from
 payment or metadata intents, improving clarity and interoperability.
 
-### Why use reverse domain names for `namespaced_domain`
+### Why use reverse domain names for `namespaced_domain`?
 
 * **Global uniqueness:** avoids collisions.
 * **Decentralized management:** no central registry needed.
@@ -124,11 +162,11 @@ payment or metadata intents, improving clarity and interoperability.
 * **Verifiability:** can tie domains to apps via `.well-known` or DNS records.
 * **Cross-platform compatibility:** works on web, mobile, desktop.
 
-### Why include scheme in the path
+### Why include a scheme in the path?
 
 * Removes ambiguity — scheme is required, not optional.
 * Supports alternative protocols (IPFS, local dev) explicitly.
-* Simplifies wallet parsing — no need to extract from query params.
+* Simplifies wallet parsing — no need to extract from query parameters.
 
 ## Path to Active
 
@@ -147,10 +185,12 @@ payment or metadata intents, improving clarity and interoperability.
 
 ### Implementation Plan
 
-- [ ] Publish and socialize the CIP draft for feedback from wallet and dApp
+- [X] Publish and socialize the CIP draft for feedback from wallet and dApp
   developers.
-- [ ] Develop a reference implementation or demo prototype showing browse URI
+- [X] Develop a reference implementation or demo prototype showing browse URI
   handling in at least one wallet.
+    - Reference Implementation: https://github.com/crypto2099/cardano-uri-parser
+    - NPM Package: https://www.npmjs.com/package/cardano-uri-parser
 - [ ] Collaborate with at least one dApp team to generate example deep links and
   test them live (e.g., at events or with public beta testers).
 - [ ] Write integration guides or example code for wallet and dApp developers.

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -132,14 +132,6 @@ web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 A dedicated `browse` authority isolates app navigation and launch intents from
 payment or metadata intents, improving clarity and interoperability.
 
-### Why use reverse domain names for `namespaced_domain`?
-
-* **Global uniqueness:** avoids collisions.
-* **Decentralized management:** no central registry needed.
-* **Developer familiarity:** matches Android, Apple, Java ecosystems.
-* **Verifiability:** can tie domains to apps via `.well-known` or DNS records.
-* **Cross-platform compatibility:** works on web, mobile, desktop.
-
 ### Why include a scheme in the path?
 
 * Removes ambiguity — scheme is required, not optional.

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -68,7 +68,7 @@ as:
 ### URI Format
 
 ```
-web+cardano://browse/<version>/<scheme>/<namespaced_domain>/<app-specific-path>?<parameters>
+web+cardano://browse/<version>?uri=<percent_encoded_uri>
 ```
 
 * **Authority (REQUIRED):** `browse`

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -71,13 +71,9 @@ as:
 web+cardano://browse/<version>?uri=<percent_encoded_uri>
 ```
 
-* **Authority (REQUIRED):** `browse`
-* **Version (REQUIRED):** `v1`
-* **Scheme (REQUIRED):** `https`, `http`, `ipfs`, etc.
-* **Namespaced domain (REQUIRED):** reverse domain name (e.g., `fi.sundae.app`)
-* **App-specific path (OPTIONAL):** full, url-encoded path within the app
-* **Query parameters (OPTIONAL):** optional, url-encoded query parameters passed
-  as-is to the app
+* **authority (REQUIRED):** `browse`
+* **version (REQUIRED):** `v1`
+* **percent_encoded_uri (REQUIRED):** percent-encoded URI (only `http` and `https` scheme is supported. If no scheme is defined, `https` scheme is assumed)
 
 ### Versioning
 

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -1,5 +1,5 @@
 ---
-CIP: XXXX
+CIP: 158
 Title: Cardano URIs - Browse Application
 Category: Wallets
 Status: Proposed

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -104,19 +104,6 @@ Local development app (HTTP localhost with port):
 web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 ```
 
-### ABNF Grammar
-
-``` 
-cardano-browse-uri = "web+cardano:" browse-path
-
-browse-path = "//browse" "/" version "/" scheme "/" namespaced-domain [ "/" app-path ] [ query ]
-version = "v1"
-scheme = ALPHA *( ALPHA / DIGIT / "." / "+" / "-" )
-namespaced-domain = *( ALPHA / DIGIT / "." / "-" )
-app-path = *( unreserved / pct-encoded / sub-delims / "/" )
-query = "?" *( unreserved / pct-encoded / sub-delims / "=" / "&" )
-```
-
 ### Wallet Behavior
 
 * Parse and validate version, scheme, and domain.

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -101,7 +101,7 @@ web+cardano://browse/v1?uri=https%3A%2F%2Fapp.sundae.fi%2Fexchange%3Fgiven%3Dada
 Local development app (HTTP localhost with port):
 
 ```
-web+cardano://browse/v1/http/localhost:3000/devPage
+web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 ```
 
 ### ABNF Grammar

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -1,0 +1,163 @@
+---
+CIP: XXXX
+Title: Cardano URIs | Browse Application
+Category: Wallets
+Status: Proposed
+Authors:
+    - Adam Dean <adam@crypto2099.io>
+Implementors:
+Discussions:
+    - https://github.com/cardano-foundation/CIPs/pull/?
+Created: 2025-07-17
+License: CC-BY-4.0
+---
+
+## Abstract
+
+This CIP proposes a new URI scheme authority, `browse`, under `web+cardano` to
+enable Cardano wallets to launch external or embedded applications and dApps
+with full path and context, using a standardized, interoperable URI format.
+
+## Motivation: why is this CIP necessary?
+
+Today, exploring dApps on Cardano — especially on mobile devices — is
+cumbersome. Most Cardano wallets with embedded browsers require users to
+manually launch the wallet, open its browser, and type or paste full URLs to
+reach specific applications. This creates significant friction, particularly in
+real-world scenarios like:
+
+* Trade shows or events promoting dApps
+* Point-of-sale terminals or vending machines using Cardano
+* Marketing campaigns linking directly to dApp actions
+
+The goal of this CIP is to introduce a **deep-linking compatible method** that
+lets dApps and external actors provide QR codes or clickable links that:
+
+* Open the user’s preferred wallet automatically (via `web+cardano` handler)
+* Direct the wallet to launch its embedded browser or app view
+* Navigate directly to the intended dApp page or state without manual user input
+
+This reduces friction, improves dApp discoverability, and creates a smoother
+experience for both developers and end-users, particularly in mobile and
+cross-device contexts.
+
+## Specification
+
+### URI Format
+
+```
+web+cardano://browse/<scheme>/<namespaced_domain>/<app-specific-path>?<parameters>
+```
+
+* **Authority (REQUIRED):** `browse`
+* **Scheme (REQUIRED):** `https`, `http`, `ipfs`, etc.
+* **Namespaced domain (REQUIRED):** reverse domain name (e.g., `fi.sundae.app`)
+* **App-specific path (OPTIONAL):** full path within the app
+* **Query parameters (OPTIONAL):** optional, passed as-is to the app
+
+### Example URIs
+
+* Web app (SundaeSwap ADA <=> USDM Trading Page):
+
+  ```
+  web+cardano://browse/https/fi.sundae.app/exchange?given=ada.lovelace&taken=c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d&routeIdent=64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
+  ```
+
+* IPFS app (simulated CID):
+
+  ```
+  web+cardano://browse/ipfs/QmXkYpAbC1234567890abcdef1234567890abcdef/actionPage
+  ```
+
+* Local development app (HTTP localhost with port):
+
+  ```
+  web+cardano://browse/http/localhost:3000/devPage
+  ```
+
+### ABNF Grammar
+
+``` 
+cardano-browse-uri = "web+cardano:" browse-path
+
+browse-path = "//browse" "/" scheme "/" namespaced-domain [ "/" app-path ] [ query ]
+scheme = ALPHA *( ALPHA / DIGIT / "." / "+" / "-" )
+namespaced-domain = *( ALPHA / DIGIT / "." / "-" )
+app-path = *( unreserved / pct-encoded / sub-delims / "/" )
+query = "?" *( unreserved / pct-encoded / sub-delims / "=" / "&" )
+```
+
+### Wallet Behavior
+
+* Parse and validate scheme and domain.
+* Forward the entire app-specific path and query string to the app.
+* Apply allowlist/blocklist and security policies:
+
+    * Warn on `http` and `localhost`.
+    * Allow `https` by default.
+    * Resolve `ipfs` via trusted gateway or native resolver.
+
+### Security Considerations
+
+* Wallets SHOULD prompt users before launching non-allowlisted or unsafe
+  schemes.
+* Wallets cannot automatically determine whether query parameters contain
+  sensitive or user-specific data; app developers are responsible for ensuring
+  that no long-lived secrets or sensitive information are embedded in shared
+  links.
+* Wallets SHOULD provide clear UI to inform users of the destination and allow
+  cancellation before proceeding.
+* dApp developers SHOULD design links and query parameters with privacy and
+  security in mind, using short-lived or ephemeral tokens where needed and
+  avoiding embedding sensitive user data.
+
+## Rationale: how does this CIP achieve its goals?
+
+A dedicated `browse` authority isolates app navigation and launch intents from
+payment or metadata intents, improving clarity and interoperability.
+
+### Why use reverse domain names for `namespaced_domain`
+
+* **Global uniqueness:** avoids collisions.
+* **Decentralized management:** no central registry needed.
+* **Developer familiarity:** matches Android, Apple, Java ecosystems.
+* **Verifiability:** can tie domains to apps via `.well-known` or DNS records.
+* **Cross-platform compatibility:** works on web, mobile, desktop.
+
+### Why include scheme in the path
+
+* Removes ambiguity — scheme is required, not optional.
+* Supports alternative protocols (IPFS, local dev) explicitly.
+* Simplifies wallet parsing — no need to extract from query params.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] At least one major Cardano wallet implements support for the browse
+  authority in web+cardano URIs, including launching its embedded browser with
+  the specified path.
+- [ ] At least one dApp publishes deep links or QR codes using the browse scheme
+  that work reliably across supported wallets.
+- [ ] Demonstrated user success in navigating from mobile device (e.g., native
+  camera or link) into a wallet and then directly into the dApp or application
+  flow.
+- [ ] Positive feedback or validation from the community or wallet/dApp
+  developers confirming interoperability.
+
+### Implementation Plan
+
+- [ ] Publish and socialize the CIP draft for feedback from wallet and dApp
+  developers.
+- [ ] Develop a reference implementation or demo prototype showing browse URI
+  handling in at least one wallet.
+- [ ] Collaborate with at least one dApp team to generate example deep links and
+  test them live (e.g., at events or with public beta testers).
+- [ ] Write integration guides or example code for wallet and dApp developers.
+- [ ] Monitor ecosystem adoption and collect feedback for potential refinements
+  or amendments to the standard.
+
+## Copyright
+
+This CIP is licensed
+under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -95,7 +95,7 @@ the time of their authoring in terms of acceptance and adoption.
 Web app (SundaeSwap ADA <=> USDM Trading Page):
 
 ```
-web+cardano://browse/v1/https/fi.sundae.app/exchange?given=ada.lovelace&taken=c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d&routeIdent=64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
+web+cardano://browse/v1?uri=https%3A%2F%2Fapp.sundae.fi%2Fexchange%3Fgiven%3Dada.lovelace%26taken%3Dc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d%26routeIdent%3D64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
 ```
 
 IPFS app (simulated CID):

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -98,12 +98,6 @@ Web app (SundaeSwap ADA <=> USDM Trading Page):
 web+cardano://browse/v1?uri=https%3A%2F%2Fapp.sundae.fi%2Fexchange%3Fgiven%3Dada.lovelace%26taken%3Dc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad.0014df105553444d%26routeIdent%3D64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef
 ```
 
-IPFS app (simulated CID):
-
-```
-web+cardano://browse/v1/ipfs/QmXkYpAbC1234567890abcdef1234567890abcdef/actionPage
-```
-
 Local development app (HTTP localhost with port):
 
 ```

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -4,7 +4,9 @@ Title: Cardano URIs - Browse Application
 Category: Wallets
 Status: Proposed
 Authors:
+Authors:
     - Adam Dean <adam@crypto2099.io>
+    - Alex Dochioiu (VESPR Wallet) <alex@vespr.xyz> 
 Implementors:
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/1058

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -132,12 +132,6 @@ web+cardano://browse/v1?uri=http%3A%2F%2Flocalhost%3A3000%2FdevPage
 A dedicated `browse` authority isolates app navigation and launch intents from
 payment or metadata intents, improving clarity and interoperability.
 
-### Why include a scheme in the path?
-
-* Removes ambiguity — scheme is required, not optional.
-* Supports alternative protocols (IPFS, local dev) explicitly.
-* Simplifies wallet parsing — no need to extract from query parameters.
-
 ## Path to Active
 
 ### Acceptance Criteria

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -58,7 +58,7 @@ QR-based "deeplink" to a precise session or page within an application, we
 enable developers to build richer, safer and more interactive experiences such
 as:
 
-* Showing a full "checkout" process and later "recipt" to the user on their
+* Showing a full "checkout" process and later "receipt" to the user on their
   mobile device rather than simply a payment request out of context
 * Navigating users directly to complex application paths that would otherwise be
   prone to user data-entry errors and typos

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -130,7 +130,6 @@ query = "?" *( unreserved / pct-encoded / sub-delims / "=" / "&" )
 * Parse and validate version, scheme, and domain.
 * Forward the entire app-specific path and query string to the app.
 * Apply allowlist/blocklist and security policies:
-
     * Warn on `http` and `localhost`.
     * Allow `https` by default.
     * Resolve `ipfs` via trusted gateway or native resolver.


### PR DESCRIPTION
This CIP seeks to define the `browse` authority for `web+cardano` URIs. The intent here being to easily enable deep-linking capabilities for Cardano mobile wallets to launch their native embedded browser to the specified application or URL. This should be particularly useful in things like point-of-sale systems and for sharing applications in the wild versus the current process which can be rather clunky requiring users to:
1. Open the wallet
2. Find the wallet's application browser
3. Search or manually type a URL to the application

*Note:* Due to personal time constraints I did use some AI assistance in drafting some of the language of this pull request but the concept behind the scheme is mine (and inspired by the existing work of @francisluz and Begin Wallet) and all language has been reviewed and edited by myself personally.

[View Rendered Document in Branch](https://github.com/Crypto2099/CIPs/tree/cardano-uris-browse-authority/CIP-0158/README.md)