### PR TITLE
CIP-0057 | Standardize parametric (generic) type naming

### DIFF
--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -17,7 +17,7 @@ Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/258
   - https://discord.gg/yUkkhqBnyV
   - https://github.com/aiken-lang/aiken/issues/972
-  - https://github.com/cardano-foundation/CIPs/pull/1203
+  - https://github.com/aiken-lang/aiken/issues/1270
 Created: 2022-05-15
 License: CC-BY-4.0
 ---

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -283,7 +283,7 @@ This keyword's value must be an array of valid _Plutus Data Schema_; possibly em
 
 Many high-level languages targeting Plutus support parametric polymorphism — type constructors that take other types as arguments (e.g. `Option<a>`, `List<a>`, `Pair<k, v>`, `Map<k, v>`, or user-defined ADTs such as `Wrapped<a>`). Once a compiler instantiates such a constructor with concrete arguments, the resulting type is a distinct on-chain type that may appear in `datum`, `redeemer`, `parameters`, or `fields`. Each distinct instantiation needs a distinct entry in the [`definitions`](#definitions) registry so that `$ref` strings can target it unambiguously.
 
-Earlier revisions of this CIP did not prescribe a syntax for naming such instantiations, and implementations have diverged: some emit `Option$Int` (legacy Aiken `< v1.1`), others emit `Option<Int>` (Aiken `>= v1.1`, Scalus), and bespoke tools have at times used `_` or `-` as separators. This divergence prevents code-generators from interoperating across producers.
+Earlier revisions of this CIP did not prescribe a syntax for naming such instantiations, and implementations have diverged: some emit `Option$Int`, others emit `Option<Int>`, and bespoke tools have at times used `_` or `-` as separators. This divergence prevents code-generators from interoperating across producers.
 
 This section defines the normative naming and encoding rules. Implementations producing `definitions` keys and `$ref` strings MUST follow them so that one blueprint can be consumed by tools across the ecosystem. Consumers MUST accept the modern angle-bracket form defined here; consumer behaviour for legacy forms is described in [Legacy syntaxes](#legacy-syntaxes) below.
 
@@ -306,7 +306,7 @@ In prose:
 3. Each type argument is itself a key matching this grammar — angle brackets nest arbitrarily deep for higher-order instantiations.
 4. Names of built-in / shared types (e.g. `Int`, `ByteArray`) MAY be unqualified (i.e. have no `/`-path prefix), at the producer's discretion.
 
-Examples of well-formed definition keys (from real-world Aiken stdlib v3 blueprints):
+Examples of well-formed definition keys:
 
 ```
 Option<Int>
@@ -316,12 +316,12 @@ List<Option<types/order/Action>>
 Option<List<Option<types/order/Action>>>
 Pair<Int,ByteArray>
 Map<ByteArray,Int>
-aiken/interval/IntervalBound<Int>
+my_contract/range/Bound<Int>
 ```
 
 ##### Tuple keys
 
-For ordered fixed-arity products (n-tuples) that some languages model as a distinct kind from ADTs, producers MUST use the reserved name `Tuple` with a single angle-bracket argument list whose contents are themselves wrapped in angle brackets — i.e. `Tuple<<A,B>>`, `Tuple<<A,B,C>>`. The doubled brackets distinguish tuples from a hypothetical single-argument `Tuple<A>` and match what current Aiken implementations emit.
+For ordered fixed-arity products (n-tuples) that some languages model as a distinct kind from ADTs, producers MUST use the reserved name `Tuple` with a single angle-bracket argument list whose contents are themselves wrapped in angle brackets — i.e. `Tuple<<A,B>>`, `Tuple<<A,B,C>>`. The doubled brackets disambiguate the tuple kind from a hypothetical single-argument generic `Tuple<A>`, which under this grammar would otherwise be indistinguishable.
 
 #### `$ref` strings
 
@@ -336,7 +336,7 @@ Examples:
 ```
 "$ref": "#/definitions/Option<Int>"
 "$ref": "#/definitions/Option<cardano~1address~1StakeCredential>"
-"$ref": "#/definitions/aiken~1interval~1IntervalBoundType<Int>"
+"$ref": "#/definitions/my_contract~1range~1BoundType<Int>"
 "$ref": "#/definitions/Pair<Int,ByteArray>"
 ```
 
@@ -348,7 +348,7 @@ When a parametric instantiation is registered, its `title` field MUST hold only 
 
 The following historical forms have appeared in blueprints emitted by older toolchains:
 
-- **Dollar-separator form**: `Option$Int`, `List$ByteArray` — used by Aiken `< v1.1` (stdlib `v1` era). Equivalent to the modern `Option<Int>`, `List<ByteArray>`.
+- **Dollar-separator form**: `Option$Int`, `List$ByteArray` — emitted by some early producers. Equivalent to the modern `Option<Int>`, `List<ByteArray>`.
 
 New producers MUST NOT emit any of these legacy forms; they MUST emit the modern angle-bracket form defined above.
 
@@ -463,17 +463,17 @@ Yet, because we do want `Data` to be the primary binary interface medium, we kee
 
 ### Parametric type naming
 
-The original revision of this CIP did not standardize a syntax for naming parametric type instantiations under `definitions`. As blueprints started appearing in the wild — first from Aiken, later from Scalus and others — two conventions emerged for separating a type constructor from its arguments: a dollar separator (`Option$Int`, used by Aiken `< v1.1`) and angle brackets (`Option<Int>`, used by Aiken `>= v1.1` and Scalus). The lack of a normative rule meant any new producer was free to invent a third, breaking interoperability with code-generators that had already been written against the others.
+The original revision of this CIP did not standardize a syntax for naming parametric type instantiations under `definitions`. As blueprints started appearing in the wild, two conventions emerged across producers for separating a type constructor from its arguments: a dollar separator (`Option$Int`) and angle brackets (`Option<Int>`). The lack of a normative rule meant any new producer was free to invent a third, breaking interoperability with code-generators written against either of the existing two.
 
 We chose angle brackets as the recommendation for three reasons:
 
 1. **Familiarity.** Angle brackets are the dominant generics syntax in the high-level languages most likely to consume blueprints (Java, TypeScript, Rust, C#, Scala). Code generators can use the key string almost verbatim to produce target-language identifiers, modulo escaping.
 2. **Compositionality.** Angle brackets nest naturally (`List<Option<Foo>>`) without ambiguity. The dollar form requires either escaping or further punctuation to express nested instantiations and tends to collide with valid identifier characters in some languages.
-3. **Existing momentum.** All current Aiken stdlib v3 output and all Scalus output already use the angle-bracket form; the dollar form is confined to legacy Aiken `< v1.1` blueprints. Standardizing on what new producers already emit minimizes churn.
+3. **Existing momentum.** Current major producers already emit the angle-bracket form, and the dollar form is confined to early blueprints from one of them. Standardizing on what new producers already emit minimizes churn.
 
 JSON Pointer's `~1` escape is reused rather than introducing a new escape mechanism because RFC 6901 is already the substrate `$ref` is built on. Angle brackets and commas were intentionally left unreserved by RFC 6901 and pass through verbatim, so no new escape semantics are introduced by this amendment.
 
-The unparameterized `title` rule reflects what Aiken and Scalus both already do in practice. Putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier; leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
+The unparameterized `title` rule reflects what current implementations already do in practice. Putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier; leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
 
 This amendment does NOT standardize a registry of shared types (e.g. `cardano/address/Credential`). Such a registry is largely a stdlib concern of individual languages and would expand the scope of CIP-57 beyond syntax. Producers remain free to use whatever qualified names their stdlib defines; this amendment only specifies how those names compose with type arguments.
 

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -284,9 +284,7 @@ This keyword's value must be an array of valid _Plutus Data Schema_; possibly em
 
 Many high-level languages targeting Plutus support parametric polymorphism — type constructors that take other types as arguments (e.g. `Option<a>`, `List<a>`, `Pair<k, v>`, `Map<k, v>`, or user-defined ADTs such as `Wrapped<a>`). Once a compiler instantiates such a constructor with concrete arguments, the resulting type is a distinct on-chain type that may appear in `datum`, `redeemer`, `parameters`, or `fields`. Each distinct instantiation needs a distinct entry in the [`definitions`](#definitions) registry so that `$ref` strings can target it unambiguously.
 
-Earlier revisions of this CIP did not prescribe a syntax for naming such instantiations, and implementations have diverged: some emit `Option$Int`, others emit `Option<Int>`, and bespoke tools have at times used `_` or `-` as separators. This divergence prevents code-generators from interoperating across producers.
-
-This section defines the normative naming and encoding rules. Implementations producing `definitions` keys and `$ref` strings MUST follow them so that one blueprint can be consumed by tools across the ecosystem. Consumers MUST accept the modern angle-bracket form defined here; consumer behaviour for legacy forms is described in [Legacy syntaxes](#legacy-syntaxes) below.
+Implementations producing `definitions` keys and `$ref` strings MUST follow the rules below so that one blueprint can be consumed by tools across the ecosystem. Consumers MUST accept the angle-bracket form; consumer behaviour for legacy forms is described in [Legacy syntaxes](#legacy-syntaxes) below.
 
 #### Definition keys
 
@@ -464,19 +462,15 @@ Yet, because we do want `Data` to be the primary binary interface medium, we kee
 
 ### Parametric type naming
 
-The original revision of this CIP did not standardize a syntax for naming parametric type instantiations under `definitions`. As blueprints started appearing in the wild, two conventions emerged across producers for separating a type constructor from its arguments: a dollar separator (`Option$Int`) and angle brackets (`Option<Int>`). The lack of a normative rule meant any new producer was free to invent a third, breaking interoperability with code-generators written against either of the existing two.
-
-We chose angle brackets as the recommendation for three reasons:
+Angle brackets are the parametric-naming delimiter for three reasons:
 
 1. **Familiarity.** Angle brackets are the dominant generics syntax in the high-level languages most likely to consume blueprints (Java, TypeScript, Rust, C#, Scala). Code generators can use the key string almost verbatim to produce target-language identifiers, modulo escaping.
-2. **Compositionality.** Angle brackets nest naturally (`List<Option<Foo>>`) without ambiguity. The dollar form requires either escaping or further punctuation to express nested instantiations and tends to collide with valid identifier characters in some languages.
-3. **Existing momentum.** Current major producers already emit the angle-bracket form, and the dollar form is confined to early blueprints from one of them. Standardizing on what new producers already emit minimizes churn.
+2. **Compositionality.** Angle brackets nest naturally (`List<Option<Foo>>`) without ambiguity. A separator built from identifier characters (such as `$`, `_`, or `-`) tends to collide with valid identifier characters in target languages and requires further escaping to express nested instantiations.
+3. **Ecosystem alignment.** Current major producers emit the angle-bracket form; standardising on it minimises churn for both producers and consumers.
 
-JSON Pointer's `~1` escape is reused rather than introducing a new escape mechanism because RFC 6901 is already the substrate `$ref` is built on. Angle brackets and commas were intentionally left unreserved by RFC 6901 and pass through verbatim, so no new escape semantics are introduced by this amendment.
+JSON Pointer's `~1` escape is reused rather than introducing a new escape mechanism because RFC 6901 is already the substrate `$ref` is built on. Angle brackets and commas are intentionally left unreserved by RFC 6901 and pass through verbatim, so no new escape semantics are introduced.
 
-The unparameterized `title` rule reflects what current implementations already do in practice. Putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier; leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
-
-This amendment does NOT standardize a registry of shared types (e.g. `cardano/address/Credential`). Such a registry is largely a stdlib concern of individual languages and would expand the scope of CIP-57 beyond syntax. Producers remain free to use whatever qualified names their stdlib defines; this amendment only specifies how those names compose with type arguments.
+The unparameterized `title` rule keeps `title` stable across instantiations: putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier, whereas leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
 
 ### Purpose
 

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -339,9 +339,12 @@ Examples:
 "$ref": "#/definitions/Pair<Int,ByteArray>"
 ```
 
-#### `title` and the unparameterized name
+#### `title` for parametric instantiations
 
-When a parametric instantiation is registered, its `title` field MUST hold only the **unparameterized constructor name** (e.g. `"Option"`, `"List"`, `"Pair"`), not the parameterized form. The angle-bracket suffix lives in the definition key and the `$ref`, not in `title`. This keeps `title` stable across instantiations and useful as a code-generation hint (e.g. the simple class / type name in the generated language).
+`title` is a human-readable hint and does NOT carry type identity. Type identity for a parametric instantiation lives in the definition key and is reached via `$ref`; consumers MUST derive type identity from those and MUST NOT use `title` to distinguish two entries. As a result, producers retain some discretion here:
+
+- Producers SHOULD emit only the **unparameterized constructor name** in `title` (e.g. `"Option"`, `"List"`, `"Pair"`). This keeps `title` stable across instantiations and lets consumers use it directly as a code-generation hint (e.g. the simple class / type name in the generated language).
+- Producers MAY emit the parameterized form (e.g. `"Pairs<ByteArray, Int>"`). Existing toolchains do so for some type constructors and consumers therefore MUST tolerate either form on read. Consumers that derive identifiers from `title` should strip any trailing angle-bracket suffix before using it.
 
 #### Legacy syntaxes
 
@@ -470,7 +473,7 @@ Angle brackets are the parametric-naming delimiter for three reasons:
 
 JSON Pointer's `~1` escape is reused rather than introducing a new escape mechanism because RFC 6901 is already the substrate `$ref` is built on. Angle brackets and commas are intentionally left unreserved by RFC 6901 and pass through verbatim, so no new escape semantics are introduced.
 
-The unparameterized `title` rule keeps `title` stable across instantiations: putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier, whereas leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
+`title` is not load-bearing for interop — type identity flows through the definition key and `$ref`, so a normative rule on `title` would constrain producers without unlocking any interoperability. The unparameterized form is recommended (SHOULD) because it makes `title` directly usable as a target-language identifier; the parameterized form is tolerated (MAY) because some producers already emit it and a hard rule there would invalidate existing blueprints without adding interop value.
 
 ### Purpose
 

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -285,11 +285,11 @@ Many high-level languages targeting Plutus support parametric polymorphism — t
 
 Earlier revisions of this CIP did not prescribe a syntax for naming such instantiations, and implementations have diverged: some emit `Option$Int` (legacy Aiken `< v1.1`), others emit `Option<Int>` (Aiken `>= v1.1`, Scalus), and bespoke tools have at times used `_` or `-` as separators. This divergence prevents code-generators from interoperating across producers.
 
-This section defines the recommended naming and encoding rules. Implementations producing or consuming `definitions` keys and `$ref` strings SHOULD follow them so that one blueprint can be consumed by tools across the ecosystem.
+This section defines the normative naming and encoding rules. Implementations producing `definitions` keys and `$ref` strings MUST follow them so that one blueprint can be consumed by tools across the ecosystem. Consumers MUST accept the modern angle-bracket form defined here; consumer behaviour for legacy forms is described in [Legacy syntaxes](#legacy-syntaxes) below.
 
 #### Definition keys
 
-For each instantiation of a parametric type constructor that appears in a blueprint, producers SHOULD register one entry under `definitions` whose key follows this grammar (informal EBNF):
+For each instantiation of a parametric type constructor that appears in a blueprint, producers MUST register one entry under `definitions` whose key follows this grammar (informal EBNF):
 
 ```
 key            = qualified-name [ "<" arg-list ">" ]
@@ -321,7 +321,7 @@ aiken/interval/IntervalBound<Int>
 
 ##### Tuple keys
 
-For ordered fixed-arity products (n-tuples) that some languages model as a distinct kind from ADTs, producers SHOULD use the reserved name `Tuple` with a single angle-bracket argument list whose contents are themselves wrapped in angle brackets — i.e. `Tuple<<A,B>>`, `Tuple<<A,B,C>>`. The doubled brackets distinguish tuples from a hypothetical single-argument `Tuple<A>` and match what current Aiken implementations emit.
+For ordered fixed-arity products (n-tuples) that some languages model as a distinct kind from ADTs, producers MUST use the reserved name `Tuple` with a single angle-bracket argument list whose contents are themselves wrapped in angle brackets — i.e. `Tuple<<A,B>>`, `Tuple<<A,B,C>>`. The doubled brackets distinguish tuples from a hypothetical single-argument `Tuple<A>` and match what current Aiken implementations emit.
 
 #### `$ref` strings
 
@@ -342,15 +342,17 @@ Examples:
 
 #### `title` and the unparameterized name
 
-When a parametric instantiation is registered, its `title` field SHOULD hold only the **unparameterized constructor name** (e.g. `"Option"`, `"List"`, `"Pair"`), not the parameterized form. The angle-bracket suffix lives in the definition key and the `$ref`, not in `title`. This keeps `title` stable across instantiations and useful as a code-generation hint (e.g. the simple class / type name in the generated language).
+When a parametric instantiation is registered, its `title` field MUST hold only the **unparameterized constructor name** (e.g. `"Option"`, `"List"`, `"Pair"`), not the parameterized form. The angle-bracket suffix lives in the definition key and the `$ref`, not in `title`. This keeps `title` stable across instantiations and useful as a code-generation hint (e.g. the simple class / type name in the generated language).
 
 #### Legacy syntaxes
 
-Producers MAY continue to emit, and consumers SHOULD tolerate, the following historical forms when processing blueprints emitted by older toolchains:
+The following historical forms have appeared in blueprints emitted by older toolchains:
 
 - **Dollar-separator form**: `Option$Int`, `List$ByteArray` — used by Aiken `< v1.1` (stdlib `v1` era). Equivalent to the modern `Option<Int>`, `List<ByteArray>`.
 
-Consumers that produce keys themselves (e.g. when synthesising auxiliary definitions during code generation) SHOULD emit the modern angle-bracket form regardless of which form they consumed. New producers SHOULD NOT emit the dollar-separator form.
+New producers MUST NOT emit any of these legacy forms; they MUST emit the modern angle-bracket form defined above.
+
+Consumers MAY support legacy forms for backwards compatibility with older blueprints, but are NOT required to. A consumer that rejects a blueprint solely because it contains legacy-form keys is conformant with this specification. When a consumer that does support legacy forms produces keys itself (e.g. when synthesising auxiliary definitions during code generation), it MUST emit the modern angle-bracket form regardless of which form it consumed.
 
 ## Example(s)
 

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -17,6 +17,7 @@ Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/258
   - https://discord.gg/yUkkhqBnyV
   - https://github.com/aiken-lang/aiken/issues/972
+  - https://github.com/cardano-foundation/CIPs/pull/1203
 Created: 2022-05-15
 License: CC-BY-4.0
 ---

--- a/CIP-0057/README.md
+++ b/CIP-0057/README.md
@@ -12,6 +12,7 @@ Implementors:
   - OpShin <https://github.com/OpShin>
   - Lucid <https://lucid.spacebudz.io/>
   - Mesh.js <https://martify.io/>
+  - Bloxbean cardano-client-lib <https://github.com/bloxbean/cardano-client-lib>
 Discussions:
   - https://github.com/cardano-foundation/CIPs/pull/258
   - https://discord.gg/yUkkhqBnyV
@@ -278,6 +279,79 @@ This keyword's value must be a non-negative integer. An instance is valid agains
 
 This keyword's value must be an array of valid _Plutus Data Schema_; possibly empty. An instance is valid against this keyword if it represents a Plutus constructor for which each field is valid under each subschema given by this keyword's value. Fields are compared positionally. This keyword is mandatory.
 
+### Parametric (generic) types
+
+Many high-level languages targeting Plutus support parametric polymorphism — type constructors that take other types as arguments (e.g. `Option<a>`, `List<a>`, `Pair<k, v>`, `Map<k, v>`, or user-defined ADTs such as `Wrapped<a>`). Once a compiler instantiates such a constructor with concrete arguments, the resulting type is a distinct on-chain type that may appear in `datum`, `redeemer`, `parameters`, or `fields`. Each distinct instantiation needs a distinct entry in the [`definitions`](#definitions) registry so that `$ref` strings can target it unambiguously.
+
+Earlier revisions of this CIP did not prescribe a syntax for naming such instantiations, and implementations have diverged: some emit `Option$Int` (legacy Aiken `< v1.1`), others emit `Option<Int>` (Aiken `>= v1.1`, Scalus), and bespoke tools have at times used `_` or `-` as separators. This divergence prevents code-generators from interoperating across producers.
+
+This section defines the recommended naming and encoding rules. Implementations producing or consuming `definitions` keys and `$ref` strings SHOULD follow them so that one blueprint can be consumed by tools across the ecosystem.
+
+#### Definition keys
+
+For each instantiation of a parametric type constructor that appears in a blueprint, producers SHOULD register one entry under `definitions` whose key follows this grammar (informal EBNF):
+
+```
+key            = qualified-name [ "<" arg-list ">" ]
+qualified-name = path-segment *( "/" path-segment )
+path-segment   = unreserved-char *( unreserved-char )
+arg-list       = key *( "," key )
+unreserved-char = ALPHA / DIGIT / "_"
+```
+
+In prose:
+
+1. The unparameterized part of the key is the type constructor's **fully qualified name** as the producing compiler understands it (e.g. `Option`, `List`, `cardano/address/Credential`, `MyProject/types/order/Action`). Module separators are written as forward slashes (`/`).
+2. If the type constructor takes type arguments, they appear inside a single pair of angle brackets (`<` and `>`) immediately after the qualified name, separated by commas (`,`), with **no whitespace**.
+3. Each type argument is itself a key matching this grammar — angle brackets nest arbitrarily deep for higher-order instantiations.
+4. Names of built-in / shared types (e.g. `Int`, `ByteArray`) MAY be unqualified (i.e. have no `/`-path prefix), at the producer's discretion.
+
+Examples of well-formed definition keys (from real-world Aiken stdlib v3 blueprints):
+
+```
+Option<Int>
+Option<cardano/address/StakeCredential>
+List<ByteArray>
+List<Option<types/order/Action>>
+Option<List<Option<types/order/Action>>>
+Pair<Int,ByteArray>
+Map<ByteArray,Int>
+aiken/interval/IntervalBound<Int>
+```
+
+##### Tuple keys
+
+For ordered fixed-arity products (n-tuples) that some languages model as a distinct kind from ADTs, producers SHOULD use the reserved name `Tuple` with a single angle-bracket argument list whose contents are themselves wrapped in angle brackets — i.e. `Tuple<<A,B>>`, `Tuple<<A,B,C>>`. The doubled brackets distinguish tuples from a hypothetical single-argument `Tuple<A>` and match what current Aiken implementations emit.
+
+#### `$ref` strings
+
+References to definitions follow [RFC 6901 — JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). The relevant escape rules are:
+
+- `/` (used as a module separator in qualified names) MUST be encoded as `~1` inside a `$ref` value.
+- `~` MUST be encoded as `~0`.
+- Angle brackets (`<`, `>`) and commas (`,`) MUST NOT be percent-encoded; they appear verbatim. JSON Pointer does not reserve them.
+
+Examples:
+
+```
+"$ref": "#/definitions/Option<Int>"
+"$ref": "#/definitions/Option<cardano~1address~1StakeCredential>"
+"$ref": "#/definitions/aiken~1interval~1IntervalBoundType<Int>"
+"$ref": "#/definitions/Pair<Int,ByteArray>"
+```
+
+#### `title` and the unparameterized name
+
+When a parametric instantiation is registered, its `title` field SHOULD hold only the **unparameterized constructor name** (e.g. `"Option"`, `"List"`, `"Pair"`), not the parameterized form. The angle-bracket suffix lives in the definition key and the `$ref`, not in `title`. This keeps `title` stable across instantiations and useful as a code-generation hint (e.g. the simple class / type name in the generated language).
+
+#### Legacy syntaxes
+
+Producers MAY continue to emit, and consumers SHOULD tolerate, the following historical forms when processing blueprints emitted by older toolchains:
+
+- **Dollar-separator form**: `Option$Int`, `List$ByteArray` — used by Aiken `< v1.1` (stdlib `v1` era). Equivalent to the modern `Option<Int>`, `List<ByteArray>`.
+
+Consumers that produce keys themselves (e.g. when synthesising auxiliary definitions during code generation) SHOULD emit the modern angle-bracket form regardless of which form they consumed. New producers SHOULD NOT emit the dollar-separator form.
+
 ## Example(s)
 
 <details>
@@ -384,6 +458,22 @@ One would have written:
 ```
 
 Yet, because we do want `Data` to be the primary binary interface medium, we keep the former notation as it's more succinct and is a unambiguous shorthand. This also allows to segregate all builtins behind a common notation -- that is, prefixed with a `#`.
+
+### Parametric type naming
+
+The original revision of this CIP did not standardize a syntax for naming parametric type instantiations under `definitions`. As blueprints started appearing in the wild — first from Aiken, later from Scalus and others — two conventions emerged for separating a type constructor from its arguments: a dollar separator (`Option$Int`, used by Aiken `< v1.1`) and angle brackets (`Option<Int>`, used by Aiken `>= v1.1` and Scalus). The lack of a normative rule meant any new producer was free to invent a third, breaking interoperability with code-generators that had already been written against the others.
+
+We chose angle brackets as the recommendation for three reasons:
+
+1. **Familiarity.** Angle brackets are the dominant generics syntax in the high-level languages most likely to consume blueprints (Java, TypeScript, Rust, C#, Scala). Code generators can use the key string almost verbatim to produce target-language identifiers, modulo escaping.
+2. **Compositionality.** Angle brackets nest naturally (`List<Option<Foo>>`) without ambiguity. The dollar form requires either escaping or further punctuation to express nested instantiations and tends to collide with valid identifier characters in some languages.
+3. **Existing momentum.** All current Aiken stdlib v3 output and all Scalus output already use the angle-bracket form; the dollar form is confined to legacy Aiken `< v1.1` blueprints. Standardizing on what new producers already emit minimizes churn.
+
+JSON Pointer's `~1` escape is reused rather than introducing a new escape mechanism because RFC 6901 is already the substrate `$ref` is built on. Angle brackets and commas were intentionally left unreserved by RFC 6901 and pass through verbatim, so no new escape semantics are introduced by this amendment.
+
+The unparameterized `title` rule reflects what Aiken and Scalus both already do in practice. Putting `<Int>` into `title` would force every code generator to strip it before deriving an identifier; leaving `title` as the bare constructor name lets it serve directly as a code-generation hint.
+
+This amendment does NOT standardize a registry of shared types (e.g. `cardano/address/Credential`). Such a registry is largely a stdlib concern of individual languages and would expand the scope of CIP-57 beyond syntax. Producers remain free to use whatever qualified names their stdlib defines; this amendment only specifies how those names compose with type arguments.
 
 ### Purpose
 


### PR DESCRIPTION
## Summary

Adds a normative section to CIP-0057 that specifies how parametric (generic) type instantiations are named in the `definitions` registry, how `$ref` strings target them under RFC 6901, and how `title` is to be populated.

The amendment is **purely additive** — no existing fields, keywords, or examples are changed. The new section codifies a single angle-bracket syntax for generic instantiations and acknowledges an earlier dollar-separator form as legacy that new producers MUST NOT emit and consumers MAY (but need not) accept.

The text is written so that a future reader of the CIP will read the parametric-types section as part of the original specification — no "earlier revisions", "we chose", or amendment-narrative voice in the CIP body itself. Specific producers are also not named in the normative or rationale sections.

### What the section specifies

**Interop-critical (MUST):**

- **Definition keys**: angle-bracket grammar — `Option<Int>`, `List<ByteArray>`, `Pair<Int,ByteArray>`, `Map<K,V>`, nested arbitrarily (`List<Option<types/order/Action>>`). Module separators stay as forward slashes inside the qualified name.
- **Tuples**: doubled angle brackets — `Tuple<<A,B>>`, `Tuple<<A,B,C>>` — to disambiguate from a hypothetical single-argument generic `Tuple<A>`.
- **`$ref` escaping**: standard JSON Pointer (RFC 6901) — `/` → `~1`, `~` → `~0`, angle brackets and commas pass through verbatim.
- **Type identity** for parametric instantiations is carried by the definition key / `$ref`; consumers MUST NOT use `title` to distinguish entries.

**Hint, not interop-load (SHOULD / MAY):**

- **`title`** SHOULD hold only the bare constructor name (`"Option"`, not `"Option<Int>"`) so it works directly as a code-generation hint, but producers MAY emit the parameterized form. Consumers MUST tolerate either form; if they derive identifiers from `title`, they strip the angle-bracket suffix.

### Legacy syntax handling

- **New producers MUST NOT** emit the dollar-separator form (`Option$Int`, `List$ByteArray`) or any other historical separator.
- **Consumers MAY support** legacy forms for backwards compatibility with older blueprints, but are NOT required to. A consumer that rejects legacy-form blueprints outright is still conformant with this spec.
- When a legacy-supporting consumer produces keys itself (e.g. synthesised auxiliary definitions during code generation), it MUST emit the modern angle-bracket form regardless of what it consumed.

### What this amendment intentionally does NOT do

- It does not deprecate or remove anything that existing tools depend on. Existing blueprints remain valid; only new producers are constrained on the MUST rules.

## Motivation (PR-side; not in the CIP text)

Today CIP-57 is silent on parametric-type naming. As blueprints have appeared from a widening set of producers, conventions diverged for separating a type constructor from its arguments (`Option$Int`, `Option<Int>`, and bespoke separators in between). Without a normative rule, every new producer is free to invent a third or fourth.

Concretely: Bloxbean's cardano-client-lib annotation processor has carried dual `<>` / `$` parsing for two years because it has to consume both. We're cleaning that out on the library side now and this PR is the upstream half of that work — pinning the convention so future producers don't reintroduce the divergence. SHOULD wouldn't actually prevent that for definition keys / `$ref` / encoding, so those rules are MUST. `title`, by contrast, doesn't carry type identity (consumers reach identity through the key), so a MUST there would constrain producers without unlocking interop and is SHOULD instead.

## Findings from real-world verification

The first draft of this amendment put a MUST on `title` requiring the unparameterized form. After authoring a batch of integration tests that compile real Aiken stdlib v3.1 contracts and feed them through code generation, I observed that one blueprint emits **both** forms in `title`:

- `Option<X>` → title `"Option"` (unparameterized — matches the rule)
- `Tuple<<A,B>>` → title `"Tuple"` (unparameterized)
- `Pairs<A,B>` → title `"Pairs<A, B>"` (parameterized)

A MUST that says "title is the unparameterized name only" would therefore declare real Aiken output non-conformant for one specific type while adding no interop benefit. Identity flows through the definition key and `$ref`, both of which remain MUST and unambiguous. This is why the title rule is SHOULD with explicit consumer-side tolerance for the parameterized form.

## Rationale (also expanded inline in the CIP)

- **Familiarity**: angle brackets are the dominant generics syntax in target languages (Java, TypeScript, Rust, C#, Scala). Code generators can use the key string nearly verbatim.
- **Compositionality**: nesting is unambiguous (`List<Option<Foo>>`); identifier-character separators collide with target-language identifiers and need extra escaping for nesting.
- **Ecosystem alignment**: current major producers already emit the angle-bracket form. Standardising on what new producers already emit minimises churn.

JSON Pointer's `~1` escape is reused rather than introducing a new mechanism, because RFC 6901 is already the substrate `$ref` is built on.

## Versioning / change-tracking

CIP-1 § Versioning treats CIP-text revisions as git-history-tracked rather than version-tagged ("this does not apply to the CIP text, for which annotated change logs are automatically generated... as a history of CIP files and directories"). CIP-57 has no Specification-versioning section today, and this change is purely additive — it does not introduce a Specification version concept or alter any existing schema.

The `Discussions:` list is updated to add [aiken-lang/aiken#1270](https://github.com/aiken-lang/aiken/issues/1270) — the upstream implementor discussion that motivated this change — alongside the existing aiken-lang/aiken#972 link. Editors who prefer the meta-PR (#1203) to also be appended per CIP-1 § Header Preamble ("must include a link to the pull request that created the CIP and any pull request that modifies it"), please say so and I'll add it.

## Implementors list change

Added `Bloxbean cardano-client-lib` (https://github.com/bloxbean/cardano-client-lib) to the Implementors list — it's been a blueprint consumer for ~2 years, just wasn't listed previously.

## Open questions for reviewers

- **Consistency with existing producer output**: the new section is intended to match what current major producers already emit. Producer maintainers — please confirm (or flag divergence in) the angle-bracket grammar described here for your toolchain.
- **Tuple syntax**: the `Tuple<<A,B>>` (doubled angle bracket) convention is chosen to disambiguate from a single-argument `Tuple<A>`. If reviewers prefer the cleaner `Tuple<A,B>` and accept the ambiguity-with-single-arg edge case, happy to adjust.
- **`title` for parametric types**: should we go further and drop normative content on `title` entirely, leaving only "it's a human-readable hint"? Current draft says SHOULD prefer the unparameterized form to make it useful for code generation, but tolerates the parameterized form. Editor preference welcome.

---

(new text sections added, rendered:)
- [Parametric (generic) types](https://github.com/matiwinnetou/CIPs/tree/cip-0057-generics-syntax/CIP-0057#parametric-generic-types)
- [Parametric type naming](https://github.com/matiwinnetou/CIPs/tree/cip-0057-generics-syntax/CIP-0057#parametric-type-naming)