### PR TITLE
CIP-0010 | add Eternl Pro and Open CryptoPay

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -136,6 +136,14 @@
     "description": "PRISM's Verifiable Data Registry for the PRISM DID method"
   },
   {
+    "transaction_metadatum_label": 37326,
+    "description": "Eternl Pro - license metadata"
+  },
+  {
+    "transaction_metadatum_label": 49314,
+    "description": "Open CryptoPay - payment identification and reconciliation metadata"
+  },
+  {
     "transaction_metadatum_label": 61284,
     "description": "CIP-0015 - Catalyst registration"
   },


### PR DESCRIPTION
## Summary

This registers two transaction metadata labels used by Eternl:

- `37326`: Eternl Pro license metadata
- `49314`: Open CryptoPay payment identification and reconciliation metadata

## Background

Eternl Pro already uses label `37326` for on-chain license metadata. This
metadata anchors public license records used by Eternl's license verification
and entitlement flow. The label is already in active on-chain use but was
previously missing from the CIP-10 registry.

Eternl will use label `49314` to identify Cardano payments made through
Open CryptoPay:

https://github.com/openCryptoPay/landingPage#open-cryptopay

The Open CryptoPay payload contains a version marker, public payment-link ID,
requested amount and currency, and an optional external merchant reference.
It deliberately excludes DFX quote/payment credentials and merchant contact
information.

## Collision checks

Both labels are outside the CIP-10 reserved ranges and are absent from the
current registry.

- Koios returns existing transactions for `37326`, corresponding to its
  established Eternl Pro usage.
- Koios returned no transactions for `49314` when checked on 2026-08-05.
- No existing CIPs pull request was found requesting either label.