### PR TITLE
Fix CPS validation workflow manual dispatch

### DIFF
--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -26,6 +26,8 @@ jobs:
         run: |
           git fetch origin pull/${{ github.event.inputs.pr_number }}/head:pr-branch
           git checkout pr-branch
+          # Overlay the script and schema from master
+          git checkout origin/master -- .github/scripts/ .github/schemas/
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Problem

Currently when the CPS manually dispatched the workflow will try and use the validation script and schema from the PR's branch. The  validation script and schema aren't always present on old PRs, causing the workflow to break.

[See example](https://github.com/cardano-foundation/CIPs/actions/runs/26129263315);

```
Validating CPS files: CPS-????/README.md 
python3: can't open file '/home/runner/work/CIPs/CIPs/.github/scripts/validate-cps.py': [Errno 2] No such file or directory
Error: Process completed with exit code 2.
```

### Resolution

For manual dispatch, checkout the `master` branch's validation script and schema.