### PR TITLE
CIP-0119 | Add discussion of possible metadata extension

### DIFF
--- a/CIP-0119/README.md
+++ b/CIP-0119/README.md
@@ -8,8 +8,9 @@ Authors:
 Implementors: []
 Discussions:
     - Original PR: https://github.com/cardano-foundation/CIPs/pull/788
-    - Video: https://vimeo.com/912374177/0e9299fb5d?share=copy
-    - Video: https://vimeo.com/915297122/c39f4a739b?share=copy
+    - Video: https://vimeo.com/912374177/0e9299fb5d
+    - Video: https://vimeo.com/915297122/c39f4a739b
+    - Metadata extensions: https://github.com/cardano-foundation/CIPs/issues/977
 Created: 2024-02-07
 License: CC-BY-4.0
 ---


### PR DESCRIPTION
This discreetly — without modifying the CIP language, which could be arguable over the detail — adds a `Discussions:` link to highlight @Quantumplation's extraordinary exposition of how interested parties could go about extending the metadata vocabulary of CIP-0119 (& in fact any other metadata component) without the usually paralysing concerns over compatibility & consensus:
* https://github.com/cardano-foundation/CIPs/issues/977

I believe this will be especially important as DReps will need to be better differentiated by the community in the course of finding real solutions (in CIPs and/or community dialogue) to:
* [CPS-0033 | DRep Voting Power Concentration](https://github.com/cardano-foundation/CIPs/blob/master/CPS-0033/README.md)

(cc @maureenblack @daniellestanko-gov + @thenic95 — see @MadOrkestra's OP https://github.com/cardano-foundation/CIPs/issues/977#issue-2825153599 for a quick view of how a better metadata vocabulary would help with DRep influence distribution)

I've closed the issue above since the only way to apply its principles would be to produce a CIP with such an extended vocabulary: so this link will ensure this information isn't lost by fading into the issue queue (any more than it has already).

@Quantumplation @Ryun1 @Crypto2099 or anyone else: if it might not be considered enough just to have the `Discussions:` link there, we might also add some text to the CIP to develop the concept of extension & refer to the issue content more explicitly: if anyone offers this I'd be happy to add it to this PR.

(BTW I've also removed the tracking component from the Vimeo links: cc @Thomas-Upfield)