### PR TITLE
CIP-0108 | Improve JSON schema

### DIFF
--- a/CIP-0108/README.md
+++ b/CIP-0108/README.md
@@ -89,6 +89,9 @@ The following properties extend the potential vocabulary of [CIP-100](https://gi
 - We extend CIP-100's references field.
 - This SHOULD NOT support markdown text styling.
 - To be an OPTIONAL set of objects, using the `@set` property.
+- Each object MUST have an `@type` field indicating the kind of reference. This MUST be one of:
+  - `GovernanceMetadata` - when the reference points to another CIP-100 compliant governance metadata document.
+  - `Other` - for any other kind of supporting document (e.g. a blog post, research paper, or community discussion).
 - Each object MUST have a `label` field to describe the reference, such as; "blog - Why we must continue to fund Catalyst".
 - Each object MUST have a `uri` field.
 - Each object MAY have a OPTIONAL `referenceHash` object.

--- a/CIP-0108/cip-0108.common.schema.json
+++ b/CIP-0108/cip-0108.common.schema.json
@@ -96,6 +96,7 @@
                 "references": {
                     "type": "array",
                     "title": "References",
+                    "uniqueItems": true,
                     "items": {
                         "$ref": "#/definitions/reference"
                     }

--- a/CIP-0108/cip-0108.common.schema.json
+++ b/CIP-0108/cip-0108.common.schema.json
@@ -48,6 +48,7 @@
             "title": "Witness",
             "description": "A witness proving that the author endorses the content of the metadata",
             "type": "object",
+            "required": ["witnessAlgorithm", "publicKey", "signature"],
             "properties": {
                 "witnessAlgorithm": {
                     "title": "WitnessAlgorithm",

--- a/CIP-0108/cip-0108.common.schema.json
+++ b/CIP-0108/cip-0108.common.schema.json
@@ -116,7 +116,8 @@
                 },
                 "label": {
                     "type": "string",
-                    "title": "Label"
+                    "title": "Label",
+                    "description": "A human-readable label describing the reference"
                 },
                 "uri": {
                     "type": "string",

--- a/CIP-0108/cip-0108.common.schema.json
+++ b/CIP-0108/cip-0108.common.schema.json
@@ -72,11 +72,13 @@
             "properties": {
                 "title": {
                     "type": "string",
+                    "maxLength": 80,
                     "title": "Title",
                     "description": "A brief introduction to the motivation for the governance action"
                 },
                 "abstract": {
                     "type": "string",
+                    "maxLength": 2500,
                     "title": "Abstract",
                     "description": "A concise summary of the motivation and rationale for the governance action"
                 },


### PR DESCRIPTION
- Adding maxLength restriction to schema, to match the CIP document's restrictions. `Title`s limited to 80 chars and `Abstract`s limited to 2500 chars.
- Enforce required properties of `witness`s in JSON schema
- Enforce uniqueness of `reference` entries in JSON schema
- Clarify `@type` of references in CIP