### PR TITLE
CIP-0099 | Add Lace, Begin Wallet, and Eternl Mobile as implementors

### DIFF
--- a/CIP-0099/README.md
+++ b/CIP-0099/README.md
@@ -10,6 +10,9 @@ Authors:
 Implementors:
 - VESPR Wallet <https://www.vespr.xyz/>
 - Yoroi Wallet <https://yoroi-wallet.com/>
+- Lace <https://www.lace.io/>
+- Begin Wallet <https://begin.is/>
+- Eternl Mobile <https://eternl.io/>
 Discussions:
 - Original PR: https://github.com/cardano-foundation/CIPs/pull/546
 Solution To:


### PR DESCRIPTION
- Add Lace, Begin Wallet, and Eternl Mobile to the CIP-99 Implementors list
- These wallets implement the CIP-99 Proof of Onboarding URI scheme and API
- URLs match the canonical implementor entries already used elsewhere in the repo