### PR TITLE
CIP-0164 | Leios Mini-Protocols

### DIFF
--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -116,6 +116,7 @@ technical resources, visit the Leios Innovation R&D site at
 - [Figure 6: LeiosVotes mini-protocol state machine](#figure-6b)
 - [Figure 6: LeiosBlockNotify mini-protocol state machine](#figure-6c)
 - [Figure 7: LeiosFetch mini-protocol state machine](#figure-7)
+- [Figure:   Protocol Pipelining](#figure-protocol-pipelining)
 - [Figure 8: SPO profitability forecast under Leios](#figure-8)
 - [Figure 9: Time for transaction to reach the ledger](#figure-9)
 - [Figure 10: Transactions reaching the ledger](#figure-10)
@@ -1353,20 +1354,34 @@ latency between peers.
 
 > **Definition of pipelining:**
 >
-> Protocol pipelining with a factor N conceptually runs N instances of a mini-protocol on a
-> single multiplexer subchannel for the given protocol ID. Each instance tracks
-> its own state and agency as per the specification. One protocol state is
-> marked as the switch state; the switch state must be one in which the
-> initiator has agency. The subchannel is governed by a pair of multiplexers,
-> one for sending and one for receiving, that behave in round-robin fashion
-> across the N instances, starting at the first instance. Requests from the
-> node are forwarded by the sending multiplexer to the currently selected
-> instance and sending the resulting protocol message to the network; whenever
-> having sent a message from the switch state, the send multiplexer selects the
-> next instance. The receive multiplexer forwards received messages from the
-> network to the currently selected protocol instance; whenever receiving a
-> message that transitions that instance into the switch state, the receive
-> multiplexer selects the next instance.
+> Protocol pipelining is a latency hiding technique commonly used in CPUs and
+> networking to improve protocol performance.   It is done by sending requests
+> without awaiting for results, and collecting them (in order of the requests)
+> as they arrive. Protocol pipelining doesn't require to change state machine
+> of the protocol, it just modifies timing of events on the pipelining side.
+> Importantly, the server side doesn't need to be implemented in any special
+> way other than to follow the protocol state machine.  The pipelining of
+> messages needs to be done from the same state in which a client has the
+> agency, which we call switch state.  The client can pipeline requests that
+> leave the switch state and later collect responses which shift the agency
+> back to the switch state.  A single protocol might have more than one switch
+> state, but it's not possible to pipeline messages from different switch
+> states.  It is also not necessary that the server immediately yields back
+> control to the client (`LeiosFetch` is an example of such a protocol).
+> Protocol pipelining on the client side can be implemented without
+> concurrency, although parallel implementations tend to perform better, simply
+> because the main mini-protocol thread can pipeline requests without being
+> blocked on computations done when receiving responses.  Below is an example
+> of protocol pipelining evolution for a simple ping-pong protocol.
+
+<div align="center">
+<a name="figure-protocol-pipelining" id="figure-protocol-pipelining"></a>
+
+![Protocol Pipelining](images/protocol-pipelining.svg)
+
+<em>Figure: Protocol Pipelining, image by [Mwhitlock](https://commons.wikimedia.org/w/index.php?title=User:Mwhitlock&action=edit&redlink=1), licensed under Public Domain</em>
+
+</div>
 
 In the three mini-protocols above, StIdle is the switch state. In case maximum
 buffering commitment shall be made for 1000 responses, one could e.g. choose a

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -1186,6 +1186,10 @@ improvements.
   Peras vote requests, Mithril's Decentralized Message Queue, and likely
   additional protocols in the future. There is opportunity for significant code
   reuse even if the mini-protocols themselves are separate.
+- **Client Side Control**.  The client side of each mini-protocol needs to be
+  in control to terminate a mini-protocol within a timeframe of `300s` to ensure
+  the node can cleanly demote a peer from hot to warm (see [clean
+  termination](#clean-termination)).
 
 **Discussion**
 
@@ -1249,6 +1253,8 @@ the node as the client in one and the server in the other. Recall that Cardano's
 topology results in each relay having many more downstream peers than upstream
 peers. Syncing peers will be discussed below.
 
+##### LeiosAnnounce Mini-Protocol
+
 <div align="center">
 <a name="figure-6a" id="figure-6a"></a>
 
@@ -1266,6 +1272,7 @@ graph LR
    StIdle -->|"MsgLeiosAnnounceRequestNext(N)"| StBusy
    StBusy -->|"MsgLeiosBlockAnnouncement<br>{ if tokens > 1; tokens −= 1}"| StBusy
    StBusy -->|"MsgLeiosBlockAnnouncement<br>{ if tokens = 1 }"| StIdle
+   StBusy -->|"MsgLeiosNoBlockAnnouncement"| StIdle
 
    StIdle -->|MsgDone| StDone
 ```
@@ -1284,6 +1291,34 @@ after each 100 received). Sending the next request before the previous one has
 been fully responded to is not modeled explicitly but supported implicitly via
 protocol pipelining as usual, see below for a definition.
 
+###### Clean termination
+
+We need `MsgLeiosNoBlockAnnouncement` message in order to retain the ability for
+the client to terminate a mini-protocol within a reasonable time limit.
+Without such a message, the server after receiving `MsgLeiosVotesRequestNext`
+will block until data is available, which might or might not happen quickly
+enough.  To avoid unclean mini-protocol shutdown, `MsgLeiosNoBlockAnnouncement`
+can be used, which gives back the agency to the client, which can decide
+whether to continue the mini-protocol (e.g. further await for data
+availability) or terminate the mini-protocol with `MsgDone`.  The
+`cardano-node` implementation deactivation timeout is set to `300s`.  Note that
+this timeout must still be preserved if the mini-protocol is pipelined, e.g. if
+we pipeline five `MsgLeiosAnnounceRequestNext` messages, and we send
+`MsgLeiosNoBlockAnnouncement` after `10s`, it will take the client exactly `50s`
+to await for all the pipelined `MsgLeiosAnnounceRequestNext` replies to
+arrive before it will be able to send `MsgDone` and terminate the
+mini-protocol.  Thus the time after which `MsgLeiosNoBlockAnnouncement` must be
+sent limits how many `MsgLeiosAnnounceRequestNext` messages can be pipelined.
+This note applies to all the other mini-protocols: `LeiosVotes`
+(`MsgLeiosNoVotes`) and `LeiosBlockNotify` (`MsgLeiosBlockNoOffers`).
+If a mini-protocol is not shutdown cleanly (e.g. it didn't send `MsgDone`)
+within the deactivation timeout, then the whole connection is terminated, and
+thus non-clean shutdowns should be avoided.  There's a clear tradeoff between
+latency of termination and how much overhead is added by sending
+`MsgLeiosNoBlockAnnouncement` too frequently.
+
+##### LeiosVotes Mini-Protocol
+
 <div align="center">
 <a name="figure-6b" id="figure-6b"></a>
 
@@ -1301,6 +1336,7 @@ graph LR
    StIdle -->|"MsgLeiosVotesRequestNext(N)"| StBusy
    StBusy -->|"MsgLeiosVote<br>{ if tokens > 1; tokens −= 1}"| StBusy
    StBusy -->|"MsgLeiosVote<br>{ if tokens = 1 }"| StIdle
+   StBusy -->|"MsgLeiosNoVotes"| StIdle
 
    StIdle -->|MsgDone| StDone
 ```
@@ -1314,6 +1350,11 @@ quickly as possible throughout the network. Since votes are small, no
 separate round-trip for requesting them is needed, downstream just keeps
 supplying the upstream with tokens so that under normal conditions the upstream
 can typically send immediately.
+
+See the [clean termination](#clean-termination) section why `MsgLeiosNoVotes`
+is needed, and how to design a timeout on `MsgLeiosVotesRequestNext` replies.
+
+##### LeiosBlockNotify Mini-Protocol
 
 <div align="center">
 <a name="figure-6c" id="figure-6c"></a>
@@ -1332,6 +1373,7 @@ graph LR
    StIdle -->|"MsgLeiosBlockNotifyRequestNext(N)"| StBusy
    StBusy -->|"MsgLeiosBlockOffer<br>{ if tokens > 1; tokens −= 1}<br><br>MsgLeiosBlockTxsOffer<br>{ if tokens > 1; tokens −= 1}"| StBusy
    StBusy -->|"MsgLeiosBlockOffer<br>{ if tokens = 1 }<br><br>MsgLeiosBlockTxsOffer<br>{ if tokens = 1 }"| StIdle
+   StBusy -->|"MsgLeiosBlockNoOffers"| StIdle
 
    StIdle -->|MsgDone| StDone
 ```
@@ -1345,6 +1387,9 @@ signals downstream that a previously announced block is now ready for download
 or that its set of referenced transactions is now fully available. Both of
 these may trigger the downstraem to fetch information from the upstream using
 the next protocol below.
+
+See the [clean termination](#clean-termination) section why `MsgLeiosBlockNoOffers`
+is needed, and how to design a timeout on `MsgLeiosBlockNotifyRequestNext` replies.
 
 It is important to note that the protocols above should be combined with
 pipelining, meaning that the request for the next batch of responses should be
@@ -1389,6 +1434,8 @@ pipelining depth of 2 with a request count of 500 each or a depth of 10 with a
 request count of 100 each; the latter would keep the worst-case demand level
 higher than the former at the price of sending slightly more data towards the
 responder.
+
+##### LeiosFetch Mini-Protocol
 
 <div align="center">
 <a name="figure-7" id="figure-7"></a>
@@ -1445,6 +1492,15 @@ received all messages related to an EB. For example, the client can send
 MsgLeiosBlockRequest as soon as it receives MsgLeiosBlockOffer, even if it has
 not yet received MsgLeiosBlockTxsOffer.
 
+See the [clean termination](#clean-termination) section how to design the
+timeouts on the `StMultiBlock` and `StBlockTxs` states.  Note that this
+protocol doesn't require responses indicating that there's no more data
+available, simply because the client is requesting data assumed to be available
+on the server rather than asking for a next update available in the future.
+Still, timeouts need to be designed to allow the mini-protocol to terminate
+cleanly within `300s` also in the presence of protocol-pipelining.
+
+
 <div align="center">
 <a name="table-4" id="table-4"></a>
 
@@ -1452,11 +1508,14 @@ not yet received MsgLeiosBlockTxsOffer.
 | ------- | ------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | Client→ | MsgLeiosAnnounceRequestNext     | integer N                      | Requests N Leios block announcement                                                                      |
 | ←Server | MsgLeiosBlockAnnouncement       | slot, EB hash, block_height    | The server has seen an EB announcement for this point and block_height                                   |
+| ←Server | MsgLeiosNoBlockAnnouncement     |                                | The server hasn't seen an EB announcement                                                                |
 | Client→ | MsgLeiosVotesRequestNext        | integer N                      | Requests N Leios votes                                                                                   |
 | ←Server | MsgLeiosVote                    | vote                           | A Leios vote                                                                                             |
+| ←Server | MsgLeiosNoVotes                 |                                | No Leios vote is available                                                                               |
 | Client→ | MsgLeiosBlockNotifyRequestNext  | integer N                      | Requests N Leios block notifications                                                                     |
 | ←Server | MsgLeiosBlockOffer              | slot, EB hash, block_height    | The server can immediately deliver this block                                                            |
 | ←Server | MsgLeiosBlockTxsOffer           | slot, EB hash, block_height    | The server can immediately deliver any transaction referenced by this block                              |
+| ←Server | MsgLeiosBlockNoOffers           |                                | The server has no block or txs to offer                                                                  |
 | Client→ | MsgLeiosMultiBlockRequest       | list of EB hashes              | Requests the EBs and all referenced transactions for the given EB hashes                                 |
 | ←Server | MsgLeiosBlock                   | EB block, list of transactions | A block requested in the previous MsgLeiosMultiBlockRequest                                              |
 | ←Server | MsgLeiosNoMoreBlocks            | $\emptyset$                    | All blocks from the previous MsgLeiosMultiBlockRequest have been delivered                               |

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -138,13 +138,16 @@ technical resources, visit the Leios Innovation R&D site at
 - [Table 1: Network Characteristics](#table-1)
 - [Table 2: Ledger Characteristics](#table-2)
 - [Table 3: Protocol Parameters](#table-3)
-- [Table 4: Leios Information Exchange Requirements (IER) table](#table-4)
-- [Table 5: Performance Metrics](#table-5)
-- [Table 6: Leios efficiency at different throughputs](#table-6)
-- [Table 7: Feasible Protocol Parameters](#table-7)
-- [Table 8: Operating Costs by Transaction Throughput](#table-8)
-- [Table 9: Required TPS for Infrastructure Cost Coverage](#table-9)
-- [Table 10: Required TPS for Current Reward Maintenance](#table-10)
+- [Table 4: LeiosAnnounce Information Exchange Requirements (IER) table](#table-4)
+- [Table 5: LeiosVotes Information Exchange Requirements (IER) table](#table-5)
+- [Table 6: LeiosBlockNotify Information Exchange Requirements (IER) table](#table-6)
+- [Table 7: LeiosFetch Information Exchange Requirements (IER) table](#table-7)
+- [Table 8: Performance Metrics](#table-8)
+- [Table 9: Leios efficiency at different throughputs](#table-9)
+- [Table 10: Feasible Protocol Parameters](#table-10)
+- [Table 11: Operating Costs by Transaction Throughput](#table-11)
+- [Table 12: Required TPS for Infrastructure Cost Coverage](#table-12)
+- [Table 13: Required TPS for Current Reward Maintenance](#table-13)
 
 </details>
 
@@ -1291,6 +1294,26 @@ after each 100 received). Sending the next request before the previous one has
 been fully responded to is not modeled explicitly but supported implicitly via
 protocol pipelining as usual, see below for a definition.
 
+The required exchange between two neighboring nodes is captured by the
+following [Information Exchange Requirements table](#table-4). For the sake of
+minimizing this proposal, each row is a mini-protocol message, but that
+correspondence does not need to remain one-to-one as the mini-protocols evolve
+over time. Note that the table does not list the messages in the anticipated
+chronological order.
+
+<div align="center">
+<a name="table-4" id="table-4"></a>
+
+| Sender  | Name                            | Arguments                      | Semantics                                                                                                |
+| ------- | ------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Client→ | MsgLeiosAnnounceRequestNext     | integer N                      | Requests N Leios block announcement                                                                      |
+| ←Server | MsgLeiosBlockAnnouncement       | slot, EB hash, block_height    | The server has seen an EB announcement for this point and block_height                                   |
+| ←Server | MsgLeiosNoBlockAnnouncement     |                                | The server hasn't seen an EB announcement                                                                |
+
+<em>Table 4: LeiosAnnounce Information Exchange Requirements table</em>
+
+</div>
+
 ###### Clean termination
 
 We need `MsgLeiosNoBlockAnnouncement` message in order to retain the ability for
@@ -1301,19 +1324,21 @@ enough.  To avoid unclean mini-protocol shutdown, `MsgLeiosNoBlockAnnouncement`
 can be used, which gives back the agency to the client, which can decide
 whether to continue the mini-protocol (e.g. further await for data
 availability) or terminate the mini-protocol with `MsgDone`.  The
-`cardano-node` implementation deactivation timeout is set to `300s`.  Note that
-this timeout must still be preserved if the mini-protocol is pipelined, e.g. if
-we pipeline five `MsgLeiosAnnounceRequestNext` messages, and we send
-`MsgLeiosNoBlockAnnouncement` after `10s`, it will take the client exactly `50s`
-to await for all the pipelined `MsgLeiosAnnounceRequestNext` replies to
+`cardano-node` implementation deactivation timeout is set to `300s` - it is the
+time that the outbound governor gives to each mini-protocol to terminate before
+the connection will be reset.  Note that this timeout must still be preserved
+if the mini-protocol is pipelined, e.g. if we pipeline five
+`MsgLeiosAnnounceRequestNext` messages, and we send
+`MsgLeiosNoBlockAnnouncement` after `10s`, it will take the client exactly
+`50s` to await for all the pipelined `MsgLeiosAnnounceRequestNext` replies to
 arrive before it will be able to send `MsgDone` and terminate the
 mini-protocol.  Thus the time after which `MsgLeiosNoBlockAnnouncement` must be
 sent limits how many `MsgLeiosAnnounceRequestNext` messages can be pipelined.
 This note applies to all the other mini-protocols: `LeiosVotes`
-(`MsgLeiosNoVotes`) and `LeiosBlockNotify` (`MsgLeiosBlockNoOffers`).
-If a mini-protocol is not shutdown cleanly (e.g. it didn't send `MsgDone`)
-within the deactivation timeout, then the whole connection is terminated, and
-thus non-clean shutdowns should be avoided.  There's a clear tradeoff between
+(`MsgLeiosNoVotes`) and `LeiosBlockNotify` (`MsgLeiosBlockNoOffers`). If
+a mini-protocol is not shutdown cleanly (e.g. it didn't send `MsgDone`) within
+the deactivation timeout, then the whole connection is terminated, and thus
+non-clean shutdowns should be avoided.  There's a clear tradeoff between
 latency of termination and how much overhead is added by sending
 `MsgLeiosNoBlockAnnouncement` too frequently.
 
@@ -1354,6 +1379,22 @@ can typically send immediately.
 See the [clean termination](#clean-termination) section why `MsgLeiosNoVotes`
 is needed, and how to design a timeout on `MsgLeiosVotesRequestNext` replies.
 
+The required exchange between two neighboring nodes is captured by the
+following [Information Exchange Requirements table](#table-5).
+
+<div align="center">
+<a name="table-5" id="table-5"></a>
+
+| Sender  | Name                            | Arguments                      | Semantics                                                                                                |
+| ------- | ------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Client→ | MsgLeiosVotesRequestNext        | integer N                      | Requests N Leios votes                                                                                   |
+| ←Server | MsgLeiosVote                    | vote                           | A Leios vote                                                                                             |
+| ←Server | MsgLeiosNoVotes                 |                                | No Leios vote is available                                                                               |
+
+<em>Table 5: LeiosVotes Information Exchange Requirements table</em>
+
+</div>
+
 ##### LeiosBlockNotify Mini-Protocol
 
 <div align="center">
@@ -1387,6 +1428,23 @@ signals downstream that a previously announced block is now ready for download
 or that its set of referenced transactions is now fully available. Both of
 these may trigger the downstraem to fetch information from the upstream using
 the next protocol below.
+
+The required exchange between two neighboring nodes is captured by the
+following [Information Exchange Requirements table](#table-6).
+
+<div align="center">
+<a name="table-6" id="table-6"></a>
+
+| Sender  | Name                            | Arguments                      | Semantics                                                                                                |
+| ------- | ------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Client→ | MsgLeiosBlockNotifyRequestNext  | integer N                      | Requests N Leios block notifications                                                                     |
+| ←Server | MsgLeiosBlockOffer              | slot, EB hash, block_height    | The server can immediately deliver this block                                                            |
+| ←Server | MsgLeiosBlockTxsOffer           | slot, EB hash, block_height    | The server can immediately deliver any transaction referenced by this block                              |
+| ←Server | MsgLeiosBlockNoOffers           |                                | The server has no block or txs to offer                                                                  |
+
+<em>Table 6: LeiosBlockNotify Information Exchange Requirements table</em>
+
+</div>
 
 See the [clean termination](#clean-termination) section why `MsgLeiosBlockNoOffers`
 is needed, and how to design a timeout on `MsgLeiosBlockNotifyRequestNext` replies.
@@ -1481,17 +1539,6 @@ proposal for the bitmap representation is inspired by roaring bitmaps:
   chunk (for values `C*64..(C+1)*64`) and the following eight octets contain
   a bitmap of which values of this chunk are in the requested set
 
-The required exchange between two neighboring nodes is captured by the
-following Information Exchange Requirements table (IER table). For the sake of
-minimizing this proposal, each row is a mini-protocol message, but that
-correspondence does not need to remain one-to-one as the mini-protocols evolve
-over time. Note that the table does not list the messages in the anticipated
-chronological order; they're grouped by request/response semantics. The
-mini-protocols permit the client to react to some messages before it has
-received all messages related to an EB. For example, the client can send
-MsgLeiosBlockRequest as soon as it receives MsgLeiosBlockOffer, even if it has
-not yet received MsgLeiosBlockTxsOffer.
-
 See the [clean termination](#clean-termination) section how to design the
 timeouts on the `StMultiBlock` and `StBlockTxs` states.  Note that this
 protocol doesn't require responses indicating that there's no more data
@@ -1500,29 +1547,25 @@ on the server rather than asking for a next update available in the future.
 Still, timeouts need to be designed to allow the mini-protocol to terminate
 cleanly within `300s` also in the presence of protocol-pipelining.
 
+The required exchange between two neighboring nodes is captured by the
+following [Information Exchange Requirements table](#table-7).
+The mini-protocols permit the client to react to some messages before it has
+received all messages related to an EB. For example, the client can send
+MsgLeiosMultiBlockRequest as soon as it receives MsgLeiosBlockOffer, even if it
+has not yet received MsgLeiosBlockTxsOffer.
 
 <div align="center">
-<a name="table-4" id="table-4"></a>
+<a name="table-7" id="table-7"></a>
 
 | Sender  | Name                            | Arguments                      | Semantics                                                                                                |
 | ------- | ------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Client→ | MsgLeiosAnnounceRequestNext     | integer N                      | Requests N Leios block announcement                                                                      |
-| ←Server | MsgLeiosBlockAnnouncement       | slot, EB hash, block_height    | The server has seen an EB announcement for this point and block_height                                   |
-| ←Server | MsgLeiosNoBlockAnnouncement     |                                | The server hasn't seen an EB announcement                                                                |
-| Client→ | MsgLeiosVotesRequestNext        | integer N                      | Requests N Leios votes                                                                                   |
-| ←Server | MsgLeiosVote                    | vote                           | A Leios vote                                                                                             |
-| ←Server | MsgLeiosNoVotes                 |                                | No Leios vote is available                                                                               |
-| Client→ | MsgLeiosBlockNotifyRequestNext  | integer N                      | Requests N Leios block notifications                                                                     |
-| ←Server | MsgLeiosBlockOffer              | slot, EB hash, block_height    | The server can immediately deliver this block                                                            |
-| ←Server | MsgLeiosBlockTxsOffer           | slot, EB hash, block_height    | The server can immediately deliver any transaction referenced by this block                              |
-| ←Server | MsgLeiosBlockNoOffers           |                                | The server has no block or txs to offer                                                                  |
 | Client→ | MsgLeiosMultiBlockRequest       | list of EB hashes              | Requests the EBs and all referenced transactions for the given EB hashes                                 |
 | ←Server | MsgLeiosBlock                   | EB block, list of transactions | A block requested in the previous MsgLeiosMultiBlockRequest                                              |
 | ←Server | MsgLeiosNoMoreBlocks            | $\emptyset$                    | All blocks from the previous MsgLeiosMultiBlockRequest have been delivered                               |
 | Client→ | MsgLeiosBlockTxsRequest         | EB hash, list of integers      | For the referenced EB, request a list of transactions identified by their sequence number within that EB |
 | ←Server | MsgLeiosBlockTxs                | list of transactions           | The transactions from an earlier MsgLeiosBlockTxsRequest                                                 |
 
-<em>Table 4: Leios Information Exchange Requirements table (IER table)</em>
+<em>Table 7: LeiosFetch Information Exchange Requirements table</em>
 
 </div>
 
@@ -1845,7 +1888,7 @@ these appear in the following section on Simulation Results. Additionally,
 future implementations of Leios can be assessed in these terms.
 
 <div align="center">
-<a name="table-5" id="table-5"></a>
+<a name="table-8" id="table-8"></a>
 
 |  Category  | Metric                                             | Measurement                                                                                           |
 | :--------: | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -1861,7 +1904,7 @@ future implementations of Leios can be assessed in these terms.
 |            | Peak CPU usage, $\hat{q}_\text{vcpu}$              | Maximum virtual CPU cores used by a node over a one-slot window                                       |
 | Resilience | Adversarial stake, $\eta_\text{adversary}(s)$      | Fractional loss in throughput due to adversarial stake of $s$                                         |
 
-<em>Table 5: Performance Metrics</em>
+<em>Table 8: Performance Metrics</em>
 
 </div>
 
@@ -2014,7 +2057,7 @@ the stake distribution in the `mini-mainnet` topology this results in a
 committee size of 208, less than the ideal size. We therefore also ran it with a
 1500 `midi-mainnet`, derived similarly, which produces a committee size of 448 —
 both lower than the ~916 voters implied by the $\sigma_c = 0.99$ default in
-[Table 7](#table-7) on mainnet stake. The results of all these tests are
+[Table 10](#table-10) on mainnet stake. The results of all these tests are
 documented in the [2026w18 analysis][2026w18].
 
 The table below summarizes the
@@ -2026,7 +2069,7 @@ conditions. In all cases there is little overhead, relative to the total bytes
 of transactions, in data that must be stored permanently as the ledger history.
 
 <div align="center">
-<a name="table-6" id="table-6"></a>
+<a name="table-9" id="table-9"></a>
 
 | Throughput [TxMB/s] | TPS at 1500 B/tx | Conditions    | Mempool to EB [s] | Mempool to ledger [s] | Space efficiency [%] |
 | ------------------: | ---------------: | ------------- | ----------------: | --------------------: | -------------------: |
@@ -2036,7 +2079,7 @@ of transactions, in data that must be stored permanently as the ledger history.
 |               0.300 |            200.0 | congestion    |              38.2 |                  76.4 |                 95.8 |
 |               0.350 |            233.3 | over capacity |              95.4 |                 134.2 |                 95.7 |
 
-<em>Table 6: Leios efficiency at different throughputs</em>
+<em>Table 9: Leios efficiency at different throughputs</em>
 
 </div>
 
@@ -2435,7 +2478,7 @@ choice of parameters for Cardano mainnet must be subject to discussion and
 consideration of tradeoffs.
 
 <div align="center">
-<a name="table-7" id="table-7"></a>
+<a name="table-10" id="table-10"></a>
 
 | Parameter                                     |      Symbol      |   Feasible value   | Justification                                                                                                                                                                                                                                                  |
 |-----------------------------------------------|:----------------:|:------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -2450,7 +2493,7 @@ consideration of tradeoffs.
 | Committee stake coverage                      |    $\sigma_c$    |        0.99        | At 99% cumulative stake the committee comprises ~916 pools (mainnet epoch 612), yielding certificates of ~203 B and vote traffic bounded by the stake-distribution tail. See [Alternatives & Extensions](#alternatives--extensions) for the coverage analysis. |
 | Quorum stake threshold                        |      $\tau$      |        0.75        | Votes representing ≥75% of total active stake must sign; ensures certified EBs are attested by >25% of honest stake even with 50% adversarial stake. Must satisfy $\tau < \sigma_c$.                                                                           |
 
-<em>Table 7: Feasible Protocol Parameters</em>
+<em>Table 10: Feasible Protocol Parameters</em>
 
 </div>
 
@@ -2527,7 +2570,7 @@ pricing of ten common hyperscale and discount cloud providers. The cost of a
 increase each month as the ledger becomes larger.
 
 <div align="center">
-<a name="table-8" id="table-8"></a>
+<a name="table-11" id="table-11"></a>
 
 | Throughput | Average-size transactions | Small transactions | Per-node operation | Per-node storage<br/>($) | Per-node storage<br/>(GB) | 10k-node network<br/>(first year) | 10k-node network<br/>(first year) |
 | ---------: | ------------------------: | -----------------: | -----------------: | -----------------------: | ------------------------: | --------------------------------: | --------------------------------: |
@@ -2537,7 +2580,7 @@ increase each month as the ledger becomes larger.
 | 300 TxkB/s |                  200 Tx/s |          1000 Tx/s |      $138.88/month |            $54.64/month² |              788 GB/month |                            $19.8M |                       $271k/epoch |
 | 350 TxkB/s |                  233 Tx/s |          1167 Tx/s |      $148.47/month |            $65.59/month² |              920 GB/month |                            $21.8M |                       $298k/epoch |
 
-<em>Table 8: Operating Costs by Transaction Throughput</em>
+<em>Table 11: Operating Costs by Transaction Throughput</em>
 
 </div>
 
@@ -2549,7 +2592,7 @@ split, fives times as much fee would have to be collected compared to what is
 listed in the table.
 
 <div align="center">
-<a name="table-9" id="table-9"></a>
+<a name="table-12" id="table-12"></a>
 
 | Infrastructure cost | Required ADA<br/>@ $0.45/ADA | Required transactions<br/>(average size)<br/>@ $0.45/ADA | Required transactions<br/>(small size)<br/>@ $0.45/ADA |
 | ------------------: | ---------------------------: | -------------------------------------------------------: | -----------------------------------------------------: |
@@ -2559,7 +2602,7 @@ listed in the table.
 |         $19.8M/year |               603k ADA/epoch |                                                6.43 Tx/s |                                              8.39 Tx/s |
 |         $21.8M/year |               622k ADA/epoch |                                                7.06 Tx/s |                                              9.21 Tx/s |
 
-<em>Table 9: Required TPS for Infrastructure Cost Coverage</em>
+<em>Table 12: Required TPS for Infrastructure Cost Coverage</em>
 
 </div>
 
@@ -2567,7 +2610,7 @@ _Required TPS for Current Reward Maintenance:_ To maintain current reward levels
 (~48 million ADA monthly) through transaction fees as the Reserve depletes.
 
 <div align="center">
-<a name="table-10" id="table-10"></a>
+<a name="table-13" id="table-13"></a>
 
 | Year | Reserve Depletion | Rewards from Fees (ADA) | Required TPS (Average size) | Required Throughput |
 | ---: | ----------------: | ----------------------: | --------------------------: | ------------------: |
@@ -2578,7 +2621,7 @@ _Required TPS for Current Reward Maintenance:_ To maintain current reward levels
 | 2029 |              ~43% |              20,640,000 |                        36.1 |           51 TxkB/s |
 | 2030 |              ~50% |              24,000,000 |                        41.9 |           59 TxkB/s |
 
-<em>Table 10: Required TPS for Current Reward Maintenance</em>
+<em>Table 13: Required TPS for Current Reward Maintenance</em>
 
 </div>
 

--- a/CIP-0164/images/protocol-pipelining.svg
+++ b/CIP-0164/images/protocol-pipelining.svg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="640.01312"
+   height="444.84097"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docname="HTTP_pipelining.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend"
+       style="overflow:visible">
+      <path
+         id="path3690"
+         style="font-size:12px;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.97309,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1329206"
+     inkscape:cx="321.68934"
+     inkscape:cy="226.21448"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1272"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="503" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-35.905901,-264.97417)">
+    <g
+       id="g12702">
+      <g
+         transform="translate(22.029626,-89.095098)"
+         id="g9353">
+        <g
+           style="fill:#0000ff;fill-opacity:1"
+           id="g10980">
+          <path
+             id="path5514"
+             d="M 100.125,461.875 L 99.875,462.84375 L 244.875,497.84375 L 245.125,496.875 L 100.125,461.875 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path10986"
+             style="font-size:12px;fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+             d="M 235.64913,490.54053 L 246.29508,497.65666 L 233.57515,499.13276 C 236.05383,497.04685 236.88073,493.57399 235.64913,490.54053 z" />
+        </g>
+        <g
+           style="fill:#800080;fill-opacity:1"
+           id="g10988">
+          <path
+             id="path8293"
+             d="M 249.8125,501.90625 L 104.8125,556.90625 L 105.1875,557.84375 L 250.1875,502.84375 L 249.8125,501.90625 z"
+             style="fill:#800080;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path10994"
+             style="font-size:12px;fill:#800080;fill-opacity:1;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+             d="M 116.56918,557.71945 L 103.76455,557.84964 L 113.4344,549.45502 C 112.56454,552.57563 113.84098,555.90959 116.56918,557.71945 z" />
+        </g>
+      </g>
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(0,100)"
+         id="use9357"
+         xlink:href="#g9353"
+         y="0"
+         x="0" />
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(0,200)"
+         id="use9359"
+         xlink:href="#g9353"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       id="g9363"
+       transform="translate(22.029626,-89.095098)">
+      <text
+         xml:space="preserve"
+         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+         x="249.793"
+         y="441.27173"
+         id="text12646"
+         sodipodi:linespacing="100%"><tspan
+           sodipodi:role="line"
+           id="tspan12648"
+           x="249.793"
+           y="441.27173">server</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:20.00006866px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+         x="99.895203"
+         y="441.27325"
+         id="text12642"
+         sodipodi:linespacing="100%"
+         transform="scale(1.0000034,0.9999966)"><tspan
+           sodipodi:role="line"
+           id="tspan12644"
+           x="99.895203"
+           y="441.27325">client</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         id="path2385"
+         d="M 100,452.36218 L 100,777.36218"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;marker-start:none;marker-end:url(#Arrow2Lend);stroke-opacity:1" />
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(150,0)"
+         id="use9361"
+         xlink:href="#path2385"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       id="g12713">
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(350,0)"
+         id="use9393"
+         xlink:href="#g9353"
+         y="0"
+         x="0" />
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(0,20)"
+         id="use9395"
+         xlink:href="#use9393"
+         y="0"
+         x="0" />
+      <use
+         height="1052.3622"
+         width="744.09448"
+         transform="translate(0,40)"
+         id="use9397"
+         xlink:href="#use9393"
+         y="0"
+         x="0" />
+    </g>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g9363"
+       id="use9369"
+       transform="translate(350,0)"
+       width="744.09448"
+       height="1052.3622" />
+    <g
+       id="g12624">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path11554"
+         d="M 110,367.36218 L 135.228,367.36218"
+         style="fill:none;fill-rule:evenodd;stroke:#00c000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         sodipodi:linespacing="100%"
+         id="text12610"
+         y="372.13232"
+         x="105.63217"
+         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:100%;writing-mode:lr-tb;text-anchor:end;fill:#00c000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+         xml:space="preserve"><tspan
+           y="372.13232"
+           x="105.63217"
+           id="tspan12612"
+           sodipodi:role="line">open</tspan></text>
+    </g>
+    <g
+       id="g12629">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 110,672.36218 L 135.228,672.36218"
+         id="path12614"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:100%;writing-mode:lr-tb;text-anchor:end;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+         x="105.48569"
+         y="677.13257"
+         id="text12620"
+         sodipodi:linespacing="100%"><tspan
+           sodipodi:role="line"
+           id="tspan12622"
+           x="105.48569"
+           y="677.13257">close</tspan></text>
+    </g>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g12624"
+       id="use12634"
+       transform="translate(350,0)"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g12629"
+       id="use12636"
+       transform="translate(350,-160)"
+       width="744.09448"
+       height="1052.3622" />
+    <g
+       id="g11549"
+       transform="translate(30.769653,-64.101661)">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path11020"
+         d="M 340,592.36218 L 340,632.36218"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;marker-end:url(#Arrow2Lend);stroke-opacity:1" />
+      <text
+         transform="matrix(0,1,-1,0,0,0)"
+         sodipodi:linespacing="100%"
+         id="text10996"
+         y="-334.89087"
+         x="583.62335"
+         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:100%;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+         xml:space="preserve"><tspan
+           y="-334.89087"
+           x="583.62335"
+           id="tspan10998"
+           sodipodi:role="line">time</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+       x="198.20439"
+       y="298.79773"
+       id="text12718"
+       sodipodi:linespacing="100%"><tspan
+         sodipodi:role="line"
+         id="tspan12720"
+         x="198.20439"
+         y="298.79773">no pipelining</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Calibri,sans-serif;-inkscape-font-specification:Calibri"
+       x="548.20441"
+       y="298.79773"
+       id="text12722"
+       sodipodi:linespacing="100%"><tspan
+         sodipodi:role="line"
+         id="tspan12724"
+         x="548.20441"
+         y="298.79773">pipelining</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
* Edited the paragraph on protocol pipelining
* Added three messages:
  - `MsgLeiosNoBlockAnnouncement` (`LeiosAnnounce` mini-protocol)
  - `MsgLeiosNoVotes` (`LeiosVotes` mini-protocol)
  - `MsgLeiosBlockNoOffers` (`LeiosBlockNotify` mini-protocol)
* Split the mini-protocols IER table into four parts, one per mini-protocol.