### PR TITLE
CIP-0138: update array serialisation format

### DIFF
--- a/CIP-0138/README.md
+++ b/CIP-0138/README.md
@@ -63,7 +63,8 @@ We add the following builtin functions:
 As with all Plutus Core builtin types, arrays must have a fixed binary representation.
 
 For arrays, this representation will be based on the one currently implemented in the [flat][8] encoding
-for the [Haskell `Array` type][9].
+for the [Haskell `List` type][9].  Plutus Core arrays must be converted to lists before being serialised,
+and deserialisation is performed by using the flat decoder for lists and converting the result to an array.
 
 ## Rationale: how does this CIP achieve its goals?
 
@@ -205,4 +206,4 @@ This CIP is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4
 [6]: https://github.com/IntersectMBO/cardano-ledger "cardano-ledger"
 [7]: https://github.com/IntersectMBO/cardano-node "cardano-node"
 [8]: https://hackage.haskell.org/package/flat "flat"
-[9]: https://hackage.haskell.org/package/array-0.5.4.0/docs/Data-Array.html#t:Array "Haskell Array"
+[9]: https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-List.html "Haskell List"


### PR DESCRIPTION
I'm not sure what the correct procedure for this is, but the IOG Plutus team would like to update the serialisation format for the Plutus Core  `array` type. 

## Plutus Core arrays
CIP-0158 proposes the addition of a new array type to Plutus Core, together with new built-in functions  to operate on arrays.  The basic functionality was implemented in [PR #6727](https://github.com/IntersectMBO/plutus/pull/6727) in the `plutus` repository, with a number of later pull requests adding costing for the array operations, a specification, and a number of other things. 

## Serialisation and deserialisation
Plutus Core scripts are serialised using the [flat](https://hackage.haskell.org/package/flat) library, and this provides a serialisation method for arrays which was proposed as the serialisation method for Plutus Core arrays in the original version of CIP-0158.  However, [experiments](https://github.com/IntersectMBO/plutus/pull/7296#issue-3364894295) show that deserialisation times are noticeably quicker if `flat`'s list serialisation format is used instead and during deserialisation a list is read in and then converted to an array: this is faster because the list serialisation scheme is simpler than the scheme for arrays and the array deserialisation function involves initially constructing a list and then [converting that to an array](https://hackage.haskell.org/package/flat-0.6/docs/src/Flat.Instances.Array.html#decodeIArray) anyway.  We have also recently forked the `flat` library for use with Plutus Core and have [refactored the list decoder](https://github.com/IntersectMBO/plutus/pull/7358) to obtain further speed improvements.

In view of this we propose updating CIP-0158 to serialise Plutus Core arrays using `flat`s list serialisation scheme instead of its `array` serialisation scheme.

### Space versus time
`Flat`'s list serialisation scheme is slightly less space-efficient than its array serialisation scheme. The serialised elements of the list are separated by `1`-bits (with a `0`-bit at the end), whereas arrays are serialised in blocks of up to 255 elements with no separation between the serialised elements but with each block preceded by a single byte containing its length.  Thus serialising a 128-element list requires serialising a 128-element array requires only one extra byte, but serialising a 128-element list requires 128 extra bits (16 bytes), but , an increase of 15 bytes over the array serialisation scheme (approximately 1/1000 of Cardano's current 16384-byte on-chain transaction size limit) .  However, rapid deserialisation is  important for the efficient functioning of the chain and we believe that the speed improvements arising from the use of the list decoder offest by the extra space..  Using a single encoding for both lists and arrays in Plutus Core also simplifies maintenance, specfication, and formalisation.

### Current implementation status
The Plutus Core array type and operations have all been fully implemented but are not expected to be enabled until the next hard fork, which is currently projected to happen in the early months of 2026.  Thus we can safely to change the serialisation method without affecting any existing scripts.  We have in fact [already updated](https://github.com/IntersectMBO/plutus/pull/7296) the array deserialiser to use our forked version of `flat`'s list serialisation scheme (although this could easily be reverted if necessary).  We would therefore like to update CIP-0158 to reflect this change and make it visible to the wider community in advance of the next hard fork.

Note that the process for opening a Plutus-related CIP no longer includes the requirement to specify a serialisation method (this was removed in #1038)

Note also that [CIP-0035](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0035#bug-fixes) states that a "fix may be submitted directly to the plutus repository and is NOT required to go through the CIP process." if "The specified behaviour is clearly wrong (in the judgement of relevant experts)"; we would claim that the change proposed in this PR meets these criteria.