### PR TITLE
CIP-0116 | Increase the maximum number of values allowed for Plutus cost models

### DIFF
--- a/CIP-0116/cardano-conway.json
+++ b/CIP-0116/cardano-conway.json
@@ -969,7 +969,7 @@
       "items": {
         "$ref": "cardano-conway.json#/definitions/Int128"
       },
-      "maxItems": 166,
+      "maxItems": 332,
       "minItems": 166
     },
     "PlutusV2CostModel": {
@@ -978,7 +978,7 @@
       "items": {
         "$ref": "cardano-conway.json#/definitions/Int128"
       },
-      "maxItems": 175,
+      "maxItems": 332,
       "minItems": 175
     },
     "PlutusV3CostModel": {
@@ -987,7 +987,7 @@
       "items": {
         "$ref": "cardano-conway.json#/definitions/Int128"
       },
-      "maxItems": 251,
+      "maxItems": 350,
       "minItems": 251
     },
     "CostModels": {

--- a/CIP-0116/changelog.md
+++ b/CIP-0116/changelog.md
@@ -3,27 +3,16 @@
 
 This document aims to catalog the changes between JSON schemas, to be updated as new eras are added.
 
-## Chang Hardfork [Babbage](./cardano-babbage.json) -> [Conway](./cardano-conway.json) (2024-xx-xx)
+## van Rossem Hardfork [Conway](./cardano-conway.json) -> [Conway](./cardano-conway.json) (2025-05-12)
 
-- [Babbage CDDL (12dc779)](https://github.com/IntersectMBO/cardano-ledger/blob/12dc779d7975cbeb69c7c18c1565964a90f50920/eras/babbage/impl/cddl-files/babbage.cddl)
-- [Conway CDDL (xxxxxxx)]()
-
-### Added
-
-### Changed
-
-### Removed
-
-### Notes
-
-## xxxx Hardfork [Conway](./cardano-conway.json) -> xxxx (202x-xx-xx)
-
-- [Conway CDDL (xxxxxxx)]()
-- 
+- [Conway CDDL (fe78729)](https://github.com/cardano-foundation/CIPs/blob/fe78729de0b564eb63a22baf53030d17c9e19e6e/CIP-0116/cardano-conway.json)
 
 ### Added
 
 ### Changed
+
+- Increased max size of Plutus Cost Models
+  matching new cost models introduced ahead of van Rossem hard fork.
 
 ### Removed
 


### PR DESCRIPTION
Protocol Version 11.0, brings new Plutus Builtins as well as Plutus Builtin consistency ascross versions.
This means that the number of values in all Plutus Cost Models are increasing.
([see enacted change on Preview testnet](https://preview.cardanoscan.io/govAction/gov_action1q9xr9etnglg3gazzzrsexj3qsnzaqpf2yvfpwrvnwk9l64n089tqqqg02j9))

This PR updates the maximum values allowed for Conway, to the new maximum.