### PR TITLE
Nominate ch1bo as a CIP editor

### DIFF
--- a/CIP-0001/README.md
+++ b/CIP-0001/README.md
@@ -425,21 +425,20 @@ Existing editors or the community may nominate new editors, provided they have p
 
 The missions of an editor include, but aren't exclusively limited to, any of the tasks listed above. Active members that seek to become listed editors may also come forth and let it be known. Any application will take the form of a pull request updating this document with a justification as the pull request's description.
 
-Current editors are listed here below:
+| Current editors  |                                              |
+|:-----------------|:---------------------------------------------|
+| Robert Phair     | [@rphair](https://github.com/rphair)         |
+| Ryan Williams    | [@Ryun1](https://github.com/Ryun1)           |
+| Thomas Vellekoop | [@perturbing](https://github.com/perturbing) |
+| Sebastian Nagel  | [@ch1bo](https://github.com/ch1bo)           |
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Thomas Vellekoop <br/> [@perturbing][] |
-| ---                            | ---                            | ---                                    |
-
-[@rphair]: https://github.com/rphair
-[@Ryun1]: https://github.com/Ryun1
-[@perturbing]: https://github.com/perturbing
-
-Emeritus editors:
-- Frederic Johnson - [@crptmppt](https://github.com/crptmppt)
-- Sebastien Guillemot - [@SebastienGllmt](https://github.com/SebastienGllmt)
-- Matthias Benkort - [@KtorZ](https://github.com/KtorZ)
-- Duncan Coutts - [@dcoutts](https://github.com/dcoutts)
-- Adam Dean - [@Crypto2099](https://github.com/Crypto2099)
+| Emeritus editors    |                                                      |
+|:--------------------|:-----------------------------------------------------|
+| Frederic Johnson    | [@crptmppt](https://github.com/crptmppt)             |
+| Sebastien Guillemot | [@SebastienGllmt](https://github.com/SebastienGllmt) |
+| Matthias Benkort    | [@KtorZ](https://github.com/KtorZ)                   |
+| Duncan Coutts       | [@dcoutts](https://github.com/dcoutts)               |
+| Adam Dean           | [@Crypto2099](https://github.com/Crypto2099)         |
 
 ## Rationale: How does this CIP achieve its goals?
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,9 @@ Proposals stalled without any updates from their authors will eventually be clos
 
 ## Editors
 
-| Robert Phair <br/> [@rphair][] | Ryan Williams <br/> [@Ryun1][] | Thomas Vellekoop <br/> [@perturbing][] |
-| ---                            | ---                            | ---                                    |
-
-[@rphair]: https://github.com/rphair
-[@Ryun1]: https://github.com/Ryun1
-[@perturbing]: https://github.com/perturbing
-
+| Name             | Github user                                  |
+|:-----------------|:---------------------------------------------|
+| Robert Phair     | [@rphair](https://github.com/rphair)         |
+| Ryan Williams    | [@Ryun1](https://github.com/Ryun1)           |
+| Thomas Vellekoop | [@perturbing](https://github.com/perturbing) |
+| Sebastian Nagel  | [@ch1bo](https://github.com/ch1bo)           |


### PR DESCRIPTION
This is a self-nomination to share the workload of editorial work on the CIPs. I get pinged on many of them either way, so I thought I'd throw my hat in to help out as an editor too. As for qualification: I'm currently the lead architect working on getting Leios out (CIP-164), prior to that I worked a bit on Mithril (CIP-137) and a lot on Hydra (CIP-42). I might be short on time the next couple of months, but thought some editorial help is better than no editorial help.