### PR TITLE
CIP-0176 | Serialize `is_valid` as the trailing element of each block transaction

### DIFF
--- a/CIP-0176/README.md
+++ b/CIP-0176/README.md
@@ -59,21 +59,15 @@ block =
   ]
 
 block_body =
-  [ invalid_transactions : [* transaction_index]
-  , transactions : [* transaction]
+  [ transactions : [* block_transaction]
   ]
 
-transaction =
-  [  transaction_body, transaction_witness_set, true, auxiliary_data/ nil
-  // transaction_body, transaction_witness_set, auxiliary_data/ nil
-  ]
+block_transaction =
+  [transaction_body, transaction_witness_set, auxiliary_data/ nil, bool]
 ```
 
-Note that we propose keeping invalid transaction indices separately, because:
-  * the `isValid` flag - which determines validity -  is controlled by the block producing node, not by the transaction creator;
-  * it's more efficient: we serialize indices only for invalid transactions, which are a small minority.
-
-Also, note that `invalid_transactions` indices precede `transactions` in the proposed layout, so that consumers can determine the validity of transactions without having to scan through the entire transaction list.
+Note that the `is_valid` flag is controlled by the block producing node, not by the transaction creator, which is why it is not part of the transaction serialization used for submission (see CIP-0167) and is instead appended to each transaction by the block producer.
+Placing it after the auxiliary data keeps all the fields supplied by the transaction author in a contiguous prefix of each `block_transaction`, and gives future block-producer-supplied fields (such as the proposed `feeChangeAmount`) a natural position at the end of the transaction.
 
 ## Rationale: How does this CIP achieve its goals?
 


### PR DESCRIPTION
## What

Amends CIP-0176 to replace the block-level `invalid_transactions` index list with a trailing `is_valid` flag on each transaction in a block:

- `block_body` becomes a plain list of `block_transaction`s
- `block_transaction = [transaction_body, transaction_witness_set, auxiliary_data/ nil, bool]`, where the trailing `bool` is the `is_valid` flag set by the block producer

## Why

1. The split between "transaction as serialized in a block" and "transaction as submitted to the mempool" plus a block-level index list proved confusing, especially with the addition of EBs (endorser blocks) in Leios, which also reference transactions.
2. Future fields that are set by the block producer rather than the transaction author (e.g. the proposed [`feeChangeAmount`](https://github.com/cardano-foundation/CIPs/pull/1218#issuecomment-4912191188)) would need the same treatment. Placing producer-set fields *after* all author-supplied fields gives them a natural, extensible position at the end of each block transaction.
3. The author-supplied fields form a contiguous prefix of each block transaction, cleanly separating the data that the transaction author signs off on from the data added at block production time (mirroring the previous segregated layout, where validity flags came last in the block body).
4. It removes the cross-field invariant ("every index must be strictly smaller than the number of transactions") that the index list required validators to check.

The block body hash is unaffected: it remains a single hash over the serialized `block_body` as a whole.

Motivated by IntersectMBO/cardano-ledger#5912.

Submitted in tandem with an amendment to CIP-0167 (#1262), which describes the mempool side of the same transaction wire-format split.
