### PR TITLE
CIP-0153 | Tighten unValueData canonicality, add scaleValue builtin

### DIFF
--- a/CIP-0153/README.md
+++ b/CIP-0153/README.md
@@ -106,8 +106,17 @@ We propose the following set of builtin functions to accompany the new builtin t
     - encodes a `BuiltinValue` as `BuiltinData`.
 6. `unValueData :: BuiltinData -> BuiltinValue`
     - decodes a `BuiltinData` into a `BuiltinValue`, or fails if it is not one.
+    - This builtin MUST reject non-canonical `Data`-encoded values.
+    - The outer `Map` must be strictly ascending by `CurrencySymbol` key and contain no duplicate keys; otherwise, the builtin fails.
+    - Each inner `Map` must be strictly ascending by `TokenName` key and contain no duplicate keys; otherwise, the builtin fails.
+    - It fails on empty inner maps.
+    - It fails on zero-amount entries in inner maps.
     - All currency symbols and token names must be no longer than 32 bytes.
-    - All amounts must lie between -2<sup>127</sup> and 2<sup>127</sup>-1 (inclusive).
+    - All amounts must lie between -2<sup>127</sup> and 2<sup>127</sup>-1 (inclusive), and be non-zero.
+7. `scaleValue :: BuiltinInteger -> BuiltinValue -> BuiltinValue`
+    - it multiplies all token quantities in the provided value by the provided integer scale factor.
+    - Any entries whose resulting quantity is zero are removed, and any currency symbols whose inner maps become empty are removed, preserving the Mary-era Value invariants.
+    - It fails if any resulting quantity lies outside -2<sup>127</sup> ≤ amount ≤ 2<sup>127</sup>-1.
 
 A note on `valueData` and `unValueData`: in Plutus V1, V2 and V3, the encoding of `BuiltinValue` in `BuiltinData` is identical to that of the [existing `Value` type](https://plutus.cardano.intersectmbo.org/haddock/latest/plutus-ledger-api/PlutusLedgerApi-V1-Value.html#t:Value) in plutus-ledger-api.
 This ensures backwards compatibility.


### PR DESCRIPTION
Specify unValueData canonicality checks: require strictly ascending, distinct keys for both outer (currency symbols) and inner (token names) maps; fail on empty inner maps and zero-quantity entries; keep existing bounds/size constraints.

Add scaleValue builtin to the operation list: multiply all quantities by a provided integer, drop zeros / remove empty inner maps to preserve invariants, and fail on out-of-bounds results.

This allows `unValueData` to simultaneously serve two purposes, the first of which is to enforce that a `BuiltinData` is a canonical multi-asset value in data encoding, the second is to convert that `BuiltinData` to `BuiltinValue`. 

Importantly, this should allow the ex-unit cost of `unValueData` to be linear instead of quadratic.