### PR TITLE
CIP-0116 | fix incorrect required property in Conway schema

### DIFF
--- a/CIP-0116/cardano-conway.json
+++ b/CIP-0116/cardano-conway.json
@@ -244,7 +244,7 @@
               "$ref": "cardano-conway.json#/definitions/Ed25519KeyHash"
             }
           },
-          "required": ["tag", "credential"],
+          "required": ["tag", "pubkey_hash"],
           "unevaluatedProperties": false
         }
       ]


### PR DESCRIPTION
For SPO `Voter` objects, `Credential` was required
`Credential`s aren't used to represent SPOs
instead `pubkey_hash` is correct,
matching the exiting propertises.