### PR TITLE
CIP-0088, CIP-0151 | update to Active

### DIFF
--- a/CIP-0088/README.md
+++ b/CIP-0088/README.md
@@ -2,12 +2,15 @@
 CIP: 88
 Title: Token Policy Registration
 Category: Tokens
-Status: Proposed
+Status: Active
 Authors:
-- Adam Dean <adam@crypto2099.io>
-Implementors: []
+    - Adam Dean <adam@crypto2099.io>
+Implementors: 
+    - VeriGlyph Nexus: https://nexus.veriglyph.io
+    - VeriGlyph Seninel: https://seninel.veriglyph.io
+    - Cardano Signer: https://github.com/gitmachtl/cardano-signer?tab=readme-ov-file#cip-88v2-calidus-pool-key-mode
 Discussions:
-- https://github.com/cardano-foundation/cips/pull/467
+    - https://github.com/cardano-foundation/cips/pull/467
 Created: 2023-02-27
 License: CC-BY-4.0
 ---
@@ -544,15 +547,15 @@ utility, and standards evolve.
 
 - [X] This CIP should receive feedback, criticism, and refinement from: CIP Editors and the community of people involved
   with token projects (both NFT and FT) to review any weaknesses or areas of improvement.
-- [ ] Guidelines and examples of publication of data as well as discovery and validation should be included as part of
+- [x] Guidelines and examples of publication of data as well as discovery and validation should be included as part of
   criteria for acceptance.
 - [X] Specifications should be updated to be written in both JSON Schema and CBOR CDDL format for maximum compatibility.
-- [ ] Implementation and use demonstrated by the community: Token Projects, Blockchain Explorers, Wallets,
+- [x] Implementation and use demonstrated by the community: Token Projects, Blockchain Explorers, Wallets,
   Marketplaces/DEXes.
 
 #### TO-DO ACCEPTANCE ACTIONS ####
 
-- [ ] Publish instructions and tooling for publication and verification of certificates
+- [x] Publish instructions and tooling for publication and verification of certificates
 - [ ] Develop standard for validation of Smart Contract minted tokens
 
 ### Implementation Plan

--- a/CIP-0151/README.md
+++ b/CIP-0151/README.md
@@ -2,7 +2,7 @@
 CIP: 151
 Title: On-Chain Registration - Stake Pools
 Category: Metadata
-Status: Proposed
+Status: Active
 Authors:
     - Adam Dean <adam@crypto2099.io>
     - Martin Lang <martin@martinlang.at>
@@ -13,6 +13,8 @@ Implementors:
     -   CNTools: https://github.com/cardano-community/guild-operators/tree/alpha
     -   SPO Scripts: https://github.com/gitmachtl/scripts
     -   Reference Implementation: https://github.com/crypto2099/calidus-demo
+    -   VeriGlyph Sentinel: https://sentinel.veriglyph.io
+    -   Ekklesia: https://ekklesia.vote
 Discussions:
     - https://github.com/cardano-foundation/CIPs/pull/999
     - https://forum.cardano.org/t/new-calidus-pool-key-for-spos-and-services-interacting-with-pools
@@ -29,7 +31,7 @@ support for stake pools to register verifiable information on-chain.
 
 ## Motivation: why is this CIP necessary?
 
-By extending the existing [CIP-0088] specification we can provide an extensible
+By extending the existing [CIP-0088] specification, we can provide an extensible
 framework for stake pool operators (SPOs) to provide verifiable, on-chain
 information related to their pool operation. This method is preferred over a
 change to the in-ledger stake pool registration certificates because additional
@@ -409,6 +411,7 @@ shown an interest in using it as a method of authentication and validation.
     * [ ] Blockfrost
     * [x] CN Tools
     * [x] SPO Scripts
+    * [x] VeriGlyph
 * Wallets
     * [x] Eternl
     * [x] Typhon
@@ -417,7 +420,8 @@ shown an interest in using it as a method of authentication and validation.
     * [ ] CardanoScan
     * [ ] AdaStat
     * [ ] PoolTool.io
-    * [ ] DripDropz
+    * [x] DripDropz
+    * [x] Ekklesia
 
 ### Implementation Plan
 


### PR DESCRIPTION
Both CIP-88 and CIP-151 have seen heavy and active development and main network usage throughout 2025. With the rise of Ekklesia voting for CIP-151 and VeriGlyph publication and validation for CIP-88 I would argue that both of these standards have risen to the level of being "active" on chain and should be adopted as such.