### PR TITLE
Repair broken links across CIPs

### DIFF
--- a/CIP-0020/README.md
+++ b/CIP-0020/README.md
@@ -18,7 +18,7 @@ Implementors:
     - Nami Wallet <https://namiwallet.io>
     - CNFT <https://cnft.io>
     - Cardano Explorer <https://cexplorer.io>
-    - SundaeSwap <https://https://sundaeswap.finance/>
+    - SundaeSwap <https://sundaeswap.finance/>
     - Minswap <https://minswap.org/>
     - MuesliSwap <https://muesliswap.com/>
     - DripDropz.io <https://dripdropz.io/>
@@ -53,7 +53,7 @@ Some of the current Tools/Sites/Explorers that have implemented it already:
 * [Nami Wallet](https://namiwallet.io)
 * [CNFT](https://cnft.io)
 * [Cardano Explorer](https://cexplorer.io)
-* [SundaeSwap](https://https://sundaeswap.finance/)
+* [SundaeSwap](https://sundaeswap.finance/)
 * [Minswap](https://minswap.org/)
 * [MuesliSwap](https://muesliswap.com/)
 * [DripDropz.io](https://dripdropz.io/)

--- a/CIP-0022/README.md
+++ b/CIP-0022/README.md
@@ -137,7 +137,7 @@ There is also some overlap with [CIP-0006](https://github.com/cardano-foundation
 ### Acceptance Criteria
 
 - [x] Tools that have implemented, or are implementing, this proposal:
-  - [x] [CNCLI](https://github.com/AndrewWestberg/cncli)
+  - [x] [CNCLI](https://github.com/cardano-community/cncli)
   - [x] [JorManager](https://bitbucket.org/muamw10/jormanager/)
   - [x] [StakePoolOperator Scripts](https://github.com/gitmachtl/scripts)
   - [x] [CNTools](https://cardano-community.github.io/guild-operators/#/Scripts/cntools)

--- a/CIP-0084/README.md
+++ b/CIP-0084/README.md
@@ -30,7 +30,7 @@ the proof-of-stake consensus mechanism used in Cardano.
 
 This CIP aims to give guidance for future CIPs related to the ledger,
 making it a registered category of the CIP process[^1].
-[^1]: See [CIP-1](https://github.com/cardano-foundation/CIPs/blob/cip-cps-rework/CIP-0001/README.md#categories).
+[^1]: See [CIP-1](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0001/README.md#categories).
 While nothing new is added to the usual CIP process,
 expectations for ledger CIPs are made explicit and some background information is provided.
 

--- a/CIP-0095/README.md
+++ b/CIP-0095/README.md
@@ -77,7 +77,7 @@ connector, this specification could be applied to similar standards.
 #### CIP-30 Inherited Data Types
 
 From
-[CIP-30's Data Types](https://github.com/cardano-foundation/CIPs/tree/master/CIP-003/README.md#data-types)
+[CIP-30's Data Types](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0030/README.md#data-types)
 we inherit:
 
 ##### [Address](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0030/README.md#address)

--- a/CIP-0161/README.md
+++ b/CIP-0161/README.md
@@ -1290,7 +1290,7 @@ The introduction of $T_\Phi$ substantially increases the **computational burden*
 
 #### 1.3 Phalanx Cost Amplification per Grinding Attack
 
-Building on the updated **grinding time formula** introduced in the previous section, which incorporates the additional **computational cost** $T_\Phi$, we can now revise the formula for a grinding attack from [CPD Section 3.4.1 - Formula](https://github.com/cardano-foundation/CIPs/tree/master/CPS-0021/CPS/CPD/README.md#341-formula), where we defined a total attack time that must fit within the **grinding opportunity window** $w_O$:
+Building on the updated **grinding time formula** introduced in the previous section, which incorporates the additional **computational cost** $T_\Phi$, we can now revise the formula for a grinding attack from [CPD Section 3.4.1 - Formula](https://github.com/cardano-foundation/CIPs/tree/master/CPS-0021/CPD/README.md#341-formula), where we defined a total attack time that must fit within the **grinding opportunity window** $w_O$:
 
 ```math
 \frac{2^{\rho} \cdot T_{\text{grinding}}^{\text{Phalanx}}}{N_{\text{CPU}}} \leq w_O

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -2972,7 +2972,7 @@ usual mechanisms of governing a hard-fork will be employed.
 <!-- Other protocol references -->
 
 [cps-17]:
-  https://github.com/cardano-scaling/CIPs/blob/settlement-cps/CPS-0017/README.md
+  https://github.com/cardano-foundation/CIPs/blob/master/CPS-0017/README.md
   "CPS-0017"
 [praos-performance]:
   https://github.com/IntersectMBO/cardano-formal-specifications/blob/6d4e5cfc224a24972162e39a6017c273cea45321/src/performance/README.md


### PR DESCRIPTION
Fixes six broken links across existing CIPs. Each replacement target was verified to resolve.

- CIP-0020: remove duplicated `https://` scheme in the SundaeSwap link (two occurrences)
- CIP-0022: update the CNCLI link to its current repository location
- CIP-0084: point the CIP-1 footnote at `master` instead of a deleted branch
- CIP-0095: fix the CIP-30 Data Types link (wrong directory number and path)
- CIP-0161: drop a non-existent path segment in the CPS-0021 CPD link
- CIP-0164: point the CPS-0017 reference at the merged document in this repository