### PR TITLE
Remove Adam Dean from CIP editors

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -427,12 +427,11 @@ The missions of an editor include, but aren't exclusively limited to, any of the
 
 Current editors are listed here below:
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] | Thomas Vellekoop <br/> [@perturbing][] |
-| ---                            | ---                            | ---                             | ---                                    |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Thomas Vellekoop <br/> [@perturbing][] |
+| ---                            | ---                            | ---                                    |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
-[@Crypto2099]: https://github.com/Crypto2099
 [@perturbing]: https://github.com/perturbing
 
 Emeritus editors:

--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -439,6 +439,7 @@ Emeritus editors:
 - Sebastien Guillemot - [@SebastienGllmt](https://github.com/SebastienGllmt)
 - Matthias Benkort - [@KtorZ](https://github.com/KtorZ)
 - Duncan Coutts - [@dcoutts](https://github.com/dcoutts)
+- Adam Dean - [@Crypto2099](https://github.com/Crypto2099)
 
 ## Rationale: how does this CIP achieve its goals?
 

--- a/README.md
+++ b/README.md
@@ -223,11 +223,10 @@ Proposals stalled without any updates from their authors will eventually be clos
 
 ## Editors
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Adam Dean <br/> [@Crypto2099][] | Thomas Vellekoop <br/> [@perturbing][] |
-| ---                            | ---                            | ---                             | ---                                    |
+| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Thomas Vellekoop <br/> [@perturbing][] |
+| ---                            | ---                            | ---                                    |
 
 [@rphair]: https://github.com/rphair
 [@Ryun1]: https://github.com/Ryun1
-[@Crypto2099]: https://github.com/Crypto2099
 [@perturbing]: https://github.com/perturbing
 


### PR DESCRIPTION
... at @Crypto2099's request near the end of last year, plus a period of inactivity.  Thanks Adam for your prior editorial contributions and for continuing to engage in CIP authorship and review. 🙏