### PR TITLE
Sync CIP & CPS titles between documents & README

### DIFF
--- a/CIP-0014/README.md
+++ b/CIP-0014/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 14
-Title: User-Facing Asset Fingerprint 
+Title: User-Facing Asset Fingerprint
 Status: Active
 Category: Tokens
 Authors:

--- a/CIP-0015/README.md
+++ b/CIP-0015/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 15
-Title: Registration Transaction Metadata Format
+Title: Catalyst Registration Transaction Metadata Format
 Category: Metadata
 Status: Active
 Authors:

--- a/CIP-0018/README.md
+++ b/CIP-0018/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 18
-Title: Multi-Stake-Keys Wallets 
+Title: Multi-Stake-Keys Wallets
 Status: Proposed
 Category: Wallets
 Authors:

--- a/CIP-0035/README.md
+++ b/CIP-0035/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 35
-Title: Changes to Plutus Core
+Title: Plutus Core Evolution
 Status: Active
 Category: Meta
 Authors:

--- a/CIP-0042/README.md
+++ b/CIP-0042/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 42
-Title: New Plutus Builtin serialiseData
+Title: New Plutus Builtin `serialiseData`
 Status: Active
 Category: Plutus
 Authors:

--- a/CIP-0069/README.md
+++ b/CIP-0069/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 69
-Title: Script Signature Unification
+Title: Plutus Script Type Uniformization
 Category: Plutus
 Authors:
   - Maksymilian 'zygomeb' Brodowicz <zygomeb@gmail.com>

--- a/CIP-0072/README.md
+++ b/CIP-0072/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 72
-Title: Cardano dApp Registration & Discovery
+Title: dApp Registration & Verification
 Status: Proposed
 Category: Metadata
 Authors: 

--- a/CIP-0074/README.md
+++ b/CIP-0074/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 74
-Title: Set minPoolCost to 0
+Title: Set `minPoolCost` to 0
 Authors:
  - Robin of Loxley <adarobinhood@tutanota.com>
 Category: Ledger

--- a/CIP-0101/README.md
+++ b/CIP-0101/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 101
-Title: Integration of keccak256 into Plutus
+Title: Integration of `keccak256` into Plutus
 Status: Proposed
 Category: Plutus
 Authors: 

--- a/CIP-0116/README.md
+++ b/CIP-0116/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 116
-Title: Standard JSON encoding for Domain Types
+Title: Canonical JSON Encoding for Domain Types
 Category: Tools
 Status: Proposed
 Authors:

--- a/CIP-0122/README.md
+++ b/CIP-0122/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 122
-Title: Logical operations over BuiltinByteString
+Title: Logical operations over `BuiltinByteString`
 Category: Plutus
 Status: Active
 Authors: 

--- a/CIP-0123/README.md
+++ b/CIP-0123/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 123
-Title: Bitwise operations over BuiltinByteString
+Title: Bitwise operations over `BuiltinByteString`
 Category: Plutus
 Status: Active
 Authors:

--- a/CIP-0127/README.md
+++ b/CIP-0127/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 127
-Title: ripemd-160 hashing in Plutus Core
+Title: Integration of `ripemd_160` into Plutus
 Status: Active
 Category: Plutus
 Authors:

--- a/CIP-0132/README.md
+++ b/CIP-0132/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 132
-Title: New Plutus Builtin dropList
+Title: New Plutus Builtin `dropList`
 Status: Proposed
 Category: Plutus
 Authors:

--- a/CIP-0156/README.md
+++ b/CIP-0156/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 156
-Title: Plutus Core Builtin Function - multiIndexArray
+Title: Plutus Core Builtin Function - `multiIndexArray`
 Category: Plutus
 Status: Proposed
 Authors:

--- a/CIP-0162/README.md
+++ b/CIP-0162/README.md
@@ -1,6 +1,6 @@
 ---
 CIP: 162
-Title: Cardano URIs - DRep Links
+Title: URI Scheme - DRep Links
 Category: Wallets
 Status: Proposed
 Authors:

--- a/CPS-0014/README.md
+++ b/CPS-0014/README.md
@@ -1,6 +1,6 @@
 ---
 CPS: 14
-Title: Register of CBOR Tags for Cardano Data structures
+Title: Register of CBOR Tags
 Category: Tools
 Status: Open
 Authors:

--- a/CPS-0014/README.md
+++ b/CPS-0014/README.md
@@ -1,6 +1,6 @@
 ---
 CPS: 14
-Title: Register of CBOR Tags
+Title: Register of On-Chain CBOR Tags
 Category: Tools
 Status: Open
 Authors:

