### PR TITLE
CPSs: Validation workflow and documentation

### DIFF
--- a/.github/CPS-VALIDATION.md
+++ b/.github/CPS-VALIDATION.md
@@ -50,7 +50,9 @@ Non-CIP labels (e.g., `Forum Post`, `Pull Request`) are allowed with any valid U
 
 ## Required Sections (H2 Headers)
 
-The following sections must exist in this order with **exact capitalization**:
+The following sections must exist in this order with **exact capitalization**.
+
+**No other H2 sections are allowed** except the optional sections listed below.
 
 | Order | Section |
 | ----- | ------- |
@@ -63,8 +65,8 @@ The following sections must exist in this order with **exact capitalization**:
 
 ## Optional Sections
 
-The following sections are allowed with exact capitalization
-they can appear after the `Open Questions`:
+The following sections are allowed with exact capitalization.
+They can appear after `Open Questions`:
 
 - `References`
 - `Appendices`

--- a/.github/CPS-VALIDATION.md
+++ b/.github/CPS-VALIDATION.md
@@ -1,0 +1,71 @@
+# CPS Validation Rules
+
+This document describes all validation rules applied to Cardano Problem Statement (CPS) documents.
+
+These validations are to be ran automatically via Github workflow using [`/scripts/validate-cps.py`](./scripts/validate-cps.py).
+
+These attempt to codify the guidance described within [CIP-9999 | Cardano Problem Statements](../CIP-9999/README.md).
+
+## File-Level Validations
+
+| Validation | Description |
+| ---------- | ----------- |
+| File path | Must be in a `CPS-*` directory |
+| Line endings | Must use UNIX line endings (LF), not Windows (CRLF) or old Mac (CR) |
+| Frontmatter | Must have valid YAML frontmatter between `---` delimiters |
+| No H1 headings | H1 (`#`) headings are not allowed in the document body |
+
+## Header Field Validations
+
+All 9 fields are **required**,
+must appear in order,
+and no extra fields are allowed.
+
+| Field | Order | Validation Rules |
+| ----- | ----- | ---------------- |
+| **CPS** | 1 | Positive integer (`1`, `42`) or `?`/`??`/etc. for unassigned |
+| **Title** | 2 | 1-100 characters, no backticks (`` ` ``) |
+| **Category** | 3 | One of: `Meta`, `Wallets`, `Tokens`, `Metadata`, `Tools`, `Plutus`, `Ledger`, `Consensus`, `Network`, `?` |
+| **Status** | 4 | `Open`, `Solved`, or `Inactive` (optionally with reason, e.g., `Inactive (Superseded)`) |
+| **Authors** | 5 | Non-empty list, each entry: `Name <email>` |
+| **Proposed Solutions** | 6 | List (can be empty), each entry: `Label: URL` |
+| **Discussions** | 7 | Non-empty list, each entry: `Label: URL` |
+| **Created** | 8 | Date in `YYYY-MM-DD` format |
+| **License** | 9 | `CC-BY-4.0` or `Apache-2.0` |
+
+## CIP Label Validation
+
+For the **Proposed Solutions** and **Discussions** fields,
+when an entry label matches the `CIP-NNNN` pattern,
+extra validation applies:
+
+| Rule | Description |
+| ---- | ----------- |
+| GitHub URL required | Must be `https://github.com/cardano-foundation/CIPs/...` |
+| Valid URL types | `/pull/NNN` (PR) or `/tree/{branch}/CIP-NNNN` or `/blob/{branch}/CIP-NNNN` (merged) |
+| `?` suffix for PRs | `CIP-0030?` required when linking to a pull request (candidate) |
+| No `?` for merged | `CIP-0030` (without `?`) required when linking to a merged CIP |
+
+Non-CIP labels (e.g., `Forum Post`, `Pull Request`) are allowed with any valid URL.
+
+## Required Sections (H2 Headers)
+
+The following sections must exist in this order with **exact capitalization**:
+
+| Order | Section |
+| ----- | ------- |
+| 1 | `Abstract` |
+| 2 | `Problem` |
+| 3 | `Use Cases` |
+| 4 | `Goals` |
+| 5 | `Open Questions` |
+| 6 | `Copyright` |
+
+## Optional Sections
+
+The following sections are allowed with exact capitalization
+they can appear after the `Open Questions`:
+
+- `References`
+- `Appendices`
+- `Acknowledgments` / `Acknowledgements`

--- a/.github/CPS-VALIDATION.md
+++ b/.github/CPS-VALIDATION.md
@@ -23,7 +23,7 @@ and no extra fields are allowed.
 
 | Field | Order | Validation Rules |
 | ----- | ----- | ---------------- |
-| **CPS** | 1 | Positive integer (`1`, `42`) or `?`/`??`/etc. for unassigned |
+| **CPS** | 1 | Positive integer (`1`, `42`) or `?`/`??`/etc. for unassigned. No leading zeros. |
 | **Title** | 2 | 1-100 characters, no backticks (`` ` ``) |
 | **Category** | 3 | One of: `Meta`, `Wallets`, `Tokens`, `Metadata`, `Tools`, `Plutus`, `Ledger`, `Consensus`, `Network`, `?` |
 | **Status** | 4 | `Open`, `Solved`, or `Inactive` (optionally with reason, e.g., `Inactive (Superseded)`) |
@@ -66,8 +66,10 @@ The following sections must exist in this order with **exact capitalization**.
 ## Optional Sections
 
 The following sections are allowed with exact capitalization.
-They can appear after `Open Questions`:
+They **must** appear after `Open Questions` and before `Copyright`:
 
 - `References`
 - `Appendices`
 - `Acknowledgments` / `Acknowledgements`
+
+Optional sections appearing before any required section (other than `Copyright`) will cause validation to fail.

--- a/.github/schemas/cps-header.schema.json
+++ b/.github/schemas/cps-header.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/cardano-foundation/CIPs/.github/schemas/cps-header.schema.json",
+  "title": "CPS Header Schema",
+  "description": "JSON Schema for validating YAML frontmatter headers in Cardano Problem Statements (CPSs)",
+  "type": "object",
+  "required": [
+    "CPS",
+    "Title",
+    "Category",
+    "Status",
+    "Authors",
+    "Proposed Solutions",
+    "Discussions",
+    "Created",
+    "License"
+  ],
+  "properties": {
+    "CPS": {
+      "description": "The CPS number (without leading 0), or one or more '?' before number has been assigned",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^\\?+$"
+        },
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "pattern": "^[1-9]\\d*$"
+        }
+      ]
+    },
+    "Title": {
+      "description": "A succinct and descriptive title. Don't use backticks (`) in titles since they disrupt formatting in other contexts. Must be less than 100 characters.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "not": {
+        "pattern": "`"
+      }
+    },
+    "Category": {
+      "description": "One of the editorially accepted categories covering one area of the ecosystem",
+      "type": "string",
+      "enum": [
+        "Meta",
+        "Wallets",
+        "Tokens",
+        "Metadata",
+        "Tools",
+        "Plutus",
+        "Ledger",
+        "Consensus",
+        "Network",
+        "?"
+      ]
+    },
+    "Status": {
+      "description": "Status of the CPS: Open, Solved, or Inactive (with optional reason)",
+      "type": "string",
+      "pattern": "^(Open|Solved|Inactive(?:\\s+\\(.*\\))?)$"
+    },
+    "Authors": {
+      "description": "A list of authors' real names and email addresses (e.g. John Doe <john.doe@email.domain>)",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^.+\\s+<.+>$",
+        "description": "Author entry in format: Name <email@domain.com>"
+      }
+    },
+    "Proposed Solutions": {
+      "description": "A list of CIPs addressing the problem, if any. Can be an empty array []. Each entry is 'Label: URL'. When label is CIP-NNNN, URL must be a GitHub CIPs repo link; use '?' suffix for PRs (candidates).",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^.+:\\s+https?://.+$",
+            "description": "Entry in format: 'Label: URL'"
+          },
+          {
+            "type": "object",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": "Dictionary format: {'Label': 'URL'}"
+          }
+        ]
+      }
+    },
+    "Discussions": {
+      "description": "A list of links where major technical discussions regarding this CPS happened. Must include a link to the pull request that created the CPS. Each entry must have a label followed by a colon and URL. Can be a string 'Label: URL' or a dictionary {'Label': 'URL'}.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "pattern": "^.+:\\s+https?://.+$",
+            "description": "Entry in format: 'Label: URL'"
+          },
+          {
+            "type": "object",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": "Dictionary format: {'Label': 'URL'}"
+          }
+        ]
+      }
+    },
+    "Created": {
+      "description": "Date created on, in ISO 8601 (YYYY-MM-DD) format",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "format": "date"
+    },
+    "License": {
+      "description": "Abbreviation of an approved license",
+      "type": "string",
+      "enum": [
+        "CC-BY-4.0",
+        "Apache-2.0"
+      ]
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/.github/scripts/validate-cps.py
+++ b/.github/scripts/validate-cps.py
@@ -353,6 +353,12 @@ def validate_sections(content: str) -> List[str]:
                           if orig.lower() in missing_sections_lower}
         errors.append(f"Missing required sections: {', '.join(sorted(missing_sections))}")
 
