### PR TITLE
Prevent pathname expansion in CPS validation workflow

### DIFF
--- a/.github/workflows/cps-validation.yaml
+++ b/.github/workflows/cps-validation.yaml
@@ -63,6 +63,8 @@ jobs:
       - name: Validate CPS files
         if: steps.get-files.outputs.has_files == 'true'
         run: |
+          # Disable pathname expansion
+          set -f
           FILES="${{ steps.get-files.outputs.files }}"
           echo "Validating CPS files: $FILES"
           python3 .github/scripts/validate-cps.py $FILES


### PR DESCRIPTION

## Problem

Directories named `CPS-????/` would be expanded to all `CPS-*` directories.

See example
- https://github.com/cardano-foundation/CIPs/actions/runs/26155073372/job/76932189268

## Solution

Prevent expansion in the shell.