### PR TITLE
Update top-level README: post meeting 137 + add note on obsolete minutes

### DIFF
--- a/BiweeklyMeetings/README.md
+++ b/BiweeklyMeetings/README.md
@@ -1,0 +1,5 @@
+### Notes about Biweekly Meetings
+
+The meeting transcripts were discontinued after the last date posted above because:
+1. Automated transcription at the time was often unintelligble, and the labour of editing to produce something usable was not justified by how few people were actually reading the minutes.
+2. It was therefore resolved (and continues to this day) that meeting updates for each item under review should be put _in that thread on GitHub_ (e.g. a comment or review under that CIP PR): to encourage editor accountability and to keep authors / reviewers fully and immediately informed as part of an interactive engagement.

--- a/README.md
+++ b/README.md
@@ -155,9 +155,12 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 0167 | [Remove isValid from transactions](./CIP-0167) | Proposed |
 | 0170 | [KERI-backed metadata attestations](./CIP-0170) | Proposed |
 | 0171 | [On-chain Smart Contract Bytecode Verification](./CIP-0171) | Proposed |
+| 0173 | [Net Change Limit Parameter](./CIP-0173) | Proposed |
 | 0176 | [Non-segregated Block Body Serialization](./CIP-0176) | Proposed |
 | 0177 | [Ouroboros Tachys - Faster Cardano partner chains](./CIP-0177) | Proposed |
+| 0179 | [On-Chain Surveys and Polls](./CIP-0179) | Proposed |
 | 0181 | [Remove DRep Requirement for Reward Withdrawals](./CIP-0181) | Proposed |
+| 0187 | [Utilization-Scaled Pledge Bonus](./CIP-0187) | Proposed |
 | 0381 | [Plutus Support for Pairings Over BLS12-381](./CIP-0381) | Active |
 | 1694 | [A First Step Towards On-Chain Decentralized Governance](./CIP-1694) | Active |
 | 1852 | [HD (Hierarchy for Deterministic) Wallets for Cardano](./CIP-1852/) | Active |
@@ -166,7 +169,7 @@ CIP editors facilitate discussions and progress submissions on GitHub, reviewing
 | 1855 | [Forging policy keys for HD Wallets](./CIP-1855/) | Proposed |
 | 9999 | [Cardano Problem Statements](./CIP-9999/) | Active |
 
-<p align="right"><i>Last updated on 2026-05-12</i></p>
+<p align="right"><i>Last updated on 2026-06-23</i></p>
 
 > [!NOTE]
 > For more details about CIP statuses, see [CIP-0001 > Statuses](./CIP-0001/README.md#statuses).


### PR DESCRIPTION
Merges:
* https://github.com/cardano-foundation/CIPs/pull/1107
* https://github.com/cardano-foundation/CIPs/pull/1129
* https://github.com/cardano-foundation/CIPs/pull/1193

Also adds a `README` to this folder to explain why (as I've noticed with new eyes today) why our CIP meeting minutes ended in September 2022 and what we've been doing instead: https://github.com/rphair/CIPs/tree/meeting-137-updates/BiweeklyMeetings#readme