+    # Check for unknown sections (not in required or optional)
+    allowed_sections_lower = required_sections_lower | optional_sections_lower
+    for header in h2_headers:
+        if header.lower() not in allowed_sections_lower:
+            errors.append(f"Unknown section: '{header}'. Only required and optional sections are allowed.")
+
     # Build a mapping from lowercase to expected capitalization
     expected_capitalization = {}
     for section in CPS_REQUIRED_SECTIONS:

--- a/.github/scripts/validate-cps.py
+++ b/.github/scripts/validate-cps.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""
+Validation script for CPS README.md files.
+Validates YAML headers and required sections.
+"""
+
+import sys
+import re
+import json
+import yaml
+from pathlib import Path
+from typing import Dict, List, Set, Tuple, Optional
+
+try:
+    import jsonschema
+except ImportError:
+    print("Error: jsonschema library is required. Install it with: pip install jsonschema", file=sys.stderr)
+    sys.exit(1)
+
+
+# Required fields for CPS headers (in required order)
+CPS_REQUIRED_FIELDS_ORDER = [
+    'CPS', 'Title', 'Category', 'Status', 'Authors',
+    'Proposed Solutions', 'Discussions', 'Created', 'License'
+]
+CPS_REQUIRED_FIELDS = set(CPS_REQUIRED_FIELDS_ORDER)
+
+# Required sections (H2 headers) in required order
+CPS_REQUIRED_SECTIONS_ORDER = [
+    'Abstract',
+    'Problem',
+    'Use Cases',
+    'Goals',
+    'Open Questions',
+    'Copyright'
+]
+CPS_REQUIRED_SECTIONS = set(CPS_REQUIRED_SECTIONS_ORDER)
+
+# Optional H2 sections (allowed but not required)
+# These should appear after the required sections, before Copyright
+CPS_OPTIONAL_SECTIONS = {
+    'References',
+    'Appendices',
+    'Acknowledgments',
+    'Acknowledgements'
+}
+
+# Load CPS header schema
+SCHEMA_PATH = Path(__file__).parent.parent / 'schemas' / 'cps-header.schema.json'
+with open(SCHEMA_PATH, 'r', encoding='utf-8') as f:
+    CPS_HEADER_SCHEMA = json.load(f)
+
+
+def parse_frontmatter(content: str) -> Tuple[Optional[Dict], Optional[str]]:
+    """Parse YAML frontmatter from markdown content.
+    
+    Returns:
+        Tuple of (frontmatter_dict, remaining_content) or (None, content) if no frontmatter
+    """
+    # Check for frontmatter delimiters - must start with ---
+    if not content.startswith('---'):
+        return None, content
+    
+    # Find the closing delimiter (--- on its own line)
+    # Split on '\n---\n' or '\n---' at end of content
+    lines = content.split('\n')
+    if lines[0] != '---':
+        return None, content
+    
+    # Find the closing ---
+    end_idx = None
+    for i in range(1, len(lines)):
+        if lines[i] == '---':
+            end_idx = i
+            break
+    
+    if end_idx is None:
+        return None, content
+    
+    # Extract frontmatter (lines between the two --- markers)
+    frontmatter_lines = lines[1:end_idx]
+    frontmatter_text = '\n'.join(frontmatter_lines)
+    
+    # Extract remaining content (everything after the closing ---)
+    remaining_lines = lines[end_idx + 1:]
+    remaining_content = '\n'.join(remaining_lines)
+    
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if frontmatter is None:
+            return None, content
+        return frontmatter, remaining_content
+    except yaml.YAMLError as e:
+        return None, content
+
+
+def extract_h2_headers(content: str) -> List[str]:
+    """Extract all H2 headers (##) from markdown content."""
+    h2_pattern = r'^##\s+(.+)$'
+    headers = []
+    for line in content.split('\n'):
+        match = re.match(h2_pattern, line)
+        if match:
+            headers.append(match.group(1).strip())
+    return headers
+
+
+def extract_h1_headers(content: str) -> List[str]:
+    """Extract all H1 headers (#) from markdown content."""
+    h1_pattern = r'^#\s+(.+)$'
+    headers = []
+    for line in content.split('\n'):
+        match = re.match(h1_pattern, line)
+        if match:
+            headers.append(match.group(1).strip())
+    return headers
+
+
+def validate_line_endings(file_path: Path) -> List[str]:
+    """Validate that file uses UNIX line endings (LF, not CRLF).
+    
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+    
+    try:
+        # Read file in binary mode to check line endings
+        with open(file_path, 'rb') as f:
+            content_bytes = f.read()
+        
+        # Check for CRLF (\r\n) - Windows line endings
+        if b'\r\n' in content_bytes:
+            errors.append("File uses Windows line endings (CRLF). Use UNIX line endings (LF) instead.")
+        
+        # Check for standalone \r without \n (old Mac line endings)
+        # Replace CRLF first, then check for remaining CR
+        content_without_crlf = content_bytes.replace(b'\r\n', b'')
+        if b'\r' in content_without_crlf:
+            errors.append("File uses old Mac line endings (CR). Use UNIX line endings (LF) instead.")
+    except Exception as e:
+        errors.append(f"Error checking line endings: {e}")
+    
+    return errors
+
+
+def validate_no_h1_headings(content: str) -> List[str]:
+    """Validate that no H1 headings are present in the document.
+    
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+    
+    h1_headers = extract_h1_headers(content)
+    if h1_headers:
+        errors.append(f"H1 headings are not allowed. Found: {', '.join(h1_headers)}")
+    
+    return errors
+
+
+def _validate_field_order(frontmatter: Dict) -> List[str]:
+    """Validate that header fields appear in the correct order.
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+
+    # Get the actual order of fields in the frontmatter
+    actual_fields = list(frontmatter.keys())
+
+    # Filter to only known required fields (ignore any extra fields for order check)
+    actual_required = [f for f in actual_fields if f in CPS_REQUIRED_FIELDS]
+
+    # Build expected order based on which required fields are present
+    expected_order = [f for f in CPS_REQUIRED_FIELDS_ORDER if f in actual_required]
+
+    if actual_required != expected_order:
+        errors.append(
+            f"Header fields are not in the correct order. "
+            f"Expected: {', '.join(expected_order)}. "
+            f"Got: {', '.join(actual_required)}"
+        )
+
+    return errors
+
+
+def validate_header(frontmatter: Dict) -> List[str]:
+    """Validate the YAML frontmatter header for CPSs.
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+
+    # Validate field order
+    errors.extend(_validate_field_order(frontmatter))
+
+    # Validate header fields using JSON Schema
+    try:
+        # Convert date objects to strings for schema validation
+        # JSON Schema expects dates as strings, but PyYAML may parse them as date objects
+        # Also normalize dictionary entries in lists to strings (YAML parses "Label: URL" as dict)
+        frontmatter_for_schema = {}
+        for key, value in frontmatter.items():
+            if key == 'Created' and hasattr(value, 'isoformat'):
+                # Handle date objects from PyYAML (datetime.date or datetime.datetime)
+                frontmatter_for_schema[key] = value.isoformat()
+            elif key in ('Proposed Solutions', 'Discussions') and isinstance(value, list):
+                # Convert dictionary entries to string format "Label: URL"
+                normalized_list = []
+                for item in value:
+                    if isinstance(item, dict):
+                        # Convert dict like {'Label': 'URL'} to string 'Label: URL'
+                        if len(item) == 1:
+                            label, url = next(iter(item.items()))
+                            normalized_list.append(f"{label}: {url}")
+                        else:
+                            # Multiple keys - join them
+                            normalized_list.append(": ".join(f"{k}: {v}" for k, v in item.items()))
+                    elif isinstance(item, str):
+                        normalized_list.append(item)
+                    else:
+                        normalized_list.append(str(item))
+                frontmatter_for_schema[key] = normalized_list
+            else:
+                frontmatter_for_schema[key] = value
+
+        jsonschema.validate(instance=frontmatter_for_schema, schema=CPS_HEADER_SCHEMA)
+    except jsonschema.ValidationError as e:
+        # Format JSON Schema validation errors in a user-friendly way
+        error_path = '.'.join(str(p) for p in e.path) if e.path else 'root'
+        errors.append(f"Header validation error at '{error_path}': {e.message}")
+    except jsonschema.SchemaError as e:
+        errors.append(f"Schema error: {e.message}")
+
+    # Validate CIP label semantic rules (label/URL relationship)
+    if 'Proposed Solutions' in frontmatter:
+        errors.extend(_validate_cip_label_entries(frontmatter['Proposed Solutions'], 'Proposed Solutions'))
+    if 'Discussions' in frontmatter:
+        errors.extend(_validate_cip_label_entries(frontmatter['Discussions'], 'Discussions'))
+
+    return errors
+
+
+def _validate_cip_label_entries(entries: list, field_name: str) -> List[str]:
+    """Validate semantic rules for entries with CIP labels.
+
+    When a label matches CIP-NNNN pattern:
+    - URL must be a GitHub CIPs repository link (PR or merged CIP)
+    - Pull request URLs require '?' suffix on the CIP number (candidate)
+    - Merged CIP URLs must NOT have '?' suffix
+
+    Other labels are allowed with any valid URL.
+
+    Args:
+        entries: List of label-URL entries
+        field_name: Name of the field for error messages
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+
+    if not isinstance(entries, list):
+        return errors
+
+    cip_label_pattern = re.compile(r'^(CIP-\d+)(\?)?$')
+    pr_pattern = re.compile(r'https://github\.com/cardano-foundation/CIPs/pull/\d+')
+    merged_pattern = re.compile(r'https://github\.com/cardano-foundation/CIPs/(tree|blob)/[^/]+/CIP-\d+')
+    github_cips_pattern = re.compile(r'^https://github\.com/cardano-foundation/CIPs/(pull/\d+|tree/[^/]+/CIP-\d+|blob/[^/]+/CIP-\d+)')
+
+    for i, entry in enumerate(entries):
+        # Normalize to label and URL
+        if isinstance(entry, dict) and len(entry) == 1:
+            label, url = next(iter(entry.items()))
+        elif isinstance(entry, str):
+            # Parse "Label: URL" format
+            match = re.match(r'^([^:]+):\s+(.+)$', entry)
+            if not match:
+                continue
+            label, url = match.groups()
+        else:
+            continue
+
+        label = label.strip()
+        url = url.strip()
+
+        # Check if label matches CIP pattern - only then apply extra validation
+        label_match = cip_label_pattern.match(label)
+        if not label_match:
+            continue  # Non-CIP labels are allowed with any URL
+
+        cip_number = label_match.group(1)
+        has_question_mark = label_match.group(2) == '?'
+
+        # For CIP labels, URL must be a GitHub CIPs repository link
+        if not github_cips_pattern.match(url):
+            errors.append(
+                f"'{field_name}' entry {i+1}: CIP label '{label}' requires a GitHub CIPs repository URL "
+                f"(pull request or merged CIP). Got: {url}"
+            )
+            continue
+
+        is_pr = pr_pattern.search(url) is not None
+        is_merged = merged_pattern.search(url) is not None
+
+        if is_pr and not has_question_mark:
+            errors.append(
+                f"'{field_name}' entry {i+1}: Pull request URL requires '?' suffix on CIP number "
+                f"(use '{cip_number}?' instead of '{cip_number}' to indicate candidate status)"
+            )
+        elif is_merged and has_question_mark:
+            errors.append(
+                f"'{field_name}' entry {i+1}: Merged CIP should not have '?' suffix "
+                f"(use '{cip_number}' instead of '{cip_number}?' since this CIP is merged)"
+            )
+
+    return errors
+
+
+def validate_sections(content: str) -> List[str]:
+    """Validate required sections exist at H2 level for CPSs.
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+
+    h2_headers = extract_h2_headers(content)
+    found_sections = set(h2_headers)
+
+    # Normalize headers to lowercase for case-insensitive comparison
+    found_sections_lower = {h.lower() for h in found_sections}
+    required_sections_lower = {h.lower() for h in CPS_REQUIRED_SECTIONS}
+    optional_sections_lower = {h.lower() for h in CPS_OPTIONAL_SECTIONS}
+
+    # Check for missing required sections (case-insensitive)
+    missing_sections_lower = required_sections_lower - found_sections_lower
+    if missing_sections_lower:
+        # Map back to original case from required_sections for error message
+        missing_sections = {orig for orig in CPS_REQUIRED_SECTIONS
+                          if orig.lower() in missing_sections_lower}
+        errors.append(f"Missing required sections: {', '.join(sorted(missing_sections))}")
+
+    # Build a mapping from lowercase to expected capitalization
+    expected_capitalization = {}
+    for section in CPS_REQUIRED_SECTIONS:
+        expected_capitalization[section.lower()] = section
+    for section in CPS_OPTIONAL_SECTIONS:
+        expected_capitalization[section.lower()] = section
+
+    # Check for incorrect capitalization
+    for header in h2_headers:
+        header_lower = header.lower()
+        if header_lower in expected_capitalization:
+            expected = expected_capitalization[header_lower]
+            if header != expected:
+                errors.append(f"Section '{header}' has incorrect capitalization. Expected: '{expected}'")
+
+    # Check section order
+    # Map found headers to their canonical names (for order comparison)
+    canonical_headers = []
+    for header in h2_headers:
+        header_lower = header.lower()
+        if header_lower in expected_capitalization:
+            canonical_headers.append(expected_capitalization[header_lower])
+        else:
+            canonical_headers.append(header)  # Keep unknown headers as-is
+
+    # Extract just the required sections in the order they appear
+    found_required_order = [h for h in canonical_headers if h in CPS_REQUIRED_SECTIONS]
+
+    # Build expected order based on which required sections are present
+    expected_required_order = [s for s in CPS_REQUIRED_SECTIONS_ORDER if s in found_required_order]
+
+    if found_required_order != expected_required_order:
+        errors.append(
+            f"Sections are not in the correct order. "
+            f"Expected: {', '.join(expected_required_order)}. "
+            f"Got: {', '.join(found_required_order)}"
+        )
+
+    return errors
+
+
+def is_cps_file(file_path: Path) -> bool:
+    """Check if file path indicates a CPS document."""
+    path_str = str(file_path)
+    # Normalize path separators and check for CPS- pattern
+    # Handles both absolute (/CPS-123/) and relative (CPS-123/) paths
+    # Also handles Windows paths (CPS-123\README.md)
+    normalized_path = path_str.replace('\\', '/')
+    
+    # Check for CPS- pattern (with or without leading slash)
+    return bool(re.search(r'(^|/)CPS-', normalized_path, re.IGNORECASE))
+
+
+def validate_file(file_path: Path) -> Tuple[bool, List[str]]:
+    """Validate a single CPS README.md file.
+    
+    Returns:
+        Tuple of (is_valid, list_of_errors)
+    """
+    errors = []
+    
+    # Check if this is a CPS file
+    if not is_cps_file(file_path):
+        return False, [f"File path does not indicate a CPS document: {file_path}"]
+    
+    # Validate line endings (must check raw file bytes)
+    line_ending_errors = validate_line_endings(file_path)
+    errors.extend(line_ending_errors)
+    
+    # Read file content
+    try:
+        content = file_path.read_text(encoding='utf-8')
+    except Exception as e:
+        return False, [f"Error reading file: {e}"]
+    
+    # Parse frontmatter
+    frontmatter, remaining_content = parse_frontmatter(content)
+    if frontmatter is None:
+        errors.append("Missing or invalid YAML frontmatter (must start with '---' and end with '---')")
+        return False, errors
+    
+    # Validate header
+    header_errors = validate_header(frontmatter)
+    errors.extend(header_errors)
+    
+    # Validate no H1 headings
+    h1_errors = validate_no_h1_headings(remaining_content)
+    errors.extend(h1_errors)
+    
+    # Validate sections
+    section_errors = validate_sections(remaining_content)
+    errors.extend(section_errors)
+    
+    is_valid = len(errors) == 0
+    return is_valid, errors
+
+
+def main():
+    """Main entry point for the validation script."""
+    if len(sys.argv) < 2:
+        print("Usage: validate-cps.py <file1> [file2] ...", file=sys.stderr)
+        sys.exit(1)
+    
+    files_to_validate = [Path(f) for f in sys.argv[1:]]
+    all_valid = True
+    all_errors = []
+    
+    for file_path in files_to_validate:
+        if not file_path.exists():
+            print(f"Error: File not found: {file_path}", file=sys.stderr)
+            all_valid = False
+            continue
+        
+        is_valid, errors = validate_file(file_path)
+        
+        if not is_valid:
+            all_valid = False
+            print(f"\nValidation failed for {file_path}:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            all_errors.append((file_path, errors))
+    
+    if not all_valid:
+        print(f"\nValidation failed for {len(all_errors)} file(s)", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"\nAll {len(files_to_validate)} file(s) passed validation", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/.github/scripts/validate-cps.py
+++ b/.github/scripts/validate-cps.py
@@ -79,12 +79,21 @@ def parse_frontmatter(content: str) -> Tuple[Optional[Dict], Optional[str]]:
     
     # Extract frontmatter (lines between the two --- markers)
     frontmatter_lines = lines[1:end_idx]
-    frontmatter_text = '\n'.join(frontmatter_lines)
-    
+
+    # Preprocess: quote standalone '?' values (YAML interprets '?' as explicit key indicator)
+    processed_lines = []
+    for line in frontmatter_lines:
+        # Match lines like "CPS: ?" or "Category: ?" and quote the ?
+        if re.match(r'^[A-Za-z][A-Za-z ]*:\s+\?+\s*$', line):
+            line = re.sub(r':\s+(\?+)\s*$', r': "\1"', line)
+        processed_lines.append(line)
+
+    frontmatter_text = '\n'.join(processed_lines)
+
     # Extract remaining content (everything after the closing ---)
     remaining_lines = lines[end_idx + 1:]
     remaining_content = '\n'.join(remaining_lines)
-    
+
     try:
         frontmatter = yaml.safe_load(frontmatter_text)
         if frontmatter is None:

--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -30,8 +30,26 @@ jobs:
         run: |
           pip install pyyaml jsonschema
 
-      - name: Validate CPS files
+      - name: Get CPS files to validate
+        id: get-files
         run: |
-          FILES="${{ github.event.inputs.files }}"
+          # Get changed CPS files from the push
+          FILES=$(git diff --name-only HEAD~1 HEAD | grep -E '^CPS-[^/]+/README\.md$' || true)
+
+          if [ -z "$FILES" ]; then
+            echo "No CPS README.md files to validate"
+            echo "has_files=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Convert newlines to spaces for passing as arguments
+          FILES_SPACE=$(echo "$FILES" | tr '\n' ' ')
+          echo "has_files=true" >> $GITHUB_OUTPUT
+          echo "files=$FILES_SPACE" >> $GITHUB_OUTPUT
+
+      - name: Validate CPS files
+        if: steps.get-files.outputs.has_files == 'true'
+        run: |
+          FILES="${{ steps.get-files.outputs.files }}"
           echo "Validating CPS files: $FILES"
           python3 .github/scripts/validate-cps.py $FILES

--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -1,0 +1,56 @@
+name: CPS Validation
+
+on:
+  pull_request:
+    paths:
+      - 'CPS-*/README.md'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pyyaml jsonschema
+
+      - name: Get changed CPS files
+        id: changed-files
+        run: |
+          # Get list of changed README.md files in CPS-* directories
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"..."$HEAD_SHA" | grep -E '^CPS-[^/]+/README\.md$' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No CPS README.md files changed"
+            echo "has_files=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Convert newlines to spaces for passing as arguments
+          FILES_SPACE=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+          echo "has_files=true" >> $GITHUB_OUTPUT
+          echo "files=$FILES_SPACE" >> $GITHUB_OUTPUT
+
+      - name: Validate CPS files
+        if: steps.changed-files.outputs.has_files == 'true'
+        run: |
+          FILES="${{ steps.changed-files.outputs.files }}"
+
+          if [ -z "$FILES" ]; then
+            echo "No files to validate"
+            exit 0
+          fi
+
+          echo "Validating CPS files: $FILES"
+          python3 .github/scripts/validate-cps.py $FILES

--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Get CPS files to validate
         id: get-files
         run: |
-          # Get changed CPS files from the push
-          FILES=$(git diff --name-only HEAD~1 HEAD | grep -E '^CPS-[^/]+/README\.md$' || true)
+          # Get changed CPS files from the push (exclude deleted files)
+          FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 HEAD | grep -E '^CPS-[^/]+/README\.md$' || true)
 
           if [ -z "$FILES" ]; then
             echo "No CPS README.md files to validate"

--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -1,16 +1,9 @@
 name: CPS Validation
 
 on:
-  workflow_dispatch:
-    inputs:
-      files:
-        description: 'CPS files to validate (e.g., CPS-0001/README.md)'
-        required: true
-        type: string
-
-  # pull_request:
-  #   paths:
-  #     - 'CPS-*/README.md'
+  pull_request:
+    paths:
+      - 'CPS-*/README.md'
 
 jobs:
   validate:

--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -1,9 +1,16 @@
 name: CPS Validation
 
 on:
-  pull_request:
-    paths:
-      - 'CPS-*/README.md'
+  workflow_dispatch:
+    inputs:
+      files:
+        description: 'CPS files to validate (e.g., CPS-0001/README.md)'
+        required: true
+        type: string
+
+  # pull_request:
+  #   paths:
+  #     - 'CPS-*/README.md'
 
 jobs:
   validate:
@@ -23,34 +30,8 @@ jobs:
         run: |
           pip install pyyaml jsonschema
 
-      - name: Get changed CPS files
-        id: changed-files
-        run: |
-          # Get list of changed README.md files in CPS-* directories
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.sha }}"
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"..."$HEAD_SHA" | grep -E '^CPS-[^/]+/README\.md$' || true)
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No CPS README.md files changed"
-            echo "has_files=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Convert newlines to spaces for passing as arguments
-          FILES_SPACE=$(echo "$CHANGED_FILES" | tr '\n' ' ')
-          echo "has_files=true" >> $GITHUB_OUTPUT
-          echo "files=$FILES_SPACE" >> $GITHUB_OUTPUT
-
       - name: Validate CPS files
