### PR TITLE
CIP-0137 | Fix protocol specifications

### DIFF
--- a/CIP-0137/README.md
+++ b/CIP-0137/README.md
@@ -564,8 +564,8 @@ localMessageNotificationMessage
   / msgClientDone
 
 msgRequestMessages          = [0, isBlocking]
-msgReplyMessagesNonBlocking = [1, [*sig.message], hasMore]
-msgReplyMessagesBlocking    = [2, [+sig.message]]
+msgReplyMessagesNonBlocking = [1, [* message], hasMore]
+msgReplyMessagesBlocking    = [2, [+ message]]
 msgClientDone               = [3]
 
 messageId    = bstr
@@ -591,7 +591,6 @@ message = [
 
 hasMore = false / true
 isBlocking = false / true
-messages = [* message]
 ```
 
 ## Rationale: how does this CIP achieve its goals?


### PR DESCRIPTION
This PR includes updates of the [**CIP-0137**](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0137/README.md):
- **The structure of the DMQ messages has evolved**:
  - the **message payload** is encoded as an array and not any more in CBOR
  - the **operational certificate** is encoded as an array and not any more in CBOR, and its structure has been specified more precisely
  - the specification of the length of messages list is now stricter in the **n2c local notification** mini-protocol
  - removed a duplicate table
- The implementation plan has been updated.

---

([latest version of updated document](https://github.com/cardano-scaling/CIPs/blob/jpraynaud/update-cip-0137-v2/CIP-0137/README.md))