--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0159 | [Account Address Enhancement](./CIP-0159) | Proposed |
 | 0160 | [Receiving Script Purpose and Addresses](./CIP-0160) | Proposed |
 | 0161 | [Ouroboros Phalanx - Breaking Grinding Incentives](./CIP-0161) | Proposed |
+| 0162 | [URI Scheme - DRep Links](./CIP-0161) | Proposed |
 | 0163 | [Time-Bound Delegation with Dynamic Rewards](./CIP-0163) | Proposed |
 | 0164 | [Ouroboros Linear Leios - Greater transaction throughput](./CIP-0164) | Proposed |
 | 0165 | [Canonical Ledger State](./CIP-0165) | Proposed |
 | 0167 | [Remove isValid from transactions](./CIP-0167) | Proposed |
 | 0170 | [KERI-backed metadata attestations](./CIP-0170) | Proposed |
 | 0171 | [On-chain Smart Contract Bytecode Verification](./CIP-0171) | Proposed |
+| 0176 | [Non-segregated Block Body Serialization](./CIP-0176) | Proposed |
 | 0381 | [Plutus Support for Pairings Over BLS12-381](./CIP-0381) | Active |
 | 1694 | [A First Step Towards On-Chain Decentralized Governance](./CIP-1694) | Active |
 | 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/) | Active |
@@ -162,7 +164,7 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 1855 | [Forging policy keys for HD Wallets](./CIP-1855/) | Proposed |
 | 9999 | [Cardano Problem Statements](./CIP-9999/) | Active |
 
