### PR TITLE
CIP-0137 | Add network magic table

### DIFF
--- a/CIP-0137/README.md
+++ b/CIP-0137/README.md
@@ -593,6 +593,16 @@ hasMore = false / true
 isBlocking = false / true
 ```
 
+### Network magic
+
+In order to identify messages belonging to a specific protocol, each DMQ network is identified by a unique network magic number:
+
+| Protocol | Cardano network | DMQ network magic number |
+| -------- | --------------- | ------------------------ |
+| Mithril  | `preview`       | `2147483650`             |
+| Mithril  | `preprod`       | `2147483649`             |
+| Mithril  | `mainnet`       | `2912307721`             |
+
 ## Rationale: how does this CIP achieve its goals?
 
 ### Why are we proposing this CIP?


### PR DESCRIPTION
This PR includes updates of the [**CIP-0137**](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0137/README.md):
- Added specification of the network magic numbers for Mithril
---

([latest version of updated document](https://github.com/cardano-scaling/CIPs/blob/jpraynaud/update-cip-0137-v3/CIP-0137/README.md))