-        if: steps.changed-files.outputs.has_files == 'true'
         run: |
-          FILES="${{ steps.changed-files.outputs.files }}"
-
-          if [ -z "$FILES" ]; then
-            echo "No files to validate"
-            exit 0
-          fi
-
+          FILES="${{ github.event.inputs.files }}"
           echo "Validating CPS files: $FILES"
           python3 .github/scripts/validate-cps.py $FILES


### PR DESCRIPTION
Goes part way to address #989, specifically just CPS document validation, CIP validation still to come.

This script and schema were used to create and validate the changes in #1128.

### Changes

- Added a JSON schema definition for CPS headers
- Added a python script to validate CPS headers, and structure
- Added a github workflow to run the script when a CPS documented is added or changed
- Added a description document explaining the validations ran by the script

For now I have set the workflow to run ONLY when manually triggered
so we can test it out on a few real examples
before having it run across all existing PRs automatically

### Motivation

- Improve compliance to CPS template and CIP-9999 for new CPSs
  - Making downstream tooling more consistent
  - Improve overall consistency between CPSs
    - Codifying some of the MUSTs from CIP-9999
- Automate some of the CIP editors role
  - Giving authors automated feedback if they deviate from template

### Examples

Examples ran on my CIPs fork (see [PR view](https://github.com/Ryun1/CIPs/pull/30)):

- When a CPS follows expected template: See [runs/21783966089](https://github.com/Ryun1/CIPs/actions/runs/21783966089) for commit [62fdcf6](https://github.com/Ryun1/CIPs/commit/62fdcf69c4a223e7fb466450e172e7d5b4c96809)
- When header missing a field: See [runs/21784045648](https://github.com/Ryun1/CIPs/actions/runs/21784045648) for commit [a68e96e](https://github.com/Ryun1/CIPs/commit/a68e96e3488c187304e4691f4f40f7c570c50f37)
- When header fields in wrong order: See [runs/21784063562](https://github.com/Ryun1/CIPs/actions/runs/21784063562/job/62852562871) for commit [3a3f846](https://github.com/Ryun1/CIPs/commit/3a3f846f5bc75a5134a720d3b471e9b93b92b000)

Additionally I have generated 44 test CPS files on [cps-validation-test](https://github.com/Ryun1/CIPs/tree/cps-validation-test) within [.github/tests/valid](https://github.com/Ryun1/CIPs/tree/cps-validation-test/.github/tests/valid) and [.github/tests/invalid](https://github.com/Ryun1/CIPs/tree/cps-validation-test/.github/tests/invalid).
These test files were all run locally with `validate-cps.py`.

### Open Questions

- Is where I have put the schema and validation description the best place?
  - maybe they're better suited as a part of CIP-999?
- While we are in the .github directory, maybe we could move the templates to their own dedicated directory?, it may help people find them easier