-<p align="right"><i>Last updated on 2026-03-18</i></p>
+<p align="right"><i>Last updated on 2026-03-31</i></p>
 
 > [!NOTE]
 > For more details about CIP statuses, see [CIP-0001 > Statuses](./CIP-0001/README.md#statuses).

--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0033 | [Reference Scripts](./CIP-0033/) | Active |
 | 0034 | [Chain ID Registry](./CIP-0034/) | Proposed |
 | 0035 | [Plutus Core Evolution](./CIP-0035) | Active |
-| 0036 | [Catalyst Registration Transaction Metadata Format](./CIP-0036) | Proposed |
+| 0036 | [Catalyst Registration Transaction Metadata Format (Updated)](./CIP-0036) | Proposed |
 | 0037 | [Dynamic Saturation Based on Pledge](./CIP-0037) | Proposed |
 | 0040 | [Collateral Output](./CIP-0040) | Active |
-| 0042 | [New Plutus Builtin: serialiseBuiltinData](./CIP-0042) | Active |
+| 0042 | [New Plutus Builtin serialiseData](./CIP-0042) | Active |
 | 0045 | [Decentralized WebRTC dApp-Wallet Communication](./CIP-0045) | Active |
 | 0049 | [ECDSA and Schnorr signatures in Plutus Core](./CIP-0049) | Active |
 | 0050 | [Pledge Leverage-Based Staking Rewards](./CIP-0050) | Proposed |
 | 0052 | [Cardano Audit Best Practice Guidelines](./CIP-0052) | Proposed |
 | 0054 | [Cardano Smart NFTs](./CIP-0054) | Proposed |
 | 0055 | [Protocol Parameters (Babbage Era)](./CIP-0055) | Active |
-| 0057 | [Plutus Smart-Contract Blueprint](./CIP-0057) | Active |
+| 0057 | [Plutus Contract Blueprint](./CIP-0057) | Active |
 | 0058 | [Plutus Bitwise Primitives](./CIP-0058) | Inactive |
 | 0059 | [Terminology Surrounding Core Features](./CIP-0059) | Active |
 | 0060 | [Music Token Metadata](./CIP-0060) | Active |
@@ -82,8 +82,8 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0068 | [Datum Metadata Standard](./CIP-0068) | Active |
 | 0069 | [Plutus Script Type Uniformization](./CIP-0069) | Active |
 | 0071 | [Non-Fungible Token (NFT) Proxy Voting Standard](./CIP-0071) | Proposed |
-| 0072 | [DApp Registration](./CIP-0072) | Proposed |
-| 0074 | [Set min-pool-cost to 0](./CIP-0074) | Proposed |
+| 0072 | [dApp Registration & Verification](./CIP-0072) | Proposed |
+| 0074 | [Set minPoolCost to 0](./CIP-0074) | Proposed |
 | 0075 | [Fair Stake Pool Rewards](./CIP-0075) | Proposed |
 | 0080 | [Transaction Serialization Deprecation Cycle](./CIP-0080) | Active |
 | 0082 | [Improved Rewards Scheme Parameters](./CIP-0082) | Proposed |
@@ -95,7 +95,7 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0089 | [Distributed DApps & Beacon Tokens](./CIP-0089) | Active |
 | 0091 | [Don't force Built-In functions](./CIP-0091) | Proposed |
 | 0093 | [Authenticated Web3 HTTP requests](./CIP-0093) | Proposed |
-| 0094 | [SPO On-chain Polls](./CIP-0094) | Active |
+| 0094 | [On-chain SPO polls](./CIP-0094) | Active |
 | 0095 | [Web-Wallet Bridge - Conway ledger era](./CIP-0095) | Active |
 | 0099 | [Proof of Onboarding](./CIP-0099) | Active |
 | 0100 | [Governance Metadata](./CIP-0100) | Active |
@@ -108,11 +108,11 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0107 | [URI Scheme - Block and transaction objects](./CIP-0107) | Proposed |
 | 0108 | [Governance Metadata - Governance Actions](./CIP-0108) | Proposed |
 | 0109 | [Modular Exponentiation Built-in for Plutus Core](./CIP-0109) | Proposed |
-| 0110 | [Plutus v1 compatible script references](./CIP-0110) | Active |
+| 0110 | [Plutus v1 Script References](./CIP-0110) | Active |
 | 0112 | [Observe script type](./CIP-0112) | Proposed |
 | 0114 | [CBOR Tags Registry](./CIP-0114) | Proposed |
 | 0115 | [CBOR tag definition - ED25519-BIP32 Keys](./CIP-0115) | Proposed |
-| 0116 | [Universal JSON Encoding for Domain Types](./CIP-0116) | Proposed |
+| 0116 | [Canonical JSON Encoding for Domain Types](./CIP-0116) | Proposed |
 | 0117 | [Explicit script return values](./CIP-0117) | Active |
 | 0118 | [Nested Transactions](./CIP-0118) | Proposed |
 | 0119 | [Governance Metadata - DReps](./CIP-0119) | Proposed |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0127 | [Integration of ripemd_160 into Plutus](./CIP-0127) | Active |
 | 0128 | [Preserving Order of Transaction Inputs](./CIP-0128) | Proposed |
 | 0129 | [Governance Identifiers](./CIP-0129) | Proposed |
-| 0132 | [New Plutus Builtin DropList](./CIP-0132) | Proposed |
+| 0132 | [New Plutus Builtin dropList](./CIP-0132) | Proposed |
 | 0133 | [Plutus support for Multi-Scalar Multiplication over BLS12-381](./CIP-0133) | Proposed |
 | 0134 | [Cardano URIs - Address Representation](./CIP-0134) | Proposed |
 | 0135 | [Disaster Recovery Plan for Cardano networks](./CIP-0135) | Active |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The following link lists "candidate" CIPs still under discussion with the commun
 | 0011 | [Universal JSON Encoding for Domain Types](./CPS-0011) | Open |
 | 0012 | [Query Layer Standardization](./CPS-0012) | Open |
 | 0013 | [Better builtin data structures in Plutus](./CPS-0013) | Open |
-| 0014 | [Register of CBOR Tags](./CPS-0014) | Open |
+| 0014 | [Register of On-Chain CBOR Tags](./CPS-0014) | Open |
 | 0016 | [Cardano URIs](./CPS-0016) | Open |
 | 0017 | [Settlement Speed](./CPS-0017) | Open |
 | 0018 | [Greater Transaction Throughput](./CPS-0018) | Open |


### PR DESCRIPTION
Fixes #900.  I believe — as suggested in https://github.com/cardano-foundation/CIPs/issues/900#issuecomment-4382180129 — that soon our repo front page `README` table will be built from the `Title:` fields of its merged CIPs and CPSs.

Therefore, since manual update of `README` when documents are merged may soon become obsolete, the main purpose of this PR is to ensure the correct titles are in the documents after they may have diverged through the editing process, given also that:
* The document titles are more regularly confirmed through the apparently more popular CIP/CPS pages on web site `cips.cardano.org`.
* Still, a final update of the `README` table provides a double-check that canonical titles are in place in the documents: before our growing GitHub workflow (https://github.com/cardano-foundation/CIPs/issues/989) might build these CIP/CPS lists automatically.

Differences are resolved by whichever appears to more closely match the latest content of the merged document.  Also, since the `README` title will often have been taken from the merging PR title rather than the document itself, sometimes this title will have had more visibility to the reviewing community & editors and therefore will be more accurate/current.

Finally, backticks are allowable in the CIP/CPS `Title:` fields but not in the `README` titles: since they must be escaped when appearing in Markdown tables and we can't always rely upon this when GitHub content is scraped into other sites.  Therefore these titles should remain different: using backticks (for all literals) in the `Title:` fields but not in the